### PR TITLE
Improve copy/paste when multiple lines are copied, fixes #121

### DIFF
--- a/docs/files/WebTerminal-v4.9.1.xml
+++ b/docs/files/WebTerminal-v4.9.1.xml
@@ -1,0 +1,2343 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25" zv="Cache for Windows (x86-64) 2017.2.1 (Build 801U)" ts="2019-10-30 18:19:39">
+<Class name="WebTerminal.Analytics">
+<Description>
+This class includes methods which collect WebTerminal's analytics such as error and installation reports.</Description>
+<TimeChanged>65316,65786.123689</TimeChanged>
+<TimeCreated>65316,65786.123689</TimeCreated>
+
+<Method name="ReportInstallStatus">
+<Description>
+This method sends a report about installation status, including error message if any errors happened.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>status:%Status=1,type:%String="Install"</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set req = ##class(%Net.HttpRequest).%New()
+    set req.Server = "www.google-analytics.com"
+    do req.EntityBody.Write("v=1&tid=UA-83005064-2&cid="_##class(%SYS.System).InstanceGUID()
+        _"&ds=web&an=WebTerminal&av="_##class(WebTerminal.Installer).#VERSION
+        _"&t=event&aiid="_$ZCONVERT($zv, "O", "URL")_"&ec="_$ZCONVERT(type, "O", "URL")_"&ea="
+        _$case($$$ISOK(status), 1: "Success", : "Failure")_"&el="
+        _$ZCONVERT($System.Status.GetErrorText(status), "O", "URL"))
+    try {
+        return req.Post("/collect")
+    } catch e {
+        write "Unable to send analytics to " _ req.Server _ ", skipping analytics collection."
+        return $$$OK
+    }
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.Autocomplete">
+<Super>Common</Super>
+<TimeChanged>65316,65786.125163</TimeChanged>
+<TimeCreated>65316,65786.125163</TimeCreated>
+
+<Method name="GetGlobals">
+<Description>
+Returns a comma-delimited string of globals names in the namespace, which begin from "beginning".</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>namespace:%String="%SYS",beginning:%String=""</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    set result = ""
+    set pattern = beginning _ "*"
+    new $Namespace
+    set $Namespace = namespace
+    set rset = ##class(%ResultSet).%New("%SYS.GlobalQuery:NameSpaceList")
+    do rset.Execute($Namespace, pattern, 1)
+    while (rset.Next()) {
+        set result = result _ $case(result = "", 1:"", :",") _ rset.GetData(1)
+    }
+    return result
+]]></Implementation>
+</Method>
+
+<Method name="GetClass">
+<Description>
+Returns a comma-delimited string of class names in the namespace, which begin from "beginning".</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>namespace:%String="%SYS",beginning:%String=""</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    new $Namespace
+    set $Namespace = namespace
+    set pattern = $REPLACE(beginning, "%", "!%") _ "%"
+    &sql(select LIST(ID) into :ids from %Dictionary.CompiledClass where ID like :pattern ESCAPE '!' and deployed <> 2)
+    return ids
+]]></Implementation>
+</Method>
+
+<Method name="GetPublicClassMembers">
+<Description>
+Returns a comma-delimited string of public class members (accessible through ##class() construction) in the class of namespace.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>namespace:%String="%SYS",className:%String="",beginning:%String=""</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    new $Namespace
+    set $Namespace = namespace
+    set pattern = $REPLACE(beginning, "%", "!%") _ "%"
+    &sql(select LIST(Name) into :names from %Dictionary.CompiledMethod WHERE parent=:className AND ClassMethod=1 AND Name like :pattern ESCAPE '!')
+    return names
+]]></Implementation>
+</Method>
+
+<Method name="GetClassMembers">
+<Description>
+Returns a comma-delimited string of class members in the class of namespace.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>namespace:%String="%SYS",className:%String="",beginning:%String="",methodsOnly=""</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    new $Namespace
+    set $Namespace = namespace
+    if $EXTRACT(beginning, 1) = "#" {
+        set ps = ..GetParameters(namespace, className, $EXTRACT(beginning, 2, $LENGTH(beginning)))
+        return:(ps = "") ps
+        return "#"_$REPLACE(ps, ",", ",#")
+    }
+    set pattern = $REPLACE(beginning, "%", "!%") _ "%"
+    set props = ""
+    &sql(select LIST(Name) into :methods from %Dictionary.CompiledMethod WHERE parent=:className AND Private = 0 AND Name like :pattern ESCAPE '!')
+    if (methodsOnly = "") {
+        &sql(select LIST(Name) into :props from %Dictionary.CompiledProperty WHERE parent=:className AND Name like :pattern ESCAPE '!')
+    }
+    return $case((methods '= "") && (props '= ""), 1: methods _ "," _ props, : methods _ props)
+]]></Implementation>
+</Method>
+
+<Method name="GetParameters">
+<Description>
+Returns a comma-delimited string of class members in the class of namespace.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>namespace:%String="%SYS",className:%String="",beginning:%String=""</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    new $Namespace
+    set $Namespace = namespace
+    set pattern = $REPLACE(beginning, "%", "!%") _ "%"
+    &sql(select LIST(Name) into :names from %Dictionary.CompiledParameter WHERE parent=:className AND Name like :pattern ESCAPE '!')
+    return names
+]]></Implementation>
+</Method>
+
+<Method name="GetRoutines">
+<Description>
+Returns a comma-delimited string of routine names in the namespace, which begin from "beginning".</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>namespace:%String="%SYS",beginning:%String=""</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    set result = ""
+    set pattern = beginning _ "*.*"
+    new $Namespace
+    set $Namespace = namespace
+    set rset = ##class(%ResultSet).%New("%Library.Routine:RoutineList")
+    do rset.Execute(pattern, , , $Namespace)
+    while (rset.Next()) {
+        set result = result _ $case(result = "", 1:"", :",") _ $PIECE(rset.GetData(1), ".", 1, *-1)
+    }
+    return result
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.Common">
+<IncludeCode>%sySystem</IncludeCode>
+<TimeChanged>65316,65786.124015</TimeChanged>
+<TimeCreated>65316,65786.124015</TimeCreated>
+
+<Parameter name="ChunkSize">
+<Description>
+Interprocess communication cannot handle big messages at once, so they need to be split.</Description>
+<Default>45</Default>
+</Parameter>
+
+<Method name="SendChunk">
+<Description>
+Send the chunk of data to another process. The process need to receive the chunk with the
+appropriate function ReceiveChunk. Consider event length less than 44 characters long.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>pid:%Numeric,flag:%String,data:%String=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set pos = 1
+    set len = $LENGTH(data) + 1 // send the last empty message if the data size = ChunkSize
+    for {
+        try {
+            set st = $system.Event.Signal(
+                pid,
+                $LB(flag, $EXTRACT(data, pos, pos + ..#ChunkSize - 1))
+            )
+        } catch (e) { return $$$NOTOK }
+        if (st '= 1) { return $$$NOTOK }
+        set pos = pos + ..#ChunkSize
+        if (pos > len) { quit }
+    }
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="ReceiveChunk">
+<Description>
+Receives the chunk of data from another process. Returns the $LISTBUILD string which contains
+flag at the first position and string at the second. This method also terminates the process
+if the parent process is gone.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>timeout:%Numeric=-1,masterProcess=0</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    set flag = ""
+    set str = ""
+    set status = -1
+    for {
+        set message = $system.Event.WaitMsg("", $Case(timeout = -1, 1: 1, :timeout))
+        set status = $LISTGET(message, 1)
+        set data = $LISTGET(message, 2)
+        if (status <= 0) {
+            if ($ZPARENT '= 0) && ('$data(^$Job($ZPARENT))) {
+                do $system.Process.Terminate($JOB, 0)
+                return $LISTBUILD("e", $LISTBUILD("", "Parent process "_$JOB_" is gone"), -1)
+            }
+            if masterProcess && ($ZCHILD '= 0) && ('$data(^$Job($ZCHILD))) {
+                return $LISTBUILD("e", $LISTBUILD("", "Child process "_$ZCHILD_" is gone"), -1)
+            }
+        }
+        if (data = "") && (timeout = 0) quit
+        if (status <= 0) {
+            set:(timeout = 0) timeout = 1
+            continue
+        }
+        set flag = $LISTGET(data, 1)
+        set m = $LISTGET(data, 2)
+        set str = str _ m
+        if (timeout = 0) set timeout = 1
+        quit:($LENGTH(m) '= ..#ChunkSize)
+    }
+    return $LISTBUILD(flag, str, status)
+]]></Implementation>
+</Method>
+
+<Method name="GetJSONString">
+<Description><![CDATA[
+Returns the contents of the proxy object to the current device in JSON format.<br/>
+This method is called when a proxy object is used in conjunction with
+the <class>%ZEN.Auxiliary.jsonProvider</class> component.<br/>
+<var>format</var> is a flags string to control output formatting options.<br/>
+The following character option codes are supported:<br/>
+1-9 : indent with this number of spaces (4 is the default with the 'i' format specifier)<br/>
+a - output null arrays/objects<br/>
+b - line break before opening { of objects<br/>
+c - output the Cach&eacute;-specific "_class" and "_id" properties (if a child property is an instance of a concrete object class)<br/>
+e - output empty object properties<br/>
+i - indent with 4 spaces unless 't' or 1-9<br/>
+l - output empty lists<br/>
+n - newline (lf)<br/>
+o - output empty arrays/objects<br/>
+q - output numeric values unquoted even when they come from a non-numeric property<br/>
+s - use strict JSON output - <strong>NOTE:</strong> special care should be taken when sending data to a browser, as using this flag
+may expose you to cross site scripting (XSS) vulnerabilities if the data is sent inside <code>&lt;script&gt;</code> tags. Zen uses
+this technique extensively, so this flag should <strong>NOT</strong> be specified for jsonProviders in Zen pages.<br/>
+t - indent with tab character<br/>
+u - output pre-converted to UTF-8 instead of in native internal format<br/>
+w - Windows-style cr/lf newline<br/>]]></Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>obj:%ZEN.proxyObject,format:%String="aeos"</FormalSpec>
+<ProcedureBlock>0</ProcedureBlock>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    set tOldIORedirected = ##class(%Device).ReDirectIO()
+    set tOldMnemonic = ##class(%Device).GetMnemonicRoutine()
+    set tOldIO = $io
+    try {
+        set str = ""
+        use $io::("^" _ $ZNAME)
+        do ##class(%Device).ReDirectIO(1)
+        do ##class(%ZEN.Auxiliary.jsonProvider).%ObjectToJSON(obj,,,format)
+    } catch ex {
+        set str = ""
+    }
+    if (tOldMnemonic '= "") {
+        use tOldIO::("^" _ tOldMnemonic)
+    } else {
+        use tOldIO
+    }
+    do ##class(%Device).ReDirectIO(tOldIORedirected)
+    return str
+
+rchr(c)
+    quit
+rstr(sz,to)
+    quit
+wchr(s)
+    do output($char(s))
+    quit
+wff()
+    do output($char(12))
+    quit
+wnl()
+    do output($char(13,10))
+    quit
+wstr(s)
+    do output(s)
+    quit
+wtab(s)
+    do output($char(9))
+    quit
+output(s)
+    set str = str _ s
+    quit
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.Core">
+<Description>
+Web Terminal version 4.9.1 core.
+The core class which handles client requests and executes ObjectScript code.
+All writes used here are used for $X and $Y compatibility, but they actually do not
+write any code to the screen.</Description>
+<ProcedureBlock>0</ProcedureBlock>
+<Super>Common</Super>
+<TimeChanged>65316,65786.124371</TimeChanged>
+<TimeCreated>65316,65786.124371</TimeCreated>
+
+<Method name="redirects">
+<Description>
+Write and read redirects used when redirecting i/o.
+Each of the redirects signals to $ZPARENT process the $LISTBUILD string.
+There is several actions defined in the WebTerminal.Engine handler class for received list.
+"o" is for output. Resulting with $lb("o", {string})
+"r" is for reading string. Resulting with $lb("r", {length}, {timeout})
+"rc" is for reading char. Resulting with $lb("rc", {timeout})
+"end" symbolizes that execution end is reached. Resulting with $lb("end", {error message})</Description>
+<Private>1</Private>
+<ProcedureBlock>0</ProcedureBlock>
+<Implementation><![CDATA[
+wstr(str)
+	do ##class(%Device).ReDirectIO($$$NO)
+	write str
+	do ##class(%Device).ReDirectIO($$$YES)
+    quit ##class(WebTerminal.Common).SendChunk($ZPARENT, "o", str)
+
+wchr(c)
+	do ##class(%Device).ReDirectIO($$$NO)
+	write $CHAR(c)
+	do ##class(%Device).ReDirectIO($$$YES)
+    quit ##class(WebTerminal.Common).SendChunk($ZPARENT, "o", $CHAR(c))
+
+wnl
+	do ##class(%Device).ReDirectIO($$$NO)
+	write !
+	do ##class(%Device).ReDirectIO($$$YES)
+    quit ##class(WebTerminal.Common).SendChunk($ZPARENT, "o", $CHAR(13, 10))
+
+wff
+	do ##class(%Device).ReDirectIO($$$NO)
+	set $X = 0
+	set $Y = 0
+	do ##class(%Device).ReDirectIO($$$YES)
+    quit ##class(WebTerminal.Common).SendChunk($ZPARENT, "o", $CHAR(12))
+
+wtab(s)
+	do ##class(%Device).ReDirectIO($$$NO)
+	set $x = s
+	do ##class(%Device).ReDirectIO($$$YES)
+    quit ##class(WebTerminal.Common).SendChunk($ZPARENT, "o", $CHAR(27) _ "[" _ (s + 1) _ "G")
+
+rstr(length = 32656, timeout = 86400)
+    do ##class(WebTerminal.Common).SendChunk($ZPARENT, "r", $lb(length, timeout))
+    quit $LISTGET(##class(WebTerminal.Common).ReceiveChunk(), 2)
+
+rchr(timeout = 86400)
+    do ##class(WebTerminal.Common).SendChunk($ZPARENT, "c", timeout)
+    quit $LISTGET(##class(WebTerminal.Common).ReceiveChunk(), 2)
+
+erdx s $x=0 q
+erdy s $y=0 q
+APC ; Application program command
+ w $c(27)_"_"
+ q
+BEL ; Ring the bell
+ w $c(7)
+ q
+CBT(%1) ; Cursor backward tabulation %1 tab stops
+ s %1=+$g(%1,1) w $c(27,91)_%1_"Z" s $zt="erdx",$x=$x+7\8-%1*8
+ q
+CCH ; Cancel character
+ w $c(27)_"T"
+ q
+CHA(%1) ; Cursor horizontal absolute (move to column %1)
+ s %1=+$g(%1,1) w $c(27,91)_%1_"G" s $zt="erdx",$x=%1-1
+ q
+CHT(%1) ; Cursor horizontal tabulation (forward %1 tab stops)
+ s %1=+$g(%1,1) w $c(27,91)_%1_"I" s $zt="erdx",$x=$x\8+%1*8
+ q
+CNL(%1) ; Cursor next line (cursor down %1 lines)
+ s %1=+$g(%1,1) w $c(27,91)_%1_"E" s $zt="erdy",$y=$y+%1
+ q
+CPL(%1) ; Cursor preceding line (cursor up %1 lines)
+ s %1=+$g(%1,1) w $c(27,91)_%1_"F" s $zt="erdy",$y=$y-%1
+ q
+CPR ; Cursor position report (return in $KEY)
+ n %1 w $c(27,91)_"6n" r %1
+ q
+CTC(%1,%2,%3,%4,%5,%6,%7,%8,%9) ; Cursor tabulation control
+ n %i,%p s %p=""
+ f %i=1:1:9 i $d(@("%"_%i)) s %p=%p_$e(";",%p'="")_@("%"_%i)
+ w $c(27,91)_%p_"W"
+ q
+CUB(%1) ; Cursor backward %1 columns
+ s %1=+$g(%1,1) w $c(27,91)_%1_"D" s $zt="erdx",$x=$x-%1
+ q
+CUD(%1) ; Cursor down %1 lines
+ s %1=+$g(%1,1) w $c(27,91)_%1_"B" s $zt="erdy",$y=$y+%1
+ q
+CUF(%1) ; Cursor forward %1 columns
+ s %1=+$g(%1,1) w $c(27,91)_%1_"C" s $zt="erdx",$x=$x+%1
+ q
+CUP(%2,%1) ; Cursor position (column %1, line %2)
+ s %1=+$g(%1,1),%2=+$g(%2,1) w $c(27,91)_%2_";"_%1_"H"
+ s $zt="ecup",$x=%1-1,$zt="erdy",$y=%2-1 q
+ecup s $x=0,$zt="erdy",$y=%2-1
+ q
+CUU(%1) ; Cursor up %1 lines
+ s %1=+$g(%1,1) w $c(27,91)_%1_"A" s $zt="erdy",$y=$y-%1
+ q
+CVT(%1) ; Cursor vertical tabulation
+ w $c(27,91)_+$g(%1,1)_"Y"
+ q
+DA ; Device attributes - return in $KEY
+ n %1,%2,%3 s %3="" u $i:("":"+S")
+ w $c(27,91)_"c" r %1 s %2=$k f  r *%1 s %3=%3_$c(%1) q:%1=99
+ s $k=%2_%3 u $i:("":"-S")
+ q
+DAQ(%1,%2,%3,%4,%5,%6,%7,%8,%9) ; Define area qualification
+ n %i,%p s %p=""
+ f %i=1:1:9 i $d(@("%"_%i)) s %p=%p_$e(";",%p'="")_@("%"_i)
+ w $c(27,91)_%p_"o"
+ q
+DCH(%1) ; Delete %1 characters
+ w $c(27,91)_+$g(%1,1)_"P"
+ q
+DCS ; Device control string
+ w $c(27)_"P"
+ q
+DL(%1) ; Delete %1 lines
+ w $c(27,91)_+$g(%1,1)_"M"
+ q
+DMI ; Disable manual input
+ q
+DSR(%1) ; Device status report - type %1 - return in $KEY
+ n %2 w $c(27,91)_+$g(%1,5)_"n" r %2
+ q
+EA(%1) ; Erase in area
+ w $c(27,91)_+$g(%1,1)_"O"
+ q
+ECH(%1) ; Erase %1 characters
+ w $c(27,91)_+$g(%1,1)_"X"
+ q
+ED(%1) ; Erase in display (%1=0 cursor-to-end,1 begin-to-cursor,2 entire scr)
+ w $c(27,91)_+$g(%1)_"J"
+ q
+EF(%1) ; Erase in field
+ w $c(27,91)_+$g(%1,1)_"N"
+ q
+EL(%1) ; Erase in line (%1=0 cursor-to-end, 1 begin-to-cursor, 2 entire line)
+ w $c(27,91)_+$g(%1)_"K"
+ q
+EMI ; Enable manual input
+ q
+EPA ; End of protected area
+ w $c(27)_"W"
+ q
+ESA ; End of selected area
+ w $c(27)_"G"
+ q
+FNT ; Font selection
+ q
+GSM ; Graphic size modification
+ q
+GSS ; Graphic size selection
+ q
+HPA(%1) ; Horizontal position attribute (cursor to column %1)
+ s %1=+$g(%1,1) w $c(27,91)_%1_"`" s $zt="erdx",$x=%1-1
+ q
+HPR(%1) ; Horizontal position relative (cursor forward %1 columns)
+ s %1=+$g(%1,1) w $c(27,91)_%1_"a" s $zt="erdx",$x=$x+%1
+ q
+HTJ ; Horizontal tab with justify
+ w $c(27)_"I"
+ q
+HTS ; Horizontal tabulation set
+ w $c(27)_"H"
+ q
+HVP(%1,%2) ; Horizontal and vertical position (column %1, line %2)
+ s %1=+$g(%1,1),%2=+$g(%2,1) w $c(27,91)_%2_";"_%1_"f"
+ s $zt="ehvp",$x=%1-1,$zt="erdy",$y=%2-1 q
+ehvp s $x=0,$zt="erdy",$y=%2-1
+ q
+ICH(%1) ; Insert %1 characters
+ w $c(27,91)_+$g(%1,1)_"@"
+ q
+IL(%1) ; Insert %1 lines
+ w $c(27,91)_+$g(%1,1),"L"
+ q
+IND ; Index
+ w $c(27)_"D" s $y=$y+1
+ q
+INT ; Interrupt
+ w $c(27,91)_"a"
+ q
+JFY ; Justify
+ q
+MC ; Media copy
+ w $c(27,91)_"i"
+ q
+MW ; Message waiting
+ w $c(27)_"U"
+ q
+NEL ; Next line
+ w $c(27)_"E" s $x=0,$y=$y+1
+ q
+NP(%1) ; Next page (advance %1 pages of terminal display memory)
+ w $c(27,91)_+$g(%1,1)_"U"
+ q
+OSC ; Operating system command
+ w $c(27)_"]"
+ q
+PLD ; Partial line down
+ w $c(27)_"K"
+ q
+PLU ; Partial line up
+ w $c(27)_"L"
+ q
+PM ; Privacy message
+ w $c(27)_"^"
+ q
+PP(%1) ; Preceding page (backup %1 pages of terminal display memory)
+ w $c(27,91)_+$g(%1,1)_"V"
+ q
+PU1 ; Private use one
+ w $c(27)_"Q"
+ q
+PU2 ; Private use two
+ w $c(27)_"R"
+ q
+QUAD ; QUAD
+ q
+REP ; Repeat
+ w $c(27,91)_"b"
+ q
+RI ; Reverse index
+ w $c(27)_"M" s $zt="erdy",$y=$y-1
+ q
+RIS ; Reset to initial state
+ w $c(27)_"c" s $x=0,$y=0
+ q
+RM(%1,%2,%3,%4,%5,%6,%7,%8,%9) ; Reset mode
+ n %i,%p s %p=""
+ f %i=1:1:9 i $d(@("%"_%i)) s %p=%p_$e(";",%p'="")_@("%"_%i)
+ w $c(27,91)_%p_"l"
+ q
+SEM ; Select editing extent mode
+ w $c(27,91)_"Q"
+ q
+SGR(%1,%2,%3,%4,%5,%6,%7,%8,%9)  ; Select graphic rendition %1 thru %9
+ n %i,%p s %p=""
+ f %i=1:1:9 i $d(@("%"_%i)) s %p=%p_$e(";",%p'="")_@("%"_%i)
+ w $c(27,91)_%p_"m"
+ q
+SL ; Scroll left
+ q
+SM(%1,%2,%3,%4,%5,%6,%7,%8,%9) ; Set mode
+ n %i,%p s %p=""
+ f %i=1:1:9 i $d(@("%"_%i)) s %p=%p_$e(";",%p'="")_@("%"_%i)
+ w $c(27,91)_%p_"h"
+ q
+SPA ; Start of protected area
+ w $c(27)_"V"
+ q
+SPI ; Spacing increment
+ q
+SR ; Scroll right
+ q
+SS2 ; Single shift two
+ w $c(27)_"N"
+ q
+SS3 ; Single shift three
+ w $c(27)_"O"
+ q
+SSA ; Start of selected area
+ w $c(27)_"F"
+ q
+ST ; String terminator
+ w $c(27)_"\"
+ q
+STS ; Set transmit state
+ w $c(27)_"S"
+ q
+SU ; Scroll up
+ w $c(27,91)_"S"
+ q
+TBC ; Tabulation clear
+ w $c(27,91)_"g"
+ q
+TSS ; Thin space specification
+ q
+VPA(%1) ; Vertical position attribute (move to row %1 at same column)
+ s %1=+$g(%1,1) w $c(27,91)_%1_"d" s $zt="erdy",$y=%1-1
+ q
+VPR(%1) ; Vertical position relative (move down %1 lines at same column)
+ s %1=+$g(%1,1) w $c(27,91)_%1_"e" s $zt="erdy",$y=$y+%1
+ q
+VTS ; Vertical tabulation sets
+ w $c(27)_"J"
+ q
+]]></Implementation>
+</Method>
+
+<Method name="VarList">
+<ClassMethod>1</ClassMethod>
+<ProcedureBlock>1</ProcedureBlock>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    if $data(%)
+    new % set %=$select($test:$LISTBUILD("%"),1:"")
+    set:$data(%0) %=%_$LISTBUILD("%0")
+    new %0 set %0="%0"
+    for {
+        set %0=$ORDER(@%0)
+        quit:%0=""
+        set %=%_$LISTBUILD(%0, $IsObject(@%0), @%0)
+    }
+    return %
+]]></Implementation>
+</Method>
+
+<Method name="WaitCommand">
+<Description>
+Retrieves a command text from the parent process.
+Terminates itself if the parent process is dead.</Description>
+<ClassMethod>1</ClassMethod>
+<ProcedureBlock>1</ProcedureBlock>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    for {
+        set data = ..ReceiveChunk()
+        set flag = $LISTGET(data, 1)
+        if (flag = "m") { // message
+            return $LISTGET(data, 2)
+        } elseif (flag = "a") { // autocomplete
+            do ##class(WebTerminal.Common).SendChunk($ZPARENT, "a", ..VarList())
+        } else { // end or unexpected
+            do $system.Process.Terminate($JOB, 2)
+            return ""
+        }
+    }
+]]></Implementation>
+</Method>
+
+<Method name="Loop">
+<Description>
+Starts new terminal loop. Must be called with JOB command.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>startupRoutine:%String=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+	if ($ZPARENT = 0) {
+        write "This method is for JOB use only."
+        return 0
+    }
+    open "terminal"::"^%X364"
+    use $io::"^" _ $ZName
+    if (startupRoutine '= "") {
+        return ..StartupRoutine(startupRoutine)
+    }
+    kill // Kill any temporary variables ProcedureBlock may have.
+    // Procedure block will hold only user-defined variables, so any declarations here may
+    // potentially influence user experience. Do not add any set expressions in this procedure block
+    for {
+        do ..StartExecMode()
+        try {
+            xecute ..WaitCommand()
+        } catch {
+            do ..EndExecMode($ZERROR)
+            continue
+        }
+        do ..EndExecMode()
+    }
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="StartupRoutine">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>routineName=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do ..StartExecMode()
+    try {
+        do @routineName
+    } catch {
+        do ..EndExecMode($ZERROR)
+        return $$$OK
+    }
+    do ..EndExecMode()
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="StartExecMode">
+<ClassMethod>1</ClassMethod>
+<Implementation><![CDATA[
+    write ! // Y pos shift
+    do ##class(%Device).ReDirectIO($$$YES)
+    do $System.Util.SetInterruptEnable($$$YES)
+]]></Implementation>
+</Method>
+
+<Method name="EndExecMode">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>error=""</FormalSpec>
+<Implementation><![CDATA[
+    use $io::"^" _ $ZName
+    do $System.Util.SetInterruptEnable($$$NO)
+    do ##class(%Device).ReDirectIO($$$NO)
+    write ! // Y pos shift
+    do ..SendChunk($ZPARENT, "e", $LISTBUILD($NAMESPACE, error))
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.Engine">
+<Description>
+Web Terminal version 4.9.1 WebSocket client.
+This class represents a connected client via WebSocket.</Description>
+<Super>%CSP.WebSocket,Common,Trace,Autocomplete</Super>
+<TimeChanged>65316,65786.145786</TimeChanged>
+<TimeCreated>65316,65786.145786</TimeCreated>
+
+<Parameter name="WSKEYEXPIRES">
+<Description>
+Timeout in minutes when connection key expires.</Description>
+<Default>3600</Default>
+</Parameter>
+
+<Parameter name="AuthorizationTimeout">
+<Description>
+How long to wait for authorization key when connection established</Description>
+<Default>5</Default>
+</Parameter>
+
+<Property name="CurrentNamespace">
+<Type>%String</Type>
+</Property>
+
+<Property name="InitialZName">
+<Type>%String</Type>
+</Property>
+
+<Property name="InitialZNamespace">
+<Type>%String</Type>
+</Property>
+
+<Property name="corePID">
+<Description>
+The process ID of the terminal core.</Description>
+<Type>%Numeric</Type>
+<InitialExpression>0</InitialExpression>
+</Property>
+
+<Property name="childNamespace">
+<Description>
+The last known namespace in child process.</Description>
+<Type>%String</Type>
+</Property>
+
+<Property name="StartupRoutine">
+<Type>%String</Type>
+</Property>
+
+<Property name="echo">
+<Description>
+Output flag</Description>
+<Type>%Boolean</Type>
+<InitialExpression>1</InitialExpression>
+</Property>
+
+<Property name="bufferOutput">
+<Description>
+flag which enables output buffering</Description>
+<Type>%Boolean</Type>
+<InitialExpression>0</InitialExpression>
+</Property>
+
+<Property name="outputBuffer">
+<Description>
+Used to buffer the output ("o" flag) when bufferOutput flag is set</Description>
+<Type>%Stream.TmpCharacter</Type>
+<InitialExpression>##class(%Stream.TmpCharacter).%New()</InitialExpression>
+</Property>
+
+<Property name="handler">
+<Description>
+Output flag</Description>
+<Type>%Boolean</Type>
+<InitialExpression>0</InitialExpression>
+<Private>1</Private>
+</Property>
+
+<Method name="GetMessage">
+<FormalSpec>timeout:%Integer=86400</FormalSpec>
+<ReturnType>%ZEN.proxyObject</ReturnType>
+<Implementation><![CDATA[
+    #define err(%e, %s) if (%e '= $$$OK) { set obj = ##class(%ZEN.proxyObject).%New() set obj.error = %s return obj }
+    set data = ..Read(, .st, timeout)
+    return:((st = $$$CSPWebSocketTimeout) || (st = $$$CSPWebSocketClosed)) ""
+    $$$err(st, "%wsReadErr: "_$System.Status.GetErrorText(st))
+    set st = ##class(%ZEN.Auxiliary.jsonProvider).%ConvertJSONToObject(data, , .obj, 1)
+    $$$err(st, "%wsParseErr: "_$System.Status.GetErrorText(st))
+    return obj
+]]></Implementation>
+</Method>
+
+<Method name="Send">
+<Description>
+Do not remove this method in future versions of WebTerminal, it is used by update.</Description>
+<FormalSpec>handler:%String="",data=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    if (handler = "o") && (..bufferOutput = 1) {
+        do ..outputBuffer.Write(data)
+        return $$$OK
+    }
+    return:((handler = "o") && (..echo = 0)) $$$OK
+    return:(handler = "o") ..Write("o"_data) // Enables 2013.2 support (no JSON)
+    set obj = ##class(%ZEN.proxyObject).%New()
+    set obj.h = handler
+    if (..handler '= 0) {
+        set obj."_cb" = ..handler
+    }
+    set obj.d = data
+    return ..Write(..GetJSONString(obj))
+]]></Implementation>
+</Method>
+
+<Method name="OnPreServer">
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set ..InitialZName = $zname
+    set ..InitialZNamespace = $znspace
+    quit $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="OnPostServer">
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    if (..corePID '= 0) {
+        do ..SendChunk(..corePID, "e")
+    }
+    quit $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="WriteToFile">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>filename:%String,data:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set file=##class(%File).%New(filename)
+    do file.Open("WSN")
+    do file.WriteLine(data)
+    do file.Close()
+]]></Implementation>
+</Method>
+
+<Method name="ExecuteSQL">
+<FormalSpec>query:%String=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set tStatement = ##class(%SQL.Statement).%New()
+    set qStatus = tStatement.%Prepare(query)
+    if qStatus'=1 {
+        write $System.Status.DisplayError(qStatus)
+    } else {
+        set rset = tStatement.%Execute()
+        do rset.%Display()
+    }
+    quit $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="RequireAuthorization">
+<Description>
+This method performs the authorization and login to WebTerminal.
+It returns a list with data (see Router.Auth method), which is used then to set up the
+initial values for the client.</Description>
+<ReturnType>%List</ReturnType>
+<Implementation><![CDATA[
+    set data = ..GetMessage(..#AuthorizationTimeout)
+    return:(data = "") $LB("%wsReadErr")
+    return:('$IsObject(data.d)) $LB($case(data.error = "", 1: "Unresolved WS message format", :data.error))
+    return:(data.d.key = "") $LB("Missing key")
+
+    set authKey = data.d.key
+    set key = $ORDER(^WebTerminal("AuthUser", ""))
+    set list = ""
+    while (key '= "") {
+        set lb = $GET(^WebTerminal("AuthUser", key))
+        if ((lb '= "") && (key = authKey)) {
+            set list = lb
+        }
+        set time = $LISTGET(lb, 2)
+        if (time '= "") && ($System.SQL.DATEDIFF("s", time, $h) > ..#WSKEYEXPIRES) {
+            kill ^WebTerminal("AuthUser", key)
+        }
+        set key = $ORDER(^WebTerminal("AuthUser", key))
+    }
+
+    if (list = "") { // not found
+        return $LB("Invalid key")
+    }
+
+    set username = $LISTGET(list, 1)
+    set namespace = $LISTGET(list, 3)
+    set ns = $Namespace
+
+    znspace "%SYS"
+    do ##class(Security.Users).Get(username, .userProps)
+    znspace ns
+
+    set namespace = $case(namespace, "":userProps("NameSpace"), :namespace)
+
+    if ($get(userProps("Routine")) '= "") {
+        set ..StartupRoutine = userProps("Routine")
+    }
+
+    if $get(userProps("Enabled")) '= 1 {
+        return $LB("User " _ username _ " is not enabled in the system")
+    }
+
+    set $LIST(list, 3) = namespace
+    set loginStatus = $System.Security.Login(username)
+
+    if (loginStatus '= 1) {
+        return $LB($System.Status.GetErrorText(loginStatus))
+    }
+
+    return $LB("", list)
+]]></Implementation>
+</Method>
+
+<Method name="ProcessRequest">
+<Description>
+See WebTerminal.Handlers</Description>
+<FormalSpec>handler:%String,data</FormalSpec>
+<Private>1</Private>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    try {
+        return $CLASSMETHOD("WebTerminal.Handlers", handler, $this, data)
+    } catch (e) {
+        set ..echo = 1
+        return e.AsSystemError()
+    }
+]]></Implementation>
+</Method>
+
+<Method name="ClientLoop">
+<Description>
+Main method for every new client.</Description>
+<Private>1</Private>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    job ##class(WebTerminal.Core).Loop(..StartupRoutine):($NAMESPACE)
+    if ($TEST '= 1) {
+        do ..Send("error", "%noJob")
+        return $$$NOTOK
+    }
+    set ..corePID = $ZCHILD
+    set ..childNamespace = $NAMESPACE
+    if (..StartupRoutine = "") {
+        do ..Send("prompt", ..childNamespace)
+    } else {
+        set message = ##class(%ZEN.proxyObject).%New()
+        set status = $CLASSMETHOD("WebTerminal.Handlers", "Execute", $this, "", 1)
+        goto loopEnd
+    }
+    //try { // temp
+    for {
+        set message = ..GetMessage()
+        quit:(message = "") // if client is gone, finish looping
+        if (message.error) {
+            set st = ..Send("error", message.error)
+            quit
+        }
+        if (message."_cb" '= "") { set ..handler = message."_cb" }
+        set status = ..ProcessRequest(message.h, message.d)
+        set ..handler = 0
+        set ..echo = 1
+        if (status '= "") && (status '= $$$OK) {
+            set eType = $EXTRACT(status, 1, 1)
+            do ..Send("oLocalized", $C(13,10) _ $case(eType = 0, 1: $System.Status.GetErrorText(status), :status))
+            continue
+        }
+    }
+loopEnd
+    //} catch (e) {  do ..Send("o", $System.Status.GetErrorText(e)) } // temp
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="SendLoginInfo">
+<Description><![CDATA[
+This method sends basic login info to the user. Use this method to set client variables
+during the WebTerminal initialization.
+<parameter>authList</parameter> See Router.Auth method.]]></Description>
+<FormalSpec>authList:%List</FormalSpec>
+<Implementation><![CDATA[
+    set obj = ##class(%ZEN.proxyObject).%New()
+    set obj.username = $USERNAME
+    set obj.name = $get(^WebTerminal("Name"))
+    set obj.cleanStart = $ListGet(authList, 4)
+    set obj.system = $SYSTEM
+    set obj.firstLaunch = ($get(^WebTerminal("FirstLaunch"), 1) '= 0)
+    set obj.InstanceGUID = ##class(%SYS.System).InstanceGUID()
+    set obj.zv = $ZVersion
+    set ^WebTerminal("FirstLaunch") = 0
+    do ..Send("init", obj)
+]]></Implementation>
+</Method>
+
+<Method name="Server">
+<Description>
+Triggered when new connection established.</Description>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set authRes = ..RequireAuthorization()
+    set authMessage = $ListGet(authRes, 1)
+    if (authMessage = "") {
+        set authList = $ListGet(authRes, 2) // see Router.Auth method
+        set namespace = $ListGet(authList, 3)
+        if (namespace '= "") && (namespace '= $Namespace) {
+            try {
+                znspace namespace
+            } catch (e) {
+                do ..Send("oLocalized",
+                    $Char(27) _ "[31m%unNS(" _ namespace _ ")"_ $Char(27) _ "[0m" _ $Char(13,10)
+                )
+            }
+        }
+        set ..CurrentNamespace = $Namespace
+        do ..SendLoginInfo(authList)
+        do ..ClientLoop()
+        do ..Send("oLocalized", "%wsNormalClose"_$C(13,10))
+    } else {
+        do ..Send("oLocalized", "%wsRefuse(" _ authMessage _ ")")
+    }
+    do ..EndServer()
+    quit $$$OK
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.ErrorDecomposer">
+<TimeChanged>65316,65786.154163</TimeChanged>
+<TimeCreated>65316,65786.154163</TimeCreated>
+
+<Parameter name="LINES">
+<Type>%Numeric</Type>
+<Default>5</Default>
+</Parameter>
+
+<Method name="DecomposeError">
+<Description>
+Takes $ZERROR function result.
+Returns either simple string or %ZEN.proxyObject representing the error details.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>err:%String="",ns:%String=""</FormalSpec>
+<Implementation><![CDATA[
+    new $namespace
+    if (ns '= "") {
+        try {
+            set $namespace = ns
+        } catch (e) {
+            return err
+        }
+    }
+    return:($FIND(err, "<") '= 2) err
+    set startPos = $FIND(err, ">")
+    return:(startPos = 0) err
+    set spacePos = $FIND(err, " ") - 1
+    return:(spacePos = startPos) err
+    set label = $EXTRACT(err, startPos, $case(spacePos = -1, 1:999, :spacePos-1))
+    return:(label = "") err
+    try {
+        set obj = ##class(%ZEN.proxyObject).%New()
+        set obj.zerror = err
+        set plusPos = $FIND(label, "+")
+        set cPos = $FIND(label, "^")
+        if (plusPos = 0) || (cPos = 0) {
+            set obj.source = $TEXT(@label)
+            set obj.line = 0
+            return obj
+        }
+        set line = +$EXTRACT(label, plusPos, cPos - 2)
+        set part1 = $EXTRACT(label, 1, plusPos - 1)
+        set part2 = $EXTRACT(label, cPos - 1, *)
+        set range = ..#LINES \ 2
+        set obj.source = ""
+        set obj.line = 0
+        for i=line-range:1:line+range {
+            continue:(i < 1)
+            set label = part1 _ i _ part2
+            set text = $TEXT(@label)
+            set:(text '= "") obj.source = obj.source _ $case(obj.source = "", 1: "", :$C(10)) _ text
+            set:((text '= "") && (i < line)) obj.line = obj.line + 1
+        }
+        return obj
+    } catch (e) {
+        return err
+    }
+    return err
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.Handlers">
+<Description>
+Web Terminal version 4.9.1 WebSocket handlers class.
+This class describes handlers for WebSocket client. Each handler method takes WS client instance
+as a first argument, and a given data as second. For example, handler for "execute"
+command will be names as "HandleExecute". Note that all the processing is synchronous and it
+blocks the WebSocket input while processing.
+This class is inherited by WebTerminal.Engine class.
+Methods must return positive status or an error if one happened.
+Method must take two arguments, the first is the WebTerminal.Engine instance, and data as second</Description>
+<TimeChanged>65316,65786.172438</TimeChanged>
+<TimeCreated>65316,65786.172438</TimeCreated>
+
+<Method name="Execute">
+<Description>
+data can be either string or %ZEN.proxyObject. In case of proxyObject, the command is hold in
+data.command property, and it may have some other control properties.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data,bareStart:%Boolean=0</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    if (bareStart) goto loop
+    if $IsObject(data) {
+        set command = data.command
+        if (data.echo = 0) {
+            set client.echo = 0
+        }
+        if (data.bufferOutput = 1) {
+            set client.bufferOutput = 1
+        }
+    } else {
+        set command = data
+    }
+    do client.Send("o", $CHAR(13, 10))
+    do client.SendChunk(client.corePID, "m", command)
+loop
+    for {
+        set message = client.ReceiveChunk(0, 1) // read from WebSocket as well: timeout = 0
+        if ($LISTGET(message, 3) < 0) {
+            return $$$ERROR($$$GeneralError, "%cpTerm")
+        }
+        set flag = $LISTGET(message, 1)
+        if (flag = "") { // if there is no messages from the child process executing the task,
+            set mes = client.GetMessage(0) // look at the incoming WebSocket messages
+            if (mes '= "") && (mes.h = "Interrupt") { // and if the interrupt has been sent
+                do $System.Util.SendInterrupt(client.corePID) // interrupt the child process
+            } else { // else hang for a while to prevent "waiting" process from loading CPU
+                hang 0.05
+            }
+            continue
+        }
+        set chunk = $LISTGET(message, 2)
+        if (flag = "o") {
+            do client.Send("o", chunk)
+        } elseif (flag = "r") {
+            set obj = ##class(%ZEN.proxyObject).%New()
+            set obj.length = $LISTGET(chunk, 1)
+            set obj.timeout = $LISTGET(chunk, 2)
+            do client.Send("readString", obj)
+            set mes = client.GetMessage()
+            if (mes.h = "Interrupt") {
+                do $System.Util.SendInterrupt(client.corePID)
+            } else {
+                do client.SendChunk(client.corePID, "m", mes.d)
+            }
+        } elseif (flag = "c") {
+            set obj = ##class(%ZEN.proxyObject).%New()
+            set obj.timeout = chunk
+            do client.Send("readChar", obj)
+            set mes = client.GetMessage()
+            if (mes.h = "Interrupt") {
+                do $System.Util.SendInterrupt(client.corePID)
+            } else {
+                do client.SendChunk(client.corePID, "m", mes.d)
+            }
+        } elseif (flag = "e") {
+            set err = ""
+            if $ListValid(chunk) {
+                if ($LISTGET(chunk, 1) '= "") {
+                    set client.childNamespace = $LISTGET(chunk, 1)
+                }
+                if ($LISTGET(chunk, 2) '= "") {
+                    set err = $LISTGET(chunk, 2)
+                }
+            }
+            if $IsObject(data) && (data.bufferOutput = 1) {
+                do client.outputBuffer.Write(err)
+                quit // break for loop
+            }
+            if (err '= "") {
+                do client.Send(
+                    "execError",
+                    ##class(ErrorDecomposer).DecomposeError(err, client.childNamespace)
+                )
+            }
+            quit // break for loop
+        } else { // unknown response - just send it to the client
+            do client.Send("o", chunk)
+        }
+    }
+    do client.Send("o", $CHAR(13, 10))
+    if $IsObject(data) {
+        if (data.echo = 0) {
+            set client.echo = 1
+        }
+        if (data.bufferOutput = 1) {
+            set client.bufferOutput = 0
+            set str = ""
+            while ('client.outputBuffer.AtEnd) {
+                set str = str _ client.outputBuffer.Read()
+            }
+            do client.Send("promptCallback", str)
+            do client.outputBuffer.Clear()
+        }
+    }
+    do:('($IsObject(data) && (data.prompt = 0)) && '(bareStart = 1)) client.Send("prompt", client.childNamespace)
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="Update">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,URL:%String</FormalSpec>
+<Implementation><![CDATA[
+    set st = ##class(WebTerminal.Updater).Update(client, URL)
+    do:($$$ISERR(st)) ##class(WebTerminal.Analytics).ReportInstallStatus(st)
+    return st
+]]></Implementation>
+</Method>
+
+<Method name="LocalAutocomplete">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data</FormalSpec>
+<Implementation><![CDATA[
+	do client.SendChunk(client.corePID, "a")
+	set list = $LISTGET(client.ReceiveChunk(, 1), 2)
+	set obj = ##class(%ZEN.proxyObject).%New()
+	for i=3:3:$LISTLENGTH(list) {
+		set obj2 = ##class(%ZEN.proxyObject).%New()
+		set obj2.isOref = $LISTGET(list, i - 1)
+		set obj2.value = $LISTGET(list, i)
+		set $PROPERTY(obj, $LISTGET(list, i - 2)) = obj2
+	}
+    do client.Send("ac", obj)
+	return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="GlobalAutocomplete">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,part:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do client.Send(, ##class(WebTerminal.Autocomplete).GetGlobals(client.childNamespace, part))
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="ClassAutocomplete">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,part:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do client.Send(, ##class(WebTerminal.Autocomplete).GetClass(client.childNamespace, part))
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="RoutineAutocomplete">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,part:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do client.Send(, ##class(WebTerminal.Autocomplete).GetRoutines(client.childNamespace, part))
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="ClassMemberAutocomplete">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do client.Send(, ##class(WebTerminal.Autocomplete).GetPublicClassMembers(client.childNamespace, data.className, data.part))
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="MemberAutocomplete">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do client.SendChunk(client.corePID, "a")
+    set list = $LISTGET(client.ReceiveChunk(, 1), 2)
+    set isOref = 0
+    set value = ""
+    for i=3:3:$LISTLENGTH(list) {
+        if $LISTGET(list, i - 2) = data.variable {
+            set isOref = $LISTGET(list, i - 1)
+            set value = $LISTGET(list, i)
+            quit
+        }
+    }
+    if isOref {
+        do client.Send(, ##class(WebTerminal.Autocomplete).GetClassMembers(
+            client.childNamespace, $PIECE(value, "@", 2), data.part, data.methodsOnly
+        ))
+    } else {
+        do client.Send(, 0)
+    }
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="ParameterAutocomplete">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do client.Send(, ##class(WebTerminal.Autocomplete).GetParameters(client.childNamespace, data.className, data.part))
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="serverNameConfigSet">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,value:%String=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set ^WebTerminal("Name") = value
+    do client.Send(, 1)
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="SQL">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    new $Namespace
+    set $Namespace = client.childNamespace
+    set sql = data.sql
+    set max = $case(data.max = "", 1: 777, :data.max)
+    set obj = ##class(%ZEN.proxyObject).%New()
+    
+    SET tStatement = ##class(%SQL.Statement).%New()
+    SET st = tStatement.%Prepare(sql)
+    if (st '= $$$OK) {
+        set obj.error = "%badSQL("_$System.Status.GetErrorText(st)_")"
+        return client.Send(, obj)
+    }
+    SET rset = tStatement.%Execute()
+    if (rset.%SQLCODE '= 0) {
+    	set obj.error = "%sqlErr(SQLCODE="_rset.%SQLCODE_"; "_rset.%Message_")"
+    	return client.Send(, obj)
+    }
+
+	set headers = ##class(%ListOfDataTypes).%New()
+	for i=1:1:tStatement.%Metadata.columns.Count() {
+		do headers.Insert(tStatement.%Metadata.columns.GetAt(i).colName)
+	}
+
+	set dt = ##class(%ListOfDataTypes).%New()
+	while rset.%Next() {
+		if (rset.%ROWCOUNT > max) quit
+		set line = ##class(%ListOfDataTypes).%New()
+		for i=1:1:headers.Count() {
+			do line.Insert(rset.%GetData(i))
+		}
+		do dt.Insert(line)
+	}
+
+	set:(dt.Count() > 0) obj.data = dt
+	set:(headers.Count() > 0) obj.headers = headers
+	
+    do client.Send(, obj)
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="Trace">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set obj = ##class(%ZEN.proxyObject).%New()
+    set obj.OK = 1
+    set obj.started = client.Trace(data)
+    if (obj.started '= 1) {
+        set obj.stopped = client.StopTracing(data)
+        if (obj.stopped '= 1) {
+            set obj.OK = 0
+        }
+    }
+    do client.Send(, obj)
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="StopTracing">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set obj = ##class(%ZEN.proxyObject).%New()
+    set obj.OK = $LISTLENGTH(client.Watches) > 0
+    while ($LISTLENGTH(client.Watches) > 0) {
+        set stopped = client.StopTracing($LIST(client.Watches, 1))
+    }
+    do client.Send(, obj)
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="TracingStatus">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set obj = ##class(%ZEN.proxyObject).%New()
+    set oldWatch = client.Watches
+    set obj.changes = client.CheckTracing()
+    set obj.stop = ##class(%ZEN.proxyObject).%New()
+    if ($LENGTH(oldWatch) > $LENGTH(client.Watches)) {
+        for i=1:1:$LISTLENGTH(oldWatch) {
+            if ($LISTFIND(client.Watches, $LISTGET(oldWatch, i)) = 0) {
+                set $PROPERTY(obj.stop, $LISTGET(oldWatch, i)) = 1
+            }
+        }
+    }
+    do client.Send(, obj)
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="Auth">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    // This method is implemented in Engine class. In case of auth is off, this method handles
+    // the auth request and never respond (like when you send something to /dev/null).
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="Interrupt">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    // The interrupt behavior is implemented in Execute class method. When the user presses Ctrl+C
+    // in normal mode, we will do *nothing*.
+    return $$$OK
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.Installer">
+<Description>
+Importing this class will install Cache WEB Terminal properly.</Description>
+<Super>%Projection.AbstractProjection</Super>
+<TimeChanged>65316,65786.187866</TimeChanged>
+<TimeCreated>65316,65786.187866</TimeCreated>
+<DependsOn>Router</DependsOn>
+
+<Parameter name="DispatchClass">
+<Default>WebTerminal.Router</Default>
+</Parameter>
+
+<Parameter name="ResourceName">
+<Default>%WebTerminal</Default>
+</Parameter>
+
+<Parameter name="RoleName">
+<Default>WebTerminal</Default>
+</Parameter>
+
+<Projection name="Reference">
+<Type>Installer</Type>
+</Projection>
+
+<Parameter name="VERSION">
+<Default>4.9.1</Default>
+</Parameter>
+
+<Parameter name="iscProductVersion">
+<Description>
+In older Cache versions, method "GetISCProduct" does not exists</Description>
+<Expression>$case(
+        ##class(%Dictionary.CompiledMethod).IDKEYExists("%SYSTEM.Version", "GetISCProduct"),
+        1: $CLASSMETHOD("%SYSTEM.Version", "GetISCProduct"),
+        : 2
+    )</Expression>
+</Parameter>
+
+<Method name="RegisterWebApplication">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>name:%String,spec</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    new $Namespace
+    set $Namespace = "%SYS"
+    set st = $$$OK
+    if ('##class(Security.Applications).Exists(name)) {
+        write !,"Creating WEB application """_name_"""..."
+        set st = ##class(Security.Applications).Create(name, .spec)
+        write !, "WEB application """_name_""" is created."
+    } else { // ensure configuration matches in case of updating from old terminal versions
+        write !, "Updating web application """_name_"""..."
+        set st = ##class(Security.Applications).Modify(name, .spec)
+        write !, "WEB application """_name_""" is updated."
+    }
+    return st
+]]></Implementation>
+</Method>
+
+<Method name="RemoveWebApplication">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>name:%String</FormalSpec>
+<Implementation><![CDATA[
+    new $Namespace
+    set $Namespace = "%SYS"
+    set st = $$$OK
+    if (##class(Security.Applications).Exists(name)) {
+        do ##class(Security.Applications).Get(name, .props)
+        if (props("DispatchClass") '= ..#DispatchClass) && (name = "/terminal") {
+            write !, "Won't delete WEB-application """_name_""" because it does not refer to dispatch class anymore."
+        } else {
+            write !, "Deleting WEB application """_name_"""..."
+            set st = ##class(Security.Applications).Delete(name)
+            write !, "WEB application """_name_""" was successfully deleted."
+        }
+    }
+    return st
+]]></Implementation>
+</Method>
+
+<Method name="ReportInstallStatus">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>st,ns=^WebTerminal("HomeNamespace")</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set $Namespace = ns
+    if (st '= 1) {
+        do $System.Status.DisplayError(st)
+    }
+    set status = ##class(WebTerminal.Analytics).ReportInstallStatus(st)
+    set $Namespace = "%SYS"
+    return status
+]]></Implementation>
+</Method>
+
+<Method name="CreateProjection">
+<Description>
+This method is invoked when a class is compiled.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec><![CDATA[cls:%String,&params]]></FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+	new $Namespace
+	set ns = $Namespace // ought to be package home namespace!
+    set ^WebTerminal("HomeNamespace") = ns
+    set ^WebTerminal("FirstLaunch") = 1
+    write !, "Installing WebTerminal application to " _ ns
+    set dbdir = $$$defdir
+    try {
+        set $Namespace = "%SYS"
+    } catch (e) {
+        set mes = "<PROTECT> The user " _ $Username _ " has no privileges"
+            _ " to enter the %SYS namespace. Please, log in as a privileged user"
+            _ " to set up the WebTerminal application."
+        set err = $$$ERROR($$$GeneralError, mes)
+        do ..ReportInstallStatus(err, ns)
+        return err
+    }
+    
+    set cspProperties("AutheEnabled") = $$$AutheCache
+    set cspProperties("NameSpace") = ns
+    set cspProperties("Description") = "A WEB application for Cache WEB Terminal."
+    set cspProperties("IsNameSpaceDefault") = $$$NO
+    set cspProperties("DispatchClass") = ..#DispatchClass
+    set st = ..RegisterWebApplication("/terminal", .cspProperties)
+    do:($$$ISERR(st)) ..ReportInstallStatus(st, ns)
+    return:$$$ISERR(st) st
+    
+    set cspProperties("AutheEnabled") = $$$AutheUnauthenticated
+    set cspProperties("Description") = "An application representing the open socket for /terminal application."
+    set cspProperties("DispatchClass") = ""
+
+    set requiredRole = $case(..#iscProductVersion >= 4, 1: "%DB_IRISSYS", : "%DB_CACHESYS")
+    set roles = ..GetDBRole(dbdir)
+    set extractedRoles = $case($get(roles) '= "", 1: ":" _ roles, : "")
+    set cspProperties("MatchRoles") = ":" _ $case(
+        $find(extractedRoles, requiredRole) = 0,
+        1: requiredRole _ extractedRoles,
+        : requiredRole
+    )
+    write !, "Assigning role " _ requiredRole _ " to a web application; resulting roles: " _ cspProperties("MatchRoles")
+
+    set st = ..RegisterWebApplication("/terminalsocket", .cspProperties)
+    do:($$$ISERR(st)) ..ReportInstallStatus(st, ns)
+    return:$$$ISERR(st) st
+    
+    do ..CreateAllNamespace()
+    
+    write !, "Mapping %WebTerminal package into all namespaces:"
+    set st = ..Map(ns)
+    if ($$$ISERR(st)) {
+        do ..ReportInstallStatus(st, ns)
+    } else {
+	    write !, "WebTerminal package successfully mapped into all namespaces."
+	    do ..ReportInstallStatus(1, ns)
+    }
+
+    if (##class(Security.Resources).Exists(..#ResourceName) = 0) {
+        set st = ##class(Security.Resources).Create(..#ResourceName,
+            "Grants access to WebTerminal if set up.", "")
+    }
+
+    if (##class(Security.Roles).Exists(..#RoleName) = 0) {
+        set st = ##class(Security.Roles).Create(..#RoleName,
+            "WebTerminal user role which may grant access to WebTerminal application if set up.",
+            "%WebTerminal:RWU")
+    }
+    
+    return st
+]]></Implementation>
+</Method>
+
+<Method name="RemoveProjection">
+<Description>
+This method is invoked when a class is 'uncompiled'.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec><![CDATA[cls:%String,&params,recompile:%Boolean]]></FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+	new $Namespace
+
+	write:(recompile) !, "Recompiling WebTerminal, skipping the deletion..."
+    return:(recompile) $$$OK
+
+	set ns = $get(^WebTerminal("HomeNamespace"), $Namespace)
+    write !, "Uninstalling WebTerminal application from ", ns
+    zn "%SYS"
+    set st = ..RemoveWebApplication("/terminal")
+    do:($$$ISERR(st)) ..ReportInstallStatus(st, ns)
+    return:($$$ISERR(st)) st
+    set st = ..RemoveWebApplication("/terminalsocket")
+    do:($$$ISERR(st)) ..ReportInstallStatus(st, ns)
+    return:($$$ISERR(st)) st
+    if (##class(Security.Resources).Exists(..#ResourceName) = 1) {
+        set st = ##class(Security.Resources).Delete(..#ResourceName)
+        do:($$$ISERR(st)) ..ReportInstallStatus(st, ns)
+        return:($$$ISERR(st)) st
+    }
+    if (##class(Security.Roles).Exists(..#RoleName) = 1) {
+        set st = ##class(Security.Roles).Delete(..#RoleName)
+        do:($$$ISERR(st)) ..ReportInstallStatus(st, ns)
+        return:($$$ISERR(st)) st
+    }
+
+    kill:st ^WebTerminal
+    write !, "Global ^WebTerminal removed."
+
+    write !, "Unmapping %WebTerminal package from all namespaces:"
+	set st = ..UnMap(ns)
+    if ($$$ISERR(st)) {
+        do ..ReportInstallStatus(st, ns)
+    } else {
+	    write !, "Unmapping complete."
+    }
+
+    return st
+]]></Implementation>
+</Method>
+
+<Method name="GetDBRole">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>directory:%String</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+	return:'$d(directory) ""
+	new $Namespace
+	set $Namespace = "%SYS"
+	#dim db As SYS.Database
+	set db = ##class(SYS.Database).%OpenId(directory)
+	if $Isobject(db) {
+		set resource = db.ResourceName
+		set role = resource // I'm assuming that default role exists (@eduard93)
+	} else {
+		set role = ""
+	}
+	return role
+]]></Implementation>
+</Method>
+
+<Method name="CreateAllNamespace">
+<ClassMethod>1</ClassMethod>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+
+	new $Namespace
+    set $Namespace = "%SYS"
+	set ns = "%All"
+    set st = $$$OK
+
+	if ('##Class(Config.Namespaces).Exists(ns)) {
+
+        set dbPrefix = $case(..#iscProductVersion >= 4, 1: "IRIS", : "CACHE")
+        set Properties("Globals") = dbPrefix _ "TEMP"
+        set Properties("Library") = dbPrefix _ "LIB"
+        set Properties("Routines") = dbPrefix _ "TEMP"
+        set Properties("SysGlobals") = dbPrefix _ "SYS"
+        set Properties("SysRoutines") = dbPrefix _ "SYS"
+        set Properties("TempGlobals") = dbPrefix _ "TEMP"
+		
+		set st = ##Class(Config.Namespaces).Create(ns, .Properties)
+		if ($$$ISERR(st)) {
+        	do $System.Status.DisplayError(st)
+    	} else {
+        	write !, "%All namespace is created."
+        }
+
+    }
+
+    return st
+]]></Implementation>
+</Method>
+
+<Method name="Map">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>fromNS=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+	new $Namespace
+    set $Namespace = "%SYS"
+    set st = $$$OK
+
+    set mapTo = $LISTBUILD("%All", "SAMPLES", "DOCBOOK")
+    do ##Class(Config.Namespaces).Get(fromNS, .InstallNSProps)
+    set Properties("Database") = $get(InstallNSProps("Routines"))
+    set ptr = 0
+    while $LISTNEXT(mapTo, ptr, namespace) {
+        continue:(fromNS = namespace)
+        continue:('##Class(Config.Namespaces).Exists(namespace))
+        write " ", namespace
+        if ('##Class(Config.MapPackages).Exists(namespace, "WebTerminal")) {
+        	set st1 = ##Class(Config.MapPackages).Create(namespace, "WebTerminal", .Properties)
+        }
+        if ('##Class(Config.MapGlobals).Exists(namespace, "WebTerminal")) {
+	        set st2 = ##Class(Config.MapGlobals).Create(namespace, "WebTerminal", .Properties)
+        }
+        set st = $$$ADDSC(st,$$$ADDSC($get(st1,$$$OK),$get(st2,$$$OK)))
+    }
+    return st
+]]></Implementation>
+</Method>
+
+<Method name="UnMap">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>fromNS:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+	new $Namespace
+    set $Namespace = "%SYS"
+    set st = $$$OK
+    
+	set mapTo = $LISTBUILD("%All", "SAMPLES", "DOCBOOK")
+    set ptr = 0
+    while $LISTNEXT(mapTo, ptr, namespace) {
+	    continue:(fromNS = namespace)
+	    continue:('##Class(Config.Namespaces).Exists(namespace))
+        write " ", namespace
+        if (##Class(Config.MapPackages).Exists(namespace, "WebTerminal")) {
+        	set st1 = ##Class(Config.MapPackages).Delete(namespace, "WebTerminal", .Properties)
+        }
+        if (##Class(Config.MapGlobals).Exists(namespace, "WebTerminal")) {
+	        set st2 = ##Class(Config.MapGlobals).Delete(namespace, "WebTerminal", .Properties)
+        }
+        set st = $$$ADDSC(st,$$$ADDSC($get(st1,$$$OK),$get(st2,$$$OK)))
+    }
+    return st
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.Router">
+<Description>
+The REST interface: class that routes HTTP requests</Description>
+<CompileAfter>StaticContent</CompileAfter>
+<Super>%CSP.REST</Super>
+<TimeChanged>65316,65786.18966</TimeChanged>
+<TimeCreated>65316,65786.18966</TimeCreated>
+
+<XData name="UrlMap">
+<Data><![CDATA[
+<Routes>
+   <Route Url="/" Method="GET" Call="Index"/>
+   <Route Url="/index" Method="GET" Call="Index"/>
+   <Route Url="/auth" Method="GET" Call="Auth"/>
+   <Route Url="/css/index.css" Method="GET" Call="GetCss"/>
+   <Route Url="/css/themes/:theme" Method="GET" Call="GetTheme"/>
+   <Route Url="/js/index.js" Method="GET" Call="GetJs"/>
+</Routes>
+]]></Data>
+</XData>
+
+<Method name="WriteStatic">
+<Description>
+Calls StaticContent.Write method or sends not modified header. Type have to be "css" or "js"</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>type:%String,ContentType:%String=""</FormalSpec>
+<Private>1</Private>
+<Implementation><![CDATA[
+    #define CompileTime ##Expression("""" _ $zd($h, 11) _ ", "_ $zdt($NOW(0), 2,1) _ " GMT""")
+    set %response.CharSet = "utf-8"
+    set %response.ContentType = $case(type,
+        "css": "text/css",
+        "js": "text/javascript",
+        "html": "text/html",
+        : $case(ContentType="", 1:"text/plain", :ContentType)
+    )
+    do %response.SetHeader("Last-Modified", $$$CompileTime)
+
+    if (%request.GetCgiEnv("HTTP_IF_MODIFIED_SINCE")=$$$CompileTime) {
+        set %response.Status = "304 Not Modified"
+    } else {
+        do ##class(StaticContent).Write(type)
+    }
+]]></Implementation>
+</Method>
+
+<Method name="Auth">
+<ClassMethod>1</ClassMethod>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set cookie = $System.Encryption.Base64Encode(%session.Key)
+    set ^WebTerminal("AuthUser", cookie) = $LB( // authList
+        $Username, // username
+        $Horolog, // granting ticket date
+        $Get(%request.Data("ns", 1), $Get(%request.Data("NS", 1))),
+        $Get(%request.Data("clean", 1), 0) '= 0
+    )
+    write "{""key"":""" _ cookie _ """}"
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="GetCss">
+<Description>
+Method writes application CSS.</Description>
+<ClassMethod>1</ClassMethod>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do ..WriteStatic("css")
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="GetTheme">
+<Description>
+Method writes application theme.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>Theme:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do ..WriteStatic("Theme"_$REPLACE(Theme, ".css", ""),"text/css")
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="GetJs">
+<Description>
+Method writes application JavaScript.</Description>
+<ClassMethod>1</ClassMethod>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do ..WriteStatic("js")
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="Index">
+<Description>
+Method writes application HTML.</Description>
+<ClassMethod>1</ClassMethod>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do ..WriteStatic("html")
+    return $$$OK
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.StaticContent">
+<Description>
+This class holds whole application static content like scripts and styles.
+Do not edit this file - use external tool to generate it.</Description>
+<TimeChanged>65316,65978.758976</TimeChanged>
+<TimeCreated>65316,65786.211005</TimeCreated>
+
+<Method name="Write">
+<Description>
+Write the contents of xData tag</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>Const:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set obj = ##class(%Dictionary.CompiledXData).%OpenId("WebTerminal.StaticContent||"_Const)
+    return:(obj = "") $$$OK
+    set xdata = obj.Data
+    set status = ##class(%XML.TextReader).ParseStream(xdata, .textreader)
+    while textreader.Read() { if (textreader.NodeType="chars") {
+        write textreader.Value
+    } }
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<XData name="Themecache">
+<Data><![CDATA[
+<data>
+<![CDATA[body,html{color:#000;background:#fff;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.terminal .hint{text-shadow:1px 1px 4px #fff}.g.m31{color:#c80000}.g.m32{color:#00c800}.g.m33{color:#c8c800}.g.m34{color:#0000c8}.g.m35{color:#c800c8}.g.m36{color:#00c8c8}.g.m41{background-color:#c80000}.g.m42{background-color:#00c800}.g.m43{background-color:#c8c800}.g.m44{background-color:#0000c8}.g.m45{background-color:#c800c8}.g.m46{background-color:#00c8c8}]]]]><![CDATA[>
+</data>
+]]></Data>
+</XData>
+
+<XData name="html">
+<Data><![CDATA[
+<data>
+<![CDATA[<!DOCTYPE html>
+         <html>
+         <head lang="en">
+             <meta charset="UTF-8"/>
+             <title>Cach&eacute; WEB Terminal</title>
+             <meta name="author" content="ZitRo"/>
+             <meta name="description" content="Web-based terminal emulator for Caché administering."/>
+             <meta name="keywords" content="Cache,Caché,terminal,web,remote,control,Caché WebTerminal"/>
+             <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, maximum-scale=1.0"/>
+             <meta name="MobileOptimized" content="320"/>
+             <meta name="HandheldFriendly" content="true"/>
+             <meta name="mobile-web-app-capable" content="yes"/>
+             <meta name="apple-mobile-web-app-capable" content="yes"/>
+             <link rel="stylesheet" href="css/index.css"/>
+             <script async src="https://www.google-analytics.com/analytics.js"></script>
+             <script type="text/javascript" src="js/index.js"></script>
+         </head>
+         <body>
+         <!-- @see js/index.js -->
+         </body>
+         </html>]]]]><![CDATA[>
+</data>
+]]></Data>
+</XData>
+
+<XData name="css">
+<Data><![CDATA[
+<data>
+<![CDATA[body,html{padding:0;margin:0;background:#000;color:#fff}.terminal,body,html{position:relative;width:100%;height:100%;overflow:hidden}.terminal{font-family:FreeMono,monospace;font-size:16px;background:inherit;-webkit-font-smoothing:subpixel-antialiased;-moz-osx-font-smoothing:auto}.terminal .output{position:absolute;white-space:pre;word-wrap:break-word;word-break:break-all;overflow-x:hidden;overflow-y:scroll;background:inherit;width:100%;height:100%;z-index:0}.terminal .output .input{position:absolute;width:100%;border:0;text-decoration:none;outline:none;margin:0;padding:0;opacity:0;font-family:inherit;font-size:inherit;z-index:3;background:transparent;color:transparent;overflow:hidden}.terminal .output .line{position:absolute;z-index:1;min-width:100%;background:inherit}.terminal .output .line .g{background:inherit}.terminal .output .line.html{z-index:2;white-space:normal;height:auto!important;word-break:normal;overflow-x:auto;width:100%}.terminal .output .caret{position:absolute;left:0;top:0;z-index:2;animation:a infinite 1s}.terminal .output .caret:after{position:relative;top:-1px;content:"_"}.terminal>.indicator{position:fixed;right:13px;top:7px;border:3px solid #fff;border-radius:30px;height:30px;margin:-15px 0 0 -15px;opacity:0;width:30px;animation:b infinite 1s}.terminal table{border-collapse:collapse;border:1px solid #666}.terminal table td,.terminal table th{padding:2px;border:1px solid #666}.terminal table td:nth-child(2n-1),.terminal table th:nth-child(2n-1){background:#222}.terminal table th{font-weight:700}a{color:#00ce00}.terminal .output .line .g.m1{font-weight:900}.terminal .output .line .g.m2{opacity:.7}.terminal .output .line .g.m3{font-style:italic}.terminal .output .line .g.m4{text-decoration:underline}.terminal .output .line .g.m5{animation:a infinite 1s}.terminal .output .line .g.m7{-khtml-filter:invert(100%);-moz-filter:invert(100%);-o-filter:invert(100%);-ms-filter:invert(100%);filter:invert(100%)}.terminal .output .line .g.m8{opacity:0}.terminal .output .line .g.hint{opacity:.5}.terminal .output .line .g.m30{color:#000}.terminal .output .line .g.m31{color:red}.terminal .output .line .g.m32{color:green}.terminal .output .line .g.m33{color:#ff0}.terminal .output .line .g.m34{color:#00f}.terminal .output .line .g.m35{color:#f0f}.terminal .output .line .g.m36{color:cyan}.terminal .output .line .g.m37{color:#fff}.terminal .output .line .g.m40{background-color:#000}.terminal .output .line .g.m41{background-color:red}.terminal .output .line .g.m42{background-color:green}.terminal .output .line .g.m43{background-color:#ff0}.terminal .output .line .g.m44{background-color:#00f}.terminal .output .line .g.m45{background-color:#f0f}.terminal .output .line .g.m46{background-color:cyan}.terminal .output .line .g.m47{background-color:#fff}.terminal .output .line .g.keyword{color:#4898ff}.terminal .output .line .g.string{color:#00c700}.terminal .output .line .g.constant{color:cyan}.terminal .output .line .g.special{color:#ff0}.terminal .output .line .g.variable{color:#ffa07a}.terminal .output .line .g.selected{color:#fff;background-color:#4169e1}.terminal .output .line .g.argument{color:#da7cff}.terminal .output .line .g.error{display:inline-block;position:relative}.terminal .output .line .g.error:after{content:"";position:absolute;display:block;bottom:0;left:0;width:100%;height:0;border-top:1px dashed red}.terminal .output .line .g.wrong{color:red}.terminal .output .line .g.global{color:#ef6913}.terminal .output .line .g.classname{color:cyan}@keyframes a{0%{-khtml-filter:invert(0);-moz-filter:invert(0);-o-filter:invert(0);-ms-filter:invert(0);filter:invert(0)}50%{-khtml-filter:invert(100%);-moz-filter:invert(100%);-o-filter:invert(100%);-ms-filter:invert(100%);filter:invert(100%)}to{-khtml-filter:invert(0);-moz-filter:invert(0);-o-filter:invert(0);-ms-filter:invert(0);filter:invert(0)}}@keyframes b{0%{transform:scale(.1);-o-transform:scale(.1);-ms-transform:scale(.1);-moz-transform:scale(.1);-webkit-transform:scale(.1);opacity:0}50%{opacity:1}to{transform:scale(.5);-o-transform:scale(.5);-ms-transform:scale(.5);-moz-transform:scale(.5);-webkit-transform:scale(.5);opacity:0}}.terminal .hintBox{position:absolute;left:0;top:0;width:300px;max-width:75%;height:0;overflow:visible;z-index:100}.terminal .hintBox>div{position:absolute;transition:all .3s ease;color:gray;border-radius:10px}]]]]><![CDATA[>
+</data>
+]]></Data>
+</XData>
+
+<XData name="js">
+<Data><![CDATA[
+<data>
+<![CDATA[!function(){function e(t,n,r){function o(i,s){if(!n[i]){if(!t[i]){var l="function"==typeof require&&require;if(!s&&l)return l(i,!0);if(a)return a(i,!0);var u=new Error("Cannot find module '"+i+"'");throw u.code="MODULE_NOT_FOUND",u}var c=n[i]={exports:{}};t[i][0].call(c.exports,function(e){return o(t[i][1][e]||e)},c,c.exports,e,t,n,r)}return n[i].exports}for(var a="function"==typeof require&&require,i=0;i<r.length;i++)o(r[i]);return o}return e}()({1:[function(e,t,n){(function(t){"use strict";function n(e,t,n){e[t]||Object[r](e,t,{writable:!0,configurable:!0,value:n})}if(e("core-js/shim"),e("regenerator-runtime/runtime"),e("core-js/fn/regexp/escape"),t._babelPolyfill)throw new Error("only one instance of babel-polyfill is allowed");t._babelPolyfill=!0;var r="defineProperty";n(String.prototype,"padLeft","".padStart),n(String.prototype,"padRight","".padEnd),"pop,reverse,shift,keys,values,entries,indexOf,every,some,forEach,map,filter,find,findIndex,includes,join,slice,concat,push,splice,unshift,sort,lastIndexOf,reduce,reduceRight,copyWithin,fill".split(",").forEach(function(e){[][e]&&n(Array,e,Function.call.bind([][e]))})}).call(this,"undefined"!=typeof global?global:"undefined"!=typeof self?self:"undefined"!=typeof window?window:{})},{"core-js/fn/regexp/escape":3,"core-js/shim":331,"regenerator-runtime/runtime":2}],2:[function(e,t,n){(function(e){!function(e){"use strict";function n(e,t,n,r){var a=t&&t.prototype instanceof o?t:o,i=Object.create(a.prototype),s=new d(r||[]);return i._invoke=u(e,n,s),i}function r(e,t,n){try{return{type:"normal",arg:e.call(t,n)}}catch(e){return{type:"throw",arg:e}}}function o(){}function a(){}function i(){}function s(e){["next","throw","return"].forEach(function(t){e[t]=function(e){return this._invoke(t,e)}})}function l(t){function n(e,o,a,i){var s=r(t[e],t,o);if("throw"!==s.type){var l=s.arg,u=l.value;return u&&"object"==typeof u&&m.call(u,"__await")?Promise.resolve(u.__await).then(function(e){n("next",e,a,i)},function(e){n("throw",e,a,i)}):Promise.resolve(u).then(function(e){l.value=e,a(l)},i)}i(s.arg)}function o(e,t){function r(){return new Promise(function(r,o){n(e,t,r,o)})}return a=a?a.then(r,r):r()}"object"==typeof e.process&&e.process.domain&&(n=e.process.domain.bind(n));var a;this._invoke=o}function u(e,t,n){var o=S;return function(a,i){if(o===E)throw new Error("Generator is already running");if(o===I){if("throw"===a)throw i;return y()}for(n.method=a,n.arg=i;;){var s=n.delegate;if(s){var l=c(s,n);if(l){if(l===C)continue;return l}}if("next"===n.method)n.sent=n._sent=n.arg;else if("throw"===n.method){if(o===S)throw o=I,n.arg;n.dispatchException(n.arg)}else"return"===n.method&&n.abrupt("return",n.arg);o=E;var u=r(e,t,n);if("normal"===u.type){if(o=n.done?I:k,u.arg===C)continue;return{value:u.arg,done:n.done}}"throw"===u.type&&(o=I,n.method="throw",n.arg=u.arg)}}}function c(e,t){var n=e.iterator[t.method];if(n===_){if(t.delegate=null,"throw"===t.method){if(e.iterator.return&&(t.method="return",t.arg=_,c(e,t),"throw"===t.method))return C;t.method="throw",t.arg=new TypeError("The iterator does not provide a 'throw' method")}return C}var o=r(n,e.iterator,t.arg);if("throw"===o.type)return t.method="throw",t.arg=o.arg,t.delegate=null,C;var a=o.arg;return a?a.done?(t[e.resultName]=a.value,t.next=e.nextLoc,"return"!==t.method&&(t.method="next",t.arg=_),t.delegate=null,C):a:(t.method="throw",t.arg=new TypeError("iterator result is not an object"),t.delegate=null,C)}function f(e){var t={tryLoc:e[0]};1 in e&&(t.catchLoc=e[1]),2 in e&&(t.finallyLoc=e[2],t.afterLoc=e[3]),this.tryEntries.push(t)}function p(e){var t=e.completion||{};t.type="normal",delete t.arg,e.completion=t}function d(e){this.tryEntries=[{tryLoc:"root"}],e.forEach(f,this),this.reset(!0)}function v(e){if(e){var t=e[b];if(t)return t.call(e);if("function"==typeof e.next)return e;if(!isNaN(e.length)){var n=-1,r=function t(){for(;++n<e.length;)if(m.call(e,n))return t.value=e[n],t.done=!1,t;return t.value=_,t.done=!0,t};return r.next=r}}return{next:y}}function y(){return{value:_,done:!0}}var _,h=Object.prototype,m=h.hasOwnProperty,g="function"==typeof Symbol?Symbol:{},b=g.iterator||"@@iterator",x=g.asyncIterator||"@@asyncIterator",w=g.toStringTag||"@@toStringTag",j="object"==typeof t,A=e.regeneratorRuntime;if(A)return void(j&&(t.exports=A));A=e.regeneratorRuntime=j?t.exports:{},A.wrap=n;var S="suspendedStart",k="suspendedYield",E="executing",I="completed",C={},O={};O[b]=function(){return this};var P=Object.getPrototypeOf,L=P&&P(P(v([])));L&&L!==h&&m.call(L,b)&&(O=L);var M=i.prototype=o.prototype=Object.create(O);a.prototype=M.constructor=i,i.constructor=a,i[w]=a.displayName="GeneratorFunction",A.isGeneratorFunction=function(e){var t="function"==typeof e&&e.constructor;return!!t&&(t===a||"GeneratorFunction"===(t.displayName||t.name))},A.mark=function(e){return Object.setPrototypeOf?Object.setPrototypeOf(e,i):(e.__proto__=i,w in e||(e[w]="GeneratorFunction")),e.prototype=Object.create(M),e},A.awrap=function(e){return{__await:e}},s(l.prototype),l.prototype[x]=function(){return this},A.AsyncIterator=l,A.async=function(e,t,r,o){var a=new l(n(e,t,r,o));return A.isGeneratorFunction(t)?a:a.next().then(function(e){return e.done?e.value:a.next()})},s(M),M[w]="Generator",M[b]=function(){return this},M.toString=function(){return"[object Generator]"},A.keys=function(e){var t=[];for(var n in e)t.push(n);return t.reverse(),function n(){for(;t.length;){var r=t.pop();if(r in e)return n.value=r,n.done=!1,n}return n.done=!0,n}},A.values=v,d.prototype={constructor:d,reset:function(e){if(this.prev=0,this.next=0,this.sent=this._sent=_,this.done=!1,this.delegate=null,this.method="next",this.arg=_,this.tryEntries.forEach(p),!e)for(var t in this)"t"===t.charAt(0)&&m.call(this,t)&&!isNaN(+t.slice(1))&&(this[t]=_)},stop:function(){this.done=!0;var e=this.tryEntries[0],t=e.completion;if("throw"===t.type)throw t.arg;return this.rval},dispatchException:function(e){function t(t,r){return a.type="throw",a.arg=e,n.next=t,r&&(n.method="next",n.arg=_),!!r}if(this.done)throw e;for(var n=this,r=this.tryEntries.length-1;r>=0;--r){var o=this.tryEntries[r],a=o.completion;if("root"===o.tryLoc)return t("end");if(o.tryLoc<=this.prev){var i=m.call(o,"catchLoc"),s=m.call(o,"finallyLoc");if(i&&s){if(this.prev<o.catchLoc)return t(o.catchLoc,!0);if(this.prev<o.finallyLoc)return t(o.finallyLoc)}else if(i){if(this.prev<o.catchLoc)return t(o.catchLoc,!0)}else{if(!s)throw new Error("try statement without catch or finally");if(this.prev<o.finallyLoc)return t(o.finallyLoc)}}}},abrupt:function(e,t){for(var n=this.tryEntries.length-1;n>=0;--n){var r=this.tryEntries[n];if(r.tryLoc<=this.prev&&m.call(r,"finallyLoc")&&this.prev<r.finallyLoc){var o=r;break}}o&&("break"===e||"continue"===e)&&o.tryLoc<=t&&t<=o.finallyLoc&&(o=null);var a=o?o.completion:{};return a.type=e,a.arg=t,o?(this.method="next",this.next=o.finallyLoc,C):this.complete(a)},complete:function(e,t){if("throw"===e.type)throw e.arg;return"break"===e.type||"continue"===e.type?this.next=e.arg:"return"===e.type?(this.rval=this.arg=e.arg,this.method="return",this.next="end"):"normal"===e.type&&t&&(this.next=t),C},finish:function(e){for(var t=this.tryEntries.length-1;t>=0;--t){var n=this.tryEntries[t];if(n.finallyLoc===e)return this.complete(n.completion,n.afterLoc),p(n),C}},catch:function(e){for(var t=this.tryEntries.length-1;t>=0;--t){var n=this.tryEntries[t];if(n.tryLoc===e){var r=n.completion;if("throw"===r.type){var o=r.arg;p(n)}return o}}throw new Error("illegal catch attempt")},delegateYield:function(e,t,n){return this.delegate={iterator:v(e),resultName:t,nextLoc:n},"next"===this.method&&(this.arg=_),C}}}("object"==typeof e?e:"object"==typeof window?window:"object"==typeof self?self:this)}).call(this,"undefined"!=typeof global?global:"undefined"!=typeof self?self:"undefined"!=typeof window?window:{})},{}],3:[function(e,t,n){e("../../modules/core.regexp.escape"),t.exports=e("../../modules/_core").RegExp.escape},{"../../modules/_core":25,"../../modules/core.regexp.escape":133}],4:[function(e,t,n){t.exports=function(e){if("function"!=typeof e)throw TypeError(e+" is not a function!");return e}},{}],5:[function(e,t,n){var r=e("./_cof");t.exports=function(e,t){if("number"!=typeof e&&"Number"!=r(e))throw TypeError(t);return+e}},{"./_cof":20}],6:[function(e,t,n){var r=e("./_wks")("unscopables"),o=Array.prototype;void 0==o[r]&&e("./_hide")(o,r,{}),t.exports=function(e){o[r][e]=!0}},{"./_hide":45,"./_wks":131}],7:[function(e,t,n){"use strict";var r=e("./_string-at")(!0);t.exports=function(e,t,n){return t+(n?r(e,t).length:1)}},{"./_string-at":108}],8:[function(e,t,n){t.exports=function(e,t,n,r){if(!(e instanceof t)||void 0!==r&&r in e)throw TypeError(n+": incorrect invocation!");return e}},{}],9:[function(e,t,n){var r=e("./_is-object");t.exports=function(e){if(!r(e))throw TypeError(e+" is not an object!");return e}},{"./_is-object":54}],10:[function(e,t,n){"use strict";var r=e("./_to-object"),o=e("./_to-absolute-index"),a=e("./_to-length");t.exports=[].copyWithin||function(e,t){var n=r(this),i=a(n.length),s=o(e,i),l=o(t,i),u=arguments.length>2?arguments[2]:void 0,c=Math.min((void 0===u?i:o(u,i))-l,i-s),f=1;for(l<s&&s<l+c&&(f=-1,l+=c-1,s+=c-1);c-- >0;)l in n?n[s]=n[l]:delete n[s],s+=f,l+=f;return n}},{"./_to-absolute-index":116,"./_to-length":120,"./_to-object":121}],11:[function(e,t,n){"use strict";var r=e("./_to-object"),o=e("./_to-absolute-index"),a=e("./_to-length");t.exports=function(e){for(var t=r(this),n=a(t.length),i=arguments.length,s=o(i>1?arguments[1]:void 0,n),l=i>2?arguments[2]:void 0,u=void 0===l?n:o(l,n);u>s;)t[s++]=e;return t}},{"./_to-absolute-index":116,"./_to-length":120,"./_to-object":121}],12:[function(e,t,n){var r=e("./_for-of");t.exports=function(e,t){var n=[];return r(e,!1,n.push,n,t),n}},{"./_for-of":41}],13:[function(e,t,n){var r=e("./_to-iobject"),o=e("./_to-length"),a=e("./_to-absolute-index");t.exports=function(e){return function(t,n,i){var s,l=r(t),u=o(l.length),c=a(i,u);if(e&&n!=n){for(;u>c;)if((s=l[c++])!=s)return!0}else for(;u>c;c++)if((e||c in l)&&l[c]===n)return e||c||0;return!e&&-1}}},{"./_to-absolute-index":116,"./_to-iobject":119,"./_to-length":120}],14:[function(e,t,n){var r=e("./_ctx"),o=e("./_iobject"),a=e("./_to-object"),i=e("./_to-length"),s=e("./_array-species-create");t.exports=function(e,t){var n=1==e,l=2==e,u=3==e,c=4==e,f=6==e,p=5==e||f,d=t||s;return function(t,s,v){for(var y,_,h=a(t),m=o(h),g=r(s,v,3),b=i(m.length),x=0,w=n?d(t,b):l?d(t,0):void 0;b>x;x++)if((p||x in m)&&(y=m[x],_=g(y,x,h),e))if(n)w[x]=_;else if(_)switch(e){case 3:return!0;case 5:return y;case 6:return x;case 2:w.push(y)}else if(c)return!1;return f?-1:u||c?c:w}}},{"./_array-species-create":17,"./_ctx":27,"./_iobject":50,"./_to-length":120,"./_to-object":121}],15:[function(e,t,n){var r=e("./_a-function"),o=e("./_to-object"),a=e("./_iobject"),i=e("./_to-length");t.exports=function(e,t,n,s,l){r(t);var u=o(e),c=a(u),f=i(u.length),p=l?f-1:0,d=l?-1:1;if(n<2)for(;;){if(p in c){s=c[p],p+=d;break}if(p+=d,l?p<0:f<=p)throw TypeError("Reduce of empty array with no initial value")}for(;l?p>=0:f>p;p+=d)p in c&&(s=t(s,c[p],p,u));return s}},{"./_a-function":4,"./_iobject":50,"./_to-length":120,"./_to-object":121}],16:[function(e,t,n){var r=e("./_is-object"),o=e("./_is-array"),a=e("./_wks")("species");t.exports=function(e){var t;return o(e)&&(t=e.constructor,"function"!=typeof t||t!==Array&&!o(t.prototype)||(t=void 0),r(t)&&null===(t=t[a])&&(t=void 0)),void 0===t?Array:t}},{"./_is-array":52,"./_is-object":54,"./_wks":131}],17:[function(e,t,n){var r=e("./_array-species-constructor");t.exports=function(e,t){return new(r(e))(t)}},{"./_array-species-constructor":16}],18:[function(e,t,n){"use strict";var r=e("./_a-function"),o=e("./_is-object"),a=e("./_invoke"),i=[].slice,s={},l=function(e,t,n){if(!(t in s)){for(var r=[],o=0;o<t;o++)r[o]="a["+o+"]";s[t]=Function("F,a","return new F("+r.join(",")+")")}return s[t](e,n)};t.exports=Function.bind||function(e){var t=r(this),n=i.call(arguments,1),s=function(){var r=n.concat(i.call(arguments));return this instanceof s?l(t,r.length,r):a(t,r,e)};return o(t.prototype)&&(s.prototype=t.prototype),s}},{"./_a-function":4,"./_invoke":49,"./_is-object":54}],19:[function(e,t,n){var r=e("./_cof"),o=e("./_wks")("toStringTag"),a="Arguments"==r(function(){return arguments}()),i=function(e,t){try{return e[t]}catch(e){}};t.exports=function(e){var t,n,s;return void 0===e?"Undefined":null===e?"Null":"string"==typeof(n=i(t=Object(e),o))?n:a?r(t):"Object"==(s=r(t))&&"function"==typeof t.callee?"Arguments":s}},{"./_cof":20,"./_wks":131}],20:[function(e,t,n){var r={}.toString;t.exports=function(e){return r.call(e).slice(8,-1)}},{}],21:[function(e,t,n){"use strict";var r=e("./_object-dp").f,o=e("./_object-create"),a=e("./_redefine-all"),i=e("./_ctx"),s=e("./_an-instance"),l=e("./_for-of"),u=e("./_iter-define"),c=e("./_iter-step"),f=e("./_set-species"),p=e("./_descriptors"),d=e("./_meta").fastKey,v=e("./_validate-collection"),y=p?"_s":"size",_=function(e,t){var n,r=d(t);if("F"!==r)return e._i[r];for(n=e._f;n;n=n.n)if(n.k==t)return n};t.exports={getConstructor:function(e,t,n,u){var c=e(function(e,r){s(e,c,t,"_i"),e._t=t,e._i=o(null),e._f=void 0,e._l=void 0,e[y]=0,void 0!=r&&l(r,n,e[u],e)});return a(c.prototype,{clear:function(){for(var e=v(this,t),n=e._i,r=e._f;r;r=r.n)r.r=!0,r.p&&(r.p=r.p.n=void 0),delete n[r.i];e._f=e._l=void 0,e[y]=0},delete:function(e){var n=v(this,t),r=_(n,e);if(r){var o=r.n,a=r.p;delete n._i[r.i],r.r=!0,a&&(a.n=o),o&&(o.p=a),n._f==r&&(n._f=o),n._l==r&&(n._l=a),n[y]--}return!!r},forEach:function(e){v(this,t);for(var n,r=i(e,arguments.length>1?arguments[1]:void 0,3);n=n?n.n:this._f;)for(r(n.v,n.k,this);n&&n.r;)n=n.p},has:function(e){return!!_(v(this,t),e)}}),p&&r(c.prototype,"size",{get:function(){return v(this,t)[y]}}),c},def:function(e,t,n){var r,o,a=_(e,t);return a?a.v=n:(e._l=a={i:o=d(t,!0),k:t,v:n,p:r=e._l,n:void 0,r:!1},e._f||(e._f=a),r&&(r.n=a),e[y]++,"F"!==o&&(e._i[o]=a)),e},getEntry:_,setStrong:function(e,t,n){u(e,t,function(e,n){this._t=v(e,t),this._k=n,this._l=void 0},function(){for(var e=this,t=e._k,n=e._l;n&&n.r;)n=n.p;return e._t&&(e._l=n=n?n.n:e._t._f)?"keys"==t?c(0,n.k):"values"==t?c(0,n.v):c(0,[n.k,n.v]):(e._t=void 0,c(1))},n?"entries":"values",!n,!0),f(t)}}},{"./_an-instance":8,"./_ctx":27,"./_descriptors":31,"./_for-of":41,"./_iter-define":58,"./_iter-step":60,"./_meta":68,"./_object-create":73,"./_object-dp":74,"./_redefine-all":93,"./_set-species":102,"./_validate-collection":128}],22:[function(e,t,n){var r=e("./_classof"),o=e("./_array-from-iterable");t.exports=function(e){return function(){if(r(this)!=e)throw TypeError(e+"#toJSON isn't generic");return o(this)}}},{"./_array-from-iterable":12,"./_classof":19}],23:[function(e,t,n){"use strict";var r=e("./_redefine-all"),o=e("./_meta").getWeak,a=e("./_an-object"),i=e("./_is-object"),s=e("./_an-instance"),l=e("./_for-of"),u=e("./_array-methods"),c=e("./_has"),f=e("./_validate-collection"),p=u(5),d=u(6),v=0,y=function(e){
+         return e._l||(e._l=new _)},_=function(){this.a=[]},h=function(e,t){return p(e.a,function(e){return e[0]===t})};_.prototype={get:function(e){var t=h(this,e);if(t)return t[1]},has:function(e){return!!h(this,e)},set:function(e,t){var n=h(this,e);n?n[1]=t:this.a.push([e,t])},delete:function(e){var t=d(this.a,function(t){return t[0]===e});return~t&&this.a.splice(t,1),!!~t}},t.exports={getConstructor:function(e,t,n,a){var u=e(function(e,r){s(e,u,t,"_i"),e._t=t,e._i=v++,e._l=void 0,void 0!=r&&l(r,n,e[a],e)});return r(u.prototype,{delete:function(e){if(!i(e))return!1;var n=o(e);return!0===n?y(f(this,t)).delete(e):n&&c(n,this._i)&&delete n[this._i]},has:function(e){if(!i(e))return!1;var n=o(e);return!0===n?y(f(this,t)).has(e):n&&c(n,this._i)}}),u},def:function(e,t,n){var r=o(a(t),!0);return!0===r?y(e).set(t,n):r[e._i]=n,e},ufstore:y}},{"./_an-instance":8,"./_an-object":9,"./_array-methods":14,"./_for-of":41,"./_has":44,"./_is-object":54,"./_meta":68,"./_redefine-all":93,"./_validate-collection":128}],24:[function(e,t,n){"use strict";var r=e("./_global"),o=e("./_export"),a=e("./_redefine"),i=e("./_redefine-all"),s=e("./_meta"),l=e("./_for-of"),u=e("./_an-instance"),c=e("./_is-object"),f=e("./_fails"),p=e("./_iter-detect"),d=e("./_set-to-string-tag"),v=e("./_inherit-if-required");t.exports=function(e,t,n,y,_,h){var m=r[e],g=m,b=_?"set":"add",x=g&&g.prototype,w={},j=function(e){var t=x[e];a(x,e,"delete"==e?function(e){return!(h&&!c(e))&&t.call(this,0===e?0:e)}:"has"==e?function(e){return!(h&&!c(e))&&t.call(this,0===e?0:e)}:"get"==e?function(e){return h&&!c(e)?void 0:t.call(this,0===e?0:e)}:"add"==e?function(e){return t.call(this,0===e?0:e),this}:function(e,n){return t.call(this,0===e?0:e,n),this})};if("function"==typeof g&&(h||x.forEach&&!f(function(){(new g).entries().next()}))){var A=new g,S=A[b](h?{}:-0,1)!=A,k=f(function(){A.has(1)}),E=p(function(e){new g(e)}),I=!h&&f(function(){for(var e=new g,t=5;t--;)e[b](t,t);return!e.has(-0)});E||(g=t(function(t,n){u(t,g,e);var r=v(new m,t,g);return void 0!=n&&l(n,_,r[b],r),r}),g.prototype=x,x.constructor=g),(k||I)&&(j("delete"),j("has"),_&&j("get")),(I||S)&&j(b),h&&x.clear&&delete x.clear}else g=y.getConstructor(t,e,_,b),i(g.prototype,n),s.NEED=!0;return d(g,e),w[e]=g,o(o.G+o.W+o.F*(g!=m),w),h||y.setStrong(g,e,_),g}},{"./_an-instance":8,"./_export":35,"./_fails":37,"./_for-of":41,"./_global":43,"./_inherit-if-required":48,"./_is-object":54,"./_iter-detect":59,"./_meta":68,"./_redefine":94,"./_redefine-all":93,"./_set-to-string-tag":103}],25:[function(e,t,n){var r=t.exports={version:"2.6.5"};"number"==typeof __e&&(__e=r)},{}],26:[function(e,t,n){"use strict";var r=e("./_object-dp"),o=e("./_property-desc");t.exports=function(e,t,n){t in e?r.f(e,t,o(0,n)):e[t]=n}},{"./_object-dp":74,"./_property-desc":92}],27:[function(e,t,n){var r=e("./_a-function");t.exports=function(e,t,n){if(r(e),void 0===t)return e;switch(n){case 1:return function(n){return e.call(t,n)};case 2:return function(n,r){return e.call(t,n,r)};case 3:return function(n,r,o){return e.call(t,n,r,o)}}return function(){return e.apply(t,arguments)}}},{"./_a-function":4}],28:[function(e,t,n){"use strict";var r=e("./_fails"),o=Date.prototype.getTime,a=Date.prototype.toISOString,i=function(e){return e>9?e:"0"+e};t.exports=r(function(){return"0385-07-25T07:06:39.999Z"!=a.call(new Date(-5e13-1))})||!r(function(){a.call(new Date(NaN))})?function(){if(!isFinite(o.call(this)))throw RangeError("Invalid time value");var e=this,t=e.getUTCFullYear(),n=e.getUTCMilliseconds(),r=t<0?"-":t>9999?"+":"";return r+("00000"+Math.abs(t)).slice(r?-6:-4)+"-"+i(e.getUTCMonth()+1)+"-"+i(e.getUTCDate())+"T"+i(e.getUTCHours())+":"+i(e.getUTCMinutes())+":"+i(e.getUTCSeconds())+"."+(n>99?n:"0"+i(n))+"Z"}:a},{"./_fails":37}],29:[function(e,t,n){"use strict";var r=e("./_an-object"),o=e("./_to-primitive");t.exports=function(e){if("string"!==e&&"number"!==e&&"default"!==e)throw TypeError("Incorrect hint");return o(r(this),"number"!=e)}},{"./_an-object":9,"./_to-primitive":122}],30:[function(e,t,n){t.exports=function(e){if(void 0==e)throw TypeError("Can't call method on  "+e);return e}},{}],31:[function(e,t,n){t.exports=!e("./_fails")(function(){return 7!=Object.defineProperty({},"a",{get:function(){return 7}}).a})},{"./_fails":37}],32:[function(e,t,n){var r=e("./_is-object"),o=e("./_global").document,a=r(o)&&r(o.createElement);t.exports=function(e){return a?o.createElement(e):{}}},{"./_global":43,"./_is-object":54}],33:[function(e,t,n){t.exports="constructor,hasOwnProperty,isPrototypeOf,propertyIsEnumerable,toLocaleString,toString,valueOf".split(",")},{}],34:[function(e,t,n){var r=e("./_object-keys"),o=e("./_object-gops"),a=e("./_object-pie");t.exports=function(e){var t=r(e),n=o.f;if(n)for(var i,s=n(e),l=a.f,u=0;s.length>u;)l.call(e,i=s[u++])&&t.push(i);return t}},{"./_object-gops":80,"./_object-keys":83,"./_object-pie":84}],35:[function(e,t,n){var r=e("./_global"),o=e("./_core"),a=e("./_hide"),i=e("./_redefine"),s=e("./_ctx"),l=function(e,t,n){var u,c,f,p,d=e&l.F,v=e&l.G,y=e&l.S,_=e&l.P,h=e&l.B,m=v?r:y?r[t]||(r[t]={}):(r[t]||{}).prototype,g=v?o:o[t]||(o[t]={}),b=g.prototype||(g.prototype={});v&&(n=t);for(u in n)c=!d&&m&&void 0!==m[u],f=(c?m:n)[u],p=h&&c?s(f,r):_&&"function"==typeof f?s(Function.call,f):f,m&&i(m,u,f,e&l.U),g[u]!=f&&a(g,u,p),_&&b[u]!=f&&(b[u]=f)};r.core=o,l.F=1,l.G=2,l.S=4,l.P=8,l.B=16,l.W=32,l.U=64,l.R=128,t.exports=l},{"./_core":25,"./_ctx":27,"./_global":43,"./_hide":45,"./_redefine":94}],36:[function(e,t,n){var r=e("./_wks")("match");t.exports=function(e){var t=/./;try{"/./"[e](t)}catch(n){try{return t[r]=!1,!"/./"[e](t)}catch(e){}}return!0}},{"./_wks":131}],37:[function(e,t,n){t.exports=function(e){try{return!!e()}catch(e){return!0}}},{}],38:[function(e,t,n){"use strict";e("./es6.regexp.exec");var r=e("./_redefine"),o=e("./_hide"),a=e("./_fails"),i=e("./_defined"),s=e("./_wks"),l=e("./_regexp-exec"),u=s("species"),c=!a(function(){var e=/./;return e.exec=function(){var e=[];return e.groups={a:"7"},e},"7"!=="".replace(e,"$<a>")}),f=function(){var e=/(?:)/,t=e.exec;e.exec=function(){return t.apply(this,arguments)};var n="ab".split(e);return 2===n.length&&"a"===n[0]&&"b"===n[1]}();t.exports=function(e,t,n){var p=s(e),d=!a(function(){var t={};return t[p]=function(){return 7},7!=""[e](t)}),v=d?!a(function(){var t=!1,n=/a/;return n.exec=function(){return t=!0,null},"split"===e&&(n.constructor={},n.constructor[u]=function(){return n}),n[p](""),!t}):void 0;if(!d||!v||"replace"===e&&!c||"split"===e&&!f){var y=/./[p],_=n(i,p,""[e],function(e,t,n,r,o){return t.exec===l?d&&!o?{done:!0,value:y.call(t,n,r)}:{done:!0,value:e.call(n,t,r)}:{done:!1}}),h=_[0],m=_[1];r(String.prototype,e,h),o(RegExp.prototype,p,2==t?function(e,t){return m.call(e,this,t)}:function(e){return m.call(e,this)})}}},{"./_defined":30,"./_fails":37,"./_hide":45,"./_redefine":94,"./_regexp-exec":96,"./_wks":131,"./es6.regexp.exec":228}],39:[function(e,t,n){"use strict";var r=e("./_an-object");t.exports=function(){var e=r(this),t="";return e.global&&(t+="g"),e.ignoreCase&&(t+="i"),e.multiline&&(t+="m"),e.unicode&&(t+="u"),e.sticky&&(t+="y"),t}},{"./_an-object":9}],40:[function(e,t,n){"use strict";function r(e,t,n,u,c,f,p,d){for(var v,y,_=c,h=0,m=!!p&&s(p,d,3);h<u;){if(h in n){if(v=m?m(n[h],h,t):n[h],y=!1,a(v)&&(y=v[l],y=void 0!==y?!!y:o(v)),y&&f>0)_=r(e,t,v,i(v.length),_,f-1)-1;else{if(_>=9007199254740991)throw TypeError();e[_]=v}_++}h++}return _}var o=e("./_is-array"),a=e("./_is-object"),i=e("./_to-length"),s=e("./_ctx"),l=e("./_wks")("isConcatSpreadable");t.exports=r},{"./_ctx":27,"./_is-array":52,"./_is-object":54,"./_to-length":120,"./_wks":131}],41:[function(e,t,n){var r=e("./_ctx"),o=e("./_iter-call"),a=e("./_is-array-iter"),i=e("./_an-object"),s=e("./_to-length"),l=e("./core.get-iterator-method"),u={},c={},n=t.exports=function(e,t,n,f,p){var d,v,y,_,h=p?function(){return e}:l(e),m=r(n,f,t?2:1),g=0;if("function"!=typeof h)throw TypeError(e+" is not iterable!");if(a(h)){for(d=s(e.length);d>g;g++)if((_=t?m(i(v=e[g])[0],v[1]):m(e[g]))===u||_===c)return _}else for(y=h.call(e);!(v=y.next()).done;)if((_=o(y,m,v.value,t))===u||_===c)return _};n.BREAK=u,n.RETURN=c},{"./_an-object":9,"./_ctx":27,"./_is-array-iter":51,"./_iter-call":56,"./_to-length":120,"./core.get-iterator-method":132}],42:[function(e,t,n){t.exports=e("./_shared")("native-function-to-string",Function.toString)},{"./_shared":105}],43:[function(e,t,n){var r=t.exports="undefined"!=typeof window&&window.Math==Math?window:"undefined"!=typeof self&&self.Math==Math?self:Function("return this")();"number"==typeof __g&&(__g=r)},{}],44:[function(e,t,n){var r={}.hasOwnProperty;t.exports=function(e,t){return r.call(e,t)}},{}],45:[function(e,t,n){var r=e("./_object-dp"),o=e("./_property-desc");t.exports=e("./_descriptors")?function(e,t,n){return r.f(e,t,o(1,n))}:function(e,t,n){return e[t]=n,e}},{"./_descriptors":31,"./_object-dp":74,"./_property-desc":92}],46:[function(e,t,n){var r=e("./_global").document;t.exports=r&&r.documentElement},{"./_global":43}],47:[function(e,t,n){t.exports=!e("./_descriptors")&&!e("./_fails")(function(){return 7!=Object.defineProperty(e("./_dom-create")("div"),"a",{get:function(){return 7}}).a})},{"./_descriptors":31,"./_dom-create":32,"./_fails":37}],48:[function(e,t,n){var r=e("./_is-object"),o=e("./_set-proto").set;t.exports=function(e,t,n){var a,i=t.constructor;return i!==n&&"function"==typeof i&&(a=i.prototype)!==n.prototype&&r(a)&&o&&o(e,a),e}},{"./_is-object":54,"./_set-proto":101}],49:[function(e,t,n){t.exports=function(e,t,n){var r=void 0===n;switch(t.length){case 0:return r?e():e.call(n);case 1:return r?e(t[0]):e.call(n,t[0]);case 2:return r?e(t[0],t[1]):e.call(n,t[0],t[1]);case 3:return r?e(t[0],t[1],t[2]):e.call(n,t[0],t[1],t[2]);case 4:return r?e(t[0],t[1],t[2],t[3]):e.call(n,t[0],t[1],t[2],t[3])}return e.apply(n,t)}},{}],50:[function(e,t,n){var r=e("./_cof");t.exports=Object("z").propertyIsEnumerable(0)?Object:function(e){return"String"==r(e)?e.split(""):Object(e)}},{"./_cof":20}],51:[function(e,t,n){var r=e("./_iterators"),o=e("./_wks")("iterator"),a=Array.prototype;t.exports=function(e){return void 0!==e&&(r.Array===e||a[o]===e)}},{"./_iterators":61,"./_wks":131}],52:[function(e,t,n){var r=e("./_cof");t.exports=Array.isArray||function(e){return"Array"==r(e)}},{"./_cof":20}],53:[function(e,t,n){var r=e("./_is-object"),o=Math.floor;t.exports=function(e){return!r(e)&&isFinite(e)&&o(e)===e}},{"./_is-object":54}],54:[function(e,t,n){t.exports=function(e){return"object"==typeof e?null!==e:"function"==typeof e}},{}],55:[function(e,t,n){var r=e("./_is-object"),o=e("./_cof"),a=e("./_wks")("match");t.exports=function(e){var t;return r(e)&&(void 0!==(t=e[a])?!!t:"RegExp"==o(e))}},{"./_cof":20,"./_is-object":54,"./_wks":131}],56:[function(e,t,n){var r=e("./_an-object");t.exports=function(e,t,n,o){try{return o?t(r(n)[0],n[1]):t(n)}catch(t){var a=e.return;throw void 0!==a&&r(a.call(e)),t}}},{"./_an-object":9}],57:[function(e,t,n){"use strict";var r=e("./_object-create"),o=e("./_property-desc"),a=e("./_set-to-string-tag"),i={};e("./_hide")(i,e("./_wks")("iterator"),function(){return this}),t.exports=function(e,t,n){e.prototype=r(i,{next:o(1,n)}),a(e,t+" Iterator")}},{"./_hide":45,"./_object-create":73,"./_property-desc":92,"./_set-to-string-tag":103,"./_wks":131}],58:[function(e,t,n){"use strict";var r=e("./_library"),o=e("./_export"),a=e("./_redefine"),i=e("./_hide"),s=e("./_iterators"),l=e("./_iter-create"),u=e("./_set-to-string-tag"),c=e("./_object-gpo"),f=e("./_wks")("iterator"),p=!([].keys&&"next"in[].keys()),d=function(){return this};t.exports=function(e,t,n,v,y,_,h){l(n,t,v);var m,g,b,x=function(e){if(!p&&e in S)return S[e];switch(e){case"keys":case"values":return function(){return new n(this,e)}}return function(){return new n(this,e)}},w=t+" Iterator",j="values"==y,A=!1,S=e.prototype,k=S[f]||S["@@iterator"]||y&&S[y],E=k||x(y),I=y?j?x("entries"):E:void 0,C="Array"==t?S.entries||k:k;if(C&&(b=c(C.call(new e)))!==Object.prototype&&b.next&&(u(b,w,!0),r||"function"==typeof b[f]||i(b,f,d)),j&&k&&"values"!==k.name&&(A=!0,E=function(){return k.call(this)}),r&&!h||!p&&!A&&S[f]||i(S,f,E),s[t]=E,s[w]=d,y)if(m={values:j?E:x("values"),keys:_?E:x("keys"),entries:I},h)for(g in m)g in S||a(S,g,m[g]);else o(o.P+o.F*(p||A),t,m);return m}},{"./_export":35,"./_hide":45,"./_iter-create":57,"./_iterators":61,"./_library":62,"./_object-gpo":81,"./_redefine":94,"./_set-to-string-tag":103,"./_wks":131}],59:[function(e,t,n){var r=e("./_wks")("iterator"),o=!1;try{var a=[7][r]();a.return=function(){o=!0},Array.from(a,function(){throw 2})}catch(e){}t.exports=function(e,t){if(!t&&!o)return!1;var n=!1;try{var a=[7],i=a[r]();i.next=function(){return{done:n=!0}},a[r]=function(){return i},e(a)}catch(e){}return n}},{"./_wks":131}],60:[function(e,t,n){t.exports=function(e,t){return{value:t,done:!!e}}},{}],61:[function(e,t,n){t.exports={}},{}],62:[function(e,t,n){t.exports=!1},{}],63:[function(e,t,n){var r=Math.expm1;t.exports=!r||r(10)>22025.465794806718||r(10)<22025.465794806718||-2e-17!=r(-2e-17)?function(e){return 0==(e=+e)?e:e>-1e-6&&e<1e-6?e+e*e/2:Math.exp(e)-1}:r},{}],64:[function(e,t,n){var r=e("./_math-sign"),o=Math.pow,a=o(2,-52),i=o(2,-23),s=o(2,127)*(2-i),l=o(2,-126),u=function(e){return e+1/a-1/a};t.exports=Math.fround||function(e){var t,n,o=Math.abs(e),c=r(e);return o<l?c*u(o/l/i)*l*i:(t=(1+i/a)*o,n=t-(t-o),n>s||n!=n?c*(1/0):c*n)}},{"./_math-sign":67}],65:[function(e,t,n){t.exports=Math.log1p||function(e){return(e=+e)>-1e-8&&e<1e-8?e-e*e/2:Math.log(1+e)}},{}],66:[function(e,t,n){t.exports=Math.scale||function(e,t,n,r,o){return 0===arguments.length||e!=e||t!=t||n!=n||r!=r||o!=o?NaN:e===1/0||e===-1/0?e:(e-t)*(o-r)/(n-t)+r}},{}],67:[function(e,t,n){t.exports=Math.sign||function(e){return 0==(e=+e)||e!=e?e:e<0?-1:1}},{}],68:[function(e,t,n){var r=e("./_uid")("meta"),o=e("./_is-object"),a=e("./_has"),i=e("./_object-dp").f,s=0,l=Object.isExtensible||function(){return!0},u=!e("./_fails")(function(){return l(Object.preventExtensions({}))}),c=function(e){i(e,r,{value:{i:"O"+ ++s,w:{}}})},f=function(e,t){if(!o(e))return"symbol"==typeof e?e:("string"==typeof e?"S":"P")+e;if(!a(e,r)){if(!l(e))return"F";if(!t)return"E";c(e)}return e[r].i},p=function(e,t){if(!a(e,r)){if(!l(e))return!0;if(!t)return!1;c(e)}return e[r].w},d=function(e){return u&&v.NEED&&l(e)&&!a(e,r)&&c(e),e},v=t.exports={KEY:r,NEED:!1,fastKey:f,getWeak:p,onFreeze:d}},{"./_fails":37,"./_has":44,"./_is-object":54,"./_object-dp":74,"./_uid":126}],69:[function(e,t,n){var r=e("./es6.map"),o=e("./_export"),a=e("./_shared")("metadata"),i=a.store||(a.store=new(e("./es6.weak-map"))),s=function(e,t,n){var o=i.get(e);if(!o){if(!n)return;i.set(e,o=new r)}var a=o.get(t);if(!a){if(!n)return;o.set(t,a=new r)}return a},l=function(e,t,n){var r=s(t,n,!1);return void 0!==r&&r.has(e)},u=function(e,t,n){var r=s(t,n,!1);return void 0===r?void 0:r.get(e)},c=function(e,t,n,r){s(n,r,!0).set(e,t)},f=function(e,t){var n=s(e,t,!1),r=[];return n&&n.forEach(function(e,t){r.push(t)}),r
+         },p=function(e){return void 0===e||"symbol"==typeof e?e:String(e)},d=function(e){o(o.S,"Reflect",e)};t.exports={store:i,map:s,has:l,get:u,set:c,keys:f,key:p,exp:d}},{"./_export":35,"./_shared":105,"./es6.map":163,"./es6.weak-map":270}],70:[function(e,t,n){var r=e("./_global"),o=e("./_task").set,a=r.MutationObserver||r.WebKitMutationObserver,i=r.process,s=r.Promise,l="process"==e("./_cof")(i);t.exports=function(){var e,t,n,u=function(){var r,o;for(l&&(r=i.domain)&&r.exit();e;){o=e.fn,e=e.next;try{o()}catch(r){throw e?n():t=void 0,r}}t=void 0,r&&r.enter()};if(l)n=function(){i.nextTick(u)};else if(!a||r.navigator&&r.navigator.standalone)if(s&&s.resolve){var c=s.resolve(void 0);n=function(){c.then(u)}}else n=function(){o.call(r,u)};else{var f=!0,p=document.createTextNode("");new a(u).observe(p,{characterData:!0}),n=function(){p.data=f=!f}}return function(r){var o={fn:r,next:void 0};t&&(t.next=o),e||(e=o,n()),t=o}}},{"./_cof":20,"./_global":43,"./_task":115}],71:[function(e,t,n){"use strict";function r(e){var t,n;this.promise=new e(function(e,r){if(void 0!==t||void 0!==n)throw TypeError("Bad Promise constructor");t=e,n=r}),this.resolve=o(t),this.reject=o(n)}var o=e("./_a-function");t.exports.f=function(e){return new r(e)}},{"./_a-function":4}],72:[function(e,t,n){"use strict";var r=e("./_object-keys"),o=e("./_object-gops"),a=e("./_object-pie"),i=e("./_to-object"),s=e("./_iobject"),l=Object.assign;t.exports=!l||e("./_fails")(function(){var e={},t={},n=Symbol(),r="abcdefghijklmnopqrst";return e[n]=7,r.split("").forEach(function(e){t[e]=e}),7!=l({},e)[n]||Object.keys(l({},t)).join("")!=r})?function(e,t){for(var n=i(e),l=arguments.length,u=1,c=o.f,f=a.f;l>u;)for(var p,d=s(arguments[u++]),v=c?r(d).concat(c(d)):r(d),y=v.length,_=0;y>_;)f.call(d,p=v[_++])&&(n[p]=d[p]);return n}:l},{"./_fails":37,"./_iobject":50,"./_object-gops":80,"./_object-keys":83,"./_object-pie":84,"./_to-object":121}],73:[function(e,t,n){var r=e("./_an-object"),o=e("./_object-dps"),a=e("./_enum-bug-keys"),i=e("./_shared-key")("IE_PROTO"),s=function(){},l=function(){var t,n=e("./_dom-create")("iframe"),r=a.length;for(n.style.display="none",e("./_html").appendChild(n),n.src="javascript:",t=n.contentWindow.document,t.open(),t.write("<script>document.F=Object<\/script>"),t.close(),l=t.F;r--;)delete l.prototype[a[r]];return l()};t.exports=Object.create||function(e,t){var n;return null!==e?(s.prototype=r(e),n=new s,s.prototype=null,n[i]=e):n=l(),void 0===t?n:o(n,t)}},{"./_an-object":9,"./_dom-create":32,"./_enum-bug-keys":33,"./_html":46,"./_object-dps":75,"./_shared-key":104}],74:[function(e,t,n){var r=e("./_an-object"),o=e("./_ie8-dom-define"),a=e("./_to-primitive"),i=Object.defineProperty;n.f=e("./_descriptors")?Object.defineProperty:function(e,t,n){if(r(e),t=a(t,!0),r(n),o)try{return i(e,t,n)}catch(e){}if("get"in n||"set"in n)throw TypeError("Accessors not supported!");return"value"in n&&(e[t]=n.value),e}},{"./_an-object":9,"./_descriptors":31,"./_ie8-dom-define":47,"./_to-primitive":122}],75:[function(e,t,n){var r=e("./_object-dp"),o=e("./_an-object"),a=e("./_object-keys");t.exports=e("./_descriptors")?Object.defineProperties:function(e,t){o(e);for(var n,i=a(t),s=i.length,l=0;s>l;)r.f(e,n=i[l++],t[n]);return e}},{"./_an-object":9,"./_descriptors":31,"./_object-dp":74,"./_object-keys":83}],76:[function(e,t,n){"use strict";t.exports=e("./_library")||!e("./_fails")(function(){var t=Math.random();__defineSetter__.call(null,t,function(){}),delete e("./_global")[t]})},{"./_fails":37,"./_global":43,"./_library":62}],77:[function(e,t,n){var r=e("./_object-pie"),o=e("./_property-desc"),a=e("./_to-iobject"),i=e("./_to-primitive"),s=e("./_has"),l=e("./_ie8-dom-define"),u=Object.getOwnPropertyDescriptor;n.f=e("./_descriptors")?u:function(e,t){if(e=a(e),t=i(t,!0),l)try{return u(e,t)}catch(e){}if(s(e,t))return o(!r.f.call(e,t),e[t])}},{"./_descriptors":31,"./_has":44,"./_ie8-dom-define":47,"./_object-pie":84,"./_property-desc":92,"./_to-iobject":119,"./_to-primitive":122}],78:[function(e,t,n){var r=e("./_to-iobject"),o=e("./_object-gopn").f,a={}.toString,i="object"==typeof window&&window&&Object.getOwnPropertyNames?Object.getOwnPropertyNames(window):[],s=function(e){try{return o(e)}catch(e){return i.slice()}};t.exports.f=function(e){return i&&"[object Window]"==a.call(e)?s(e):o(r(e))}},{"./_object-gopn":79,"./_to-iobject":119}],79:[function(e,t,n){var r=e("./_object-keys-internal"),o=e("./_enum-bug-keys").concat("length","prototype");n.f=Object.getOwnPropertyNames||function(e){return r(e,o)}},{"./_enum-bug-keys":33,"./_object-keys-internal":82}],80:[function(e,t,n){n.f=Object.getOwnPropertySymbols},{}],81:[function(e,t,n){var r=e("./_has"),o=e("./_to-object"),a=e("./_shared-key")("IE_PROTO"),i=Object.prototype;t.exports=Object.getPrototypeOf||function(e){return e=o(e),r(e,a)?e[a]:"function"==typeof e.constructor&&e instanceof e.constructor?e.constructor.prototype:e instanceof Object?i:null}},{"./_has":44,"./_shared-key":104,"./_to-object":121}],82:[function(e,t,n){var r=e("./_has"),o=e("./_to-iobject"),a=e("./_array-includes")(!1),i=e("./_shared-key")("IE_PROTO");t.exports=function(e,t){var n,s=o(e),l=0,u=[];for(n in s)n!=i&&r(s,n)&&u.push(n);for(;t.length>l;)r(s,n=t[l++])&&(~a(u,n)||u.push(n));return u}},{"./_array-includes":13,"./_has":44,"./_shared-key":104,"./_to-iobject":119}],83:[function(e,t,n){var r=e("./_object-keys-internal"),o=e("./_enum-bug-keys");t.exports=Object.keys||function(e){return r(e,o)}},{"./_enum-bug-keys":33,"./_object-keys-internal":82}],84:[function(e,t,n){n.f={}.propertyIsEnumerable},{}],85:[function(e,t,n){var r=e("./_export"),o=e("./_core"),a=e("./_fails");t.exports=function(e,t){var n=(o.Object||{})[e]||Object[e],i={};i[e]=t(n),r(r.S+r.F*a(function(){n(1)}),"Object",i)}},{"./_core":25,"./_export":35,"./_fails":37}],86:[function(e,t,n){var r=e("./_object-keys"),o=e("./_to-iobject"),a=e("./_object-pie").f;t.exports=function(e){return function(t){for(var n,i=o(t),s=r(i),l=s.length,u=0,c=[];l>u;)a.call(i,n=s[u++])&&c.push(e?[n,i[n]]:i[n]);return c}}},{"./_object-keys":83,"./_object-pie":84,"./_to-iobject":119}],87:[function(e,t,n){var r=e("./_object-gopn"),o=e("./_object-gops"),a=e("./_an-object"),i=e("./_global").Reflect;t.exports=i&&i.ownKeys||function(e){var t=r.f(a(e)),n=o.f;return n?t.concat(n(e)):t}},{"./_an-object":9,"./_global":43,"./_object-gopn":79,"./_object-gops":80}],88:[function(e,t,n){var r=e("./_global").parseFloat,o=e("./_string-trim").trim;t.exports=1/r(e("./_string-ws")+"-0")!=-1/0?function(e){var t=o(String(e),3),n=r(t);return 0===n&&"-"==t.charAt(0)?-0:n}:r},{"./_global":43,"./_string-trim":113,"./_string-ws":114}],89:[function(e,t,n){var r=e("./_global").parseInt,o=e("./_string-trim").trim,a=e("./_string-ws"),i=/^[-+]?0[xX]/;t.exports=8!==r(a+"08")||22!==r(a+"0x16")?function(e,t){var n=o(String(e),3);return r(n,t>>>0||(i.test(n)?16:10))}:r},{"./_global":43,"./_string-trim":113,"./_string-ws":114}],90:[function(e,t,n){t.exports=function(e){try{return{e:!1,v:e()}}catch(e){return{e:!0,v:e}}}},{}],91:[function(e,t,n){var r=e("./_an-object"),o=e("./_is-object"),a=e("./_new-promise-capability");t.exports=function(e,t){if(r(e),o(t)&&t.constructor===e)return t;var n=a.f(e);return(0,n.resolve)(t),n.promise}},{"./_an-object":9,"./_is-object":54,"./_new-promise-capability":71}],92:[function(e,t,n){t.exports=function(e,t){return{enumerable:!(1&e),configurable:!(2&e),writable:!(4&e),value:t}}},{}],93:[function(e,t,n){var r=e("./_redefine");t.exports=function(e,t,n){for(var o in t)r(e,o,t[o],n);return e}},{"./_redefine":94}],94:[function(e,t,n){var r=e("./_global"),o=e("./_hide"),a=e("./_has"),i=e("./_uid")("src"),s=e("./_function-to-string"),l=(""+s).split("toString");e("./_core").inspectSource=function(e){return s.call(e)},(t.exports=function(e,t,n,s){var u="function"==typeof n;u&&(a(n,"name")||o(n,"name",t)),e[t]!==n&&(u&&(a(n,i)||o(n,i,e[t]?""+e[t]:l.join(String(t)))),e===r?e[t]=n:s?e[t]?e[t]=n:o(e,t,n):(delete e[t],o(e,t,n)))})(Function.prototype,"toString",function(){return"function"==typeof this&&this[i]||s.call(this)})},{"./_core":25,"./_function-to-string":42,"./_global":43,"./_has":44,"./_hide":45,"./_uid":126}],95:[function(e,t,n){"use strict";var r=e("./_classof"),o=RegExp.prototype.exec;t.exports=function(e,t){var n=e.exec;if("function"==typeof n){var a=n.call(e,t);if("object"!=typeof a)throw new TypeError("RegExp exec method returned something other than an Object or null");return a}if("RegExp"!==r(e))throw new TypeError("RegExp#exec called on incompatible receiver");return o.call(e,t)}},{"./_classof":19}],96:[function(e,t,n){"use strict";var r=e("./_flags"),o=RegExp.prototype.exec,a=String.prototype.replace,i=o,s=function(){var e=/a/,t=/b*/g;return o.call(e,"a"),o.call(t,"a"),0!==e.lastIndex||0!==t.lastIndex}(),l=void 0!==/()??/.exec("")[1];(s||l)&&(i=function(e){var t,n,i,u,c=this;return l&&(n=new RegExp("^"+c.source+"$(?!\\s)",r.call(c))),s&&(t=c.lastIndex),i=o.call(c,e),s&&i&&(c.lastIndex=c.global?i.index+i[0].length:t),l&&i&&i.length>1&&a.call(i[0],n,function(){for(u=1;u<arguments.length-2;u++)void 0===arguments[u]&&(i[u]=void 0)}),i}),t.exports=i},{"./_flags":39}],97:[function(e,t,n){t.exports=function(e,t){var n=t===Object(t)?function(e){return t[e]}:t;return function(t){return String(t).replace(e,n)}}},{}],98:[function(e,t,n){t.exports=Object.is||function(e,t){return e===t?0!==e||1/e==1/t:e!=e&&t!=t}},{}],99:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_a-function"),a=e("./_ctx"),i=e("./_for-of");t.exports=function(e){r(r.S,e,{from:function(e){var t,n,r,s,l=arguments[1];return o(this),t=void 0!==l,t&&o(l),void 0==e?new this:(n=[],t?(r=0,s=a(l,arguments[2],2),i(e,!1,function(e){n.push(s(e,r++))})):i(e,!1,n.push,n),new this(n))}})}},{"./_a-function":4,"./_ctx":27,"./_export":35,"./_for-of":41}],100:[function(e,t,n){"use strict";var r=e("./_export");t.exports=function(e){r(r.S,e,{of:function(){for(var e=arguments.length,t=new Array(e);e--;)t[e]=arguments[e];return new this(t)}})}},{"./_export":35}],101:[function(e,t,n){var r=e("./_is-object"),o=e("./_an-object"),a=function(e,t){if(o(e),!r(t)&&null!==t)throw TypeError(t+": can't set as prototype!")};t.exports={set:Object.setPrototypeOf||("__proto__"in{}?function(t,n,r){try{r=e("./_ctx")(Function.call,e("./_object-gopd").f(Object.prototype,"__proto__").set,2),r(t,[]),n=!(t instanceof Array)}catch(e){n=!0}return function(e,t){return a(e,t),n?e.__proto__=t:r(e,t),e}}({},!1):void 0),check:a}},{"./_an-object":9,"./_ctx":27,"./_is-object":54,"./_object-gopd":77}],102:[function(e,t,n){"use strict";var r=e("./_global"),o=e("./_object-dp"),a=e("./_descriptors"),i=e("./_wks")("species");t.exports=function(e){var t=r[e];a&&t&&!t[i]&&o.f(t,i,{configurable:!0,get:function(){return this}})}},{"./_descriptors":31,"./_global":43,"./_object-dp":74,"./_wks":131}],103:[function(e,t,n){var r=e("./_object-dp").f,o=e("./_has"),a=e("./_wks")("toStringTag");t.exports=function(e,t,n){e&&!o(e=n?e:e.prototype,a)&&r(e,a,{configurable:!0,value:t})}},{"./_has":44,"./_object-dp":74,"./_wks":131}],104:[function(e,t,n){var r=e("./_shared")("keys"),o=e("./_uid");t.exports=function(e){return r[e]||(r[e]=o(e))}},{"./_shared":105,"./_uid":126}],105:[function(e,t,n){var r=e("./_core"),o=e("./_global"),a=o["__core-js_shared__"]||(o["__core-js_shared__"]={});(t.exports=function(e,t){return a[e]||(a[e]=void 0!==t?t:{})})("versions",[]).push({version:r.version,mode:e("./_library")?"pure":"global",copyright:"\xa9 2019 Denis Pushkarev (zloirock.ru)"})},{"./_core":25,"./_global":43,"./_library":62}],106:[function(e,t,n){var r=e("./_an-object"),o=e("./_a-function"),a=e("./_wks")("species");t.exports=function(e,t){var n,i=r(e).constructor;return void 0===i||void 0==(n=r(i)[a])?t:o(n)}},{"./_a-function":4,"./_an-object":9,"./_wks":131}],107:[function(e,t,n){"use strict";var r=e("./_fails");t.exports=function(e,t){return!!e&&r(function(){t?e.call(null,function(){},1):e.call(null)})}},{"./_fails":37}],108:[function(e,t,n){var r=e("./_to-integer"),o=e("./_defined");t.exports=function(e){return function(t,n){var a,i,s=String(o(t)),l=r(n),u=s.length;return l<0||l>=u?e?"":void 0:(a=s.charCodeAt(l),a<55296||a>56319||l+1===u||(i=s.charCodeAt(l+1))<56320||i>57343?e?s.charAt(l):a:e?s.slice(l,l+2):i-56320+(a-55296<<10)+65536)}}},{"./_defined":30,"./_to-integer":118}],109:[function(e,t,n){var r=e("./_is-regexp"),o=e("./_defined");t.exports=function(e,t,n){if(r(t))throw TypeError("String#"+n+" doesn't accept regex!");return String(o(e))}},{"./_defined":30,"./_is-regexp":55}],110:[function(e,t,n){var r=e("./_export"),o=e("./_fails"),a=e("./_defined"),i=/"/g,s=function(e,t,n,r){var o=String(a(e)),s="<"+t;return""!==n&&(s+=" "+n+'="'+String(r).replace(i,"&quot;")+'"'),s+">"+o+"</"+t+">"};t.exports=function(e,t){var n={};n[e]=t(s),r(r.P+r.F*o(function(){var t=""[e]('"');return t!==t.toLowerCase()||t.split('"').length>3}),"String",n)}},{"./_defined":30,"./_export":35,"./_fails":37}],111:[function(e,t,n){var r=e("./_to-length"),o=e("./_string-repeat"),a=e("./_defined");t.exports=function(e,t,n,i){var s=String(a(e)),l=s.length,u=void 0===n?" ":String(n),c=r(t);if(c<=l||""==u)return s;var f=c-l,p=o.call(u,Math.ceil(f/u.length));return p.length>f&&(p=p.slice(0,f)),i?p+s:s+p}},{"./_defined":30,"./_string-repeat":112,"./_to-length":120}],112:[function(e,t,n){"use strict";var r=e("./_to-integer"),o=e("./_defined");t.exports=function(e){var t=String(o(this)),n="",a=r(e);if(a<0||a==1/0)throw RangeError("Count can't be negative");for(;a>0;(a>>>=1)&&(t+=t))1&a&&(n+=t);return n}},{"./_defined":30,"./_to-integer":118}],113:[function(e,t,n){var r=e("./_export"),o=e("./_defined"),a=e("./_fails"),i=e("./_string-ws"),s="["+i+"]",l="\u200b\x85",u=RegExp("^"+s+s+"*"),c=RegExp(s+s+"*$"),f=function(e,t,n){var o={},s=a(function(){return!!i[e]()||l[e]()!=l}),u=o[e]=s?t(p):i[e];n&&(o[n]=u),r(r.P+r.F*s,"String",o)},p=f.trim=function(e,t){return e=String(o(e)),1&t&&(e=e.replace(u,"")),2&t&&(e=e.replace(c,"")),e};t.exports=f},{"./_defined":30,"./_export":35,"./_fails":37,"./_string-ws":114}],114:[function(e,t,n){t.exports="\t\n\v\f\r \xa0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000\u2028\u2029\ufeff"},{}],115:[function(e,t,n){var r,o,a,i=e("./_ctx"),s=e("./_invoke"),l=e("./_html"),u=e("./_dom-create"),c=e("./_global"),f=c.process,p=c.setImmediate,d=c.clearImmediate,v=c.MessageChannel,y=c.Dispatch,_=0,h={},m=function(){var e=+this;if(h.hasOwnProperty(e)){var t=h[e];delete h[e],t()}},g=function(e){m.call(e.data)};p&&d||(p=function(e){for(var t=[],n=1;arguments.length>n;)t.push(arguments[n++]);return h[++_]=function(){s("function"==typeof e?e:Function(e),t)},r(_),_},d=function(e){delete h[e]},"process"==e("./_cof")(f)?r=function(e){f.nextTick(i(m,e,1))}:y&&y.now?r=function(e){y.now(i(m,e,1))}:v?(o=new v,a=o.port2,o.port1.onmessage=g,r=i(a.postMessage,a,1)):c.addEventListener&&"function"==typeof postMessage&&!c.importScripts?(r=function(e){c.postMessage(e+"","*")
+         },c.addEventListener("message",g,!1)):r="onreadystatechange"in u("script")?function(e){l.appendChild(u("script")).onreadystatechange=function(){l.removeChild(this),m.call(e)}}:function(e){setTimeout(i(m,e,1),0)}),t.exports={set:p,clear:d}},{"./_cof":20,"./_ctx":27,"./_dom-create":32,"./_global":43,"./_html":46,"./_invoke":49}],116:[function(e,t,n){var r=e("./_to-integer"),o=Math.max,a=Math.min;t.exports=function(e,t){return e=r(e),e<0?o(e+t,0):a(e,t)}},{"./_to-integer":118}],117:[function(e,t,n){var r=e("./_to-integer"),o=e("./_to-length");t.exports=function(e){if(void 0===e)return 0;var t=r(e),n=o(t);if(t!==n)throw RangeError("Wrong length!");return n}},{"./_to-integer":118,"./_to-length":120}],118:[function(e,t,n){var r=Math.ceil,o=Math.floor;t.exports=function(e){return isNaN(e=+e)?0:(e>0?o:r)(e)}},{}],119:[function(e,t,n){var r=e("./_iobject"),o=e("./_defined");t.exports=function(e){return r(o(e))}},{"./_defined":30,"./_iobject":50}],120:[function(e,t,n){var r=e("./_to-integer"),o=Math.min;t.exports=function(e){return e>0?o(r(e),9007199254740991):0}},{"./_to-integer":118}],121:[function(e,t,n){var r=e("./_defined");t.exports=function(e){return Object(r(e))}},{"./_defined":30}],122:[function(e,t,n){var r=e("./_is-object");t.exports=function(e,t){if(!r(e))return e;var n,o;if(t&&"function"==typeof(n=e.toString)&&!r(o=n.call(e)))return o;if("function"==typeof(n=e.valueOf)&&!r(o=n.call(e)))return o;if(!t&&"function"==typeof(n=e.toString)&&!r(o=n.call(e)))return o;throw TypeError("Can't convert object to primitive value")}},{"./_is-object":54}],123:[function(e,t,n){"use strict";if(e("./_descriptors")){var r=e("./_library"),o=e("./_global"),a=e("./_fails"),i=e("./_export"),s=e("./_typed"),l=e("./_typed-buffer"),u=e("./_ctx"),c=e("./_an-instance"),f=e("./_property-desc"),p=e("./_hide"),d=e("./_redefine-all"),v=e("./_to-integer"),y=e("./_to-length"),_=e("./_to-index"),h=e("./_to-absolute-index"),m=e("./_to-primitive"),g=e("./_has"),b=e("./_classof"),x=e("./_is-object"),w=e("./_to-object"),j=e("./_is-array-iter"),A=e("./_object-create"),S=e("./_object-gpo"),k=e("./_object-gopn").f,E=e("./core.get-iterator-method"),I=e("./_uid"),C=e("./_wks"),O=e("./_array-methods"),P=e("./_array-includes"),L=e("./_species-constructor"),M=e("./es6.array.iterator"),T=e("./_iterators"),R=e("./_iter-detect"),N=e("./_set-species"),D=e("./_array-fill"),F=e("./_array-copy-within"),H=e("./_object-dp"),G=e("./_object-gopd"),U=H.f,W=G.f,B=o.RangeError,Y=o.TypeError,z=o.Uint8Array,q=Array.prototype,X=l.ArrayBuffer,V=l.DataView,K=O(0),Q=O(2),J=O(3),Z=O(4),$=O(5),ee=O(6),te=P(!0),ne=P(!1),re=M.values,oe=M.keys,ae=M.entries,ie=q.lastIndexOf,se=q.reduce,le=q.reduceRight,ue=q.join,ce=q.sort,fe=q.slice,pe=q.toString,de=q.toLocaleString,ve=C("iterator"),ye=C("toStringTag"),_e=I("typed_constructor"),he=I("def_constructor"),me=s.CONSTR,ge=s.TYPED,be=s.VIEW,xe=O(1,function(e,t){return ke(L(e,e[he]),t)}),we=a(function(){return 1===new z(new Uint16Array([1]).buffer)[0]}),je=!!z&&!!z.prototype.set&&a(function(){new z(1).set({})}),Ae=function(e,t){var n=v(e);if(n<0||n%t)throw B("Wrong offset!");return n},Se=function(e){if(x(e)&&ge in e)return e;throw Y(e+" is not a typed array!")},ke=function(e,t){if(!(x(e)&&_e in e))throw Y("It is not a typed array constructor!");return new e(t)},Ee=function(e,t){return Ie(L(e,e[he]),t)},Ie=function(e,t){for(var n=0,r=t.length,o=ke(e,r);r>n;)o[n]=t[n++];return o},Ce=function(e,t,n){U(e,t,{get:function(){return this._d[n]}})},Oe=function(e){var t,n,r,o,a,i,s=w(e),l=arguments.length,c=l>1?arguments[1]:void 0,f=void 0!==c,p=E(s);if(void 0!=p&&!j(p)){for(i=p.call(s),r=[],t=0;!(a=i.next()).done;t++)r.push(a.value);s=r}for(f&&l>2&&(c=u(c,arguments[2],2)),t=0,n=y(s.length),o=ke(this,n);n>t;t++)o[t]=f?c(s[t],t):s[t];return o},Pe=function(){for(var e=0,t=arguments.length,n=ke(this,t);t>e;)n[e]=arguments[e++];return n},Le=!!z&&a(function(){de.call(new z(1))}),Me=function(){return de.apply(Le?fe.call(Se(this)):Se(this),arguments)},Te={copyWithin:function(e,t){return F.call(Se(this),e,t,arguments.length>2?arguments[2]:void 0)},every:function(e){return Z(Se(this),e,arguments.length>1?arguments[1]:void 0)},fill:function(e){return D.apply(Se(this),arguments)},filter:function(e){return Ee(this,Q(Se(this),e,arguments.length>1?arguments[1]:void 0))},find:function(e){return $(Se(this),e,arguments.length>1?arguments[1]:void 0)},findIndex:function(e){return ee(Se(this),e,arguments.length>1?arguments[1]:void 0)},forEach:function(e){K(Se(this),e,arguments.length>1?arguments[1]:void 0)},indexOf:function(e){return ne(Se(this),e,arguments.length>1?arguments[1]:void 0)},includes:function(e){return te(Se(this),e,arguments.length>1?arguments[1]:void 0)},join:function(e){return ue.apply(Se(this),arguments)},lastIndexOf:function(e){return ie.apply(Se(this),arguments)},map:function(e){return xe(Se(this),e,arguments.length>1?arguments[1]:void 0)},reduce:function(e){return se.apply(Se(this),arguments)},reduceRight:function(e){return le.apply(Se(this),arguments)},reverse:function(){for(var e,t=this,n=Se(t).length,r=Math.floor(n/2),o=0;o<r;)e=t[o],t[o++]=t[--n],t[n]=e;return t},some:function(e){return J(Se(this),e,arguments.length>1?arguments[1]:void 0)},sort:function(e){return ce.call(Se(this),e)},subarray:function(e,t){var n=Se(this),r=n.length,o=h(e,r);return new(L(n,n[he]))(n.buffer,n.byteOffset+o*n.BYTES_PER_ELEMENT,y((void 0===t?r:h(t,r))-o))}},Re=function(e,t){return Ee(this,fe.call(Se(this),e,t))},Ne=function(e){Se(this);var t=Ae(arguments[1],1),n=this.length,r=w(e),o=y(r.length),a=0;if(o+t>n)throw B("Wrong length!");for(;a<o;)this[t+a]=r[a++]},De={entries:function(){return ae.call(Se(this))},keys:function(){return oe.call(Se(this))},values:function(){return re.call(Se(this))}},Fe=function(e,t){return x(e)&&e[ge]&&"symbol"!=typeof t&&t in e&&String(+t)==String(t)},He=function(e,t){return Fe(e,t=m(t,!0))?f(2,e[t]):W(e,t)},Ge=function(e,t,n){return!(Fe(e,t=m(t,!0))&&x(n)&&g(n,"value"))||g(n,"get")||g(n,"set")||n.configurable||g(n,"writable")&&!n.writable||g(n,"enumerable")&&!n.enumerable?U(e,t,n):(e[t]=n.value,e)};me||(G.f=He,H.f=Ge),i(i.S+i.F*!me,"Object",{getOwnPropertyDescriptor:He,defineProperty:Ge}),a(function(){pe.call({})})&&(pe=de=function(){return ue.call(this)});var Ue=d({},Te);d(Ue,De),p(Ue,ve,De.values),d(Ue,{slice:Re,set:Ne,constructor:function(){},toString:pe,toLocaleString:Me}),Ce(Ue,"buffer","b"),Ce(Ue,"byteOffset","o"),Ce(Ue,"byteLength","l"),Ce(Ue,"length","e"),U(Ue,ye,{get:function(){return this[ge]}}),t.exports=function(e,t,n,l){l=!!l;var u=e+(l?"Clamped":"")+"Array",f="get"+e,d="set"+e,v=o[u],h=v||{},m=v&&S(v),g=!v||!s.ABV,w={},j=v&&v.prototype,E=function(e,n){var r=e._d;return r.v[f](n*t+r.o,we)},I=function(e,n,r){var o=e._d;l&&(r=(r=Math.round(r))<0?0:r>255?255:255&r),o.v[d](n*t+o.o,r,we)},C=function(e,t){U(e,t,{get:function(){return E(this,t)},set:function(e){return I(this,t,e)},enumerable:!0})};g?(v=n(function(e,n,r,o){c(e,v,u,"_d");var a,i,s,l,f=0,d=0;if(x(n)){if(!(n instanceof X||"ArrayBuffer"==(l=b(n))||"SharedArrayBuffer"==l))return ge in n?Ie(v,n):Oe.call(v,n);a=n,d=Ae(r,t);var h=n.byteLength;if(void 0===o){if(h%t)throw B("Wrong length!");if((i=h-d)<0)throw B("Wrong length!")}else if((i=y(o)*t)+d>h)throw B("Wrong length!");s=i/t}else s=_(n),i=s*t,a=new X(i);for(p(e,"_d",{b:a,o:d,l:i,e:s,v:new V(a)});f<s;)C(e,f++)}),j=v.prototype=A(Ue),p(j,"constructor",v)):a(function(){v(1)})&&a(function(){new v(-1)})&&R(function(e){new v,new v(null),new v(1.5),new v(e)},!0)||(v=n(function(e,n,r,o){c(e,v,u);var a;return x(n)?n instanceof X||"ArrayBuffer"==(a=b(n))||"SharedArrayBuffer"==a?void 0!==o?new h(n,Ae(r,t),o):void 0!==r?new h(n,Ae(r,t)):new h(n):ge in n?Ie(v,n):Oe.call(v,n):new h(_(n))}),K(m!==Function.prototype?k(h).concat(k(m)):k(h),function(e){e in v||p(v,e,h[e])}),v.prototype=j,r||(j.constructor=v));var O=j[ve],P=!!O&&("values"==O.name||void 0==O.name),L=De.values;p(v,_e,!0),p(j,ge,u),p(j,be,!0),p(j,he,v),(l?new v(1)[ye]==u:ye in j)||U(j,ye,{get:function(){return u}}),w[u]=v,i(i.G+i.W+i.F*(v!=h),w),i(i.S,u,{BYTES_PER_ELEMENT:t}),i(i.S+i.F*a(function(){h.of.call(v,1)}),u,{from:Oe,of:Pe}),"BYTES_PER_ELEMENT"in j||p(j,"BYTES_PER_ELEMENT",t),i(i.P,u,Te),N(u),i(i.P+i.F*je,u,{set:Ne}),i(i.P+i.F*!P,u,De),r||j.toString==pe||(j.toString=pe),i(i.P+i.F*a(function(){new v(1).slice()}),u,{slice:Re}),i(i.P+i.F*(a(function(){return[1,2].toLocaleString()!=new v([1,2]).toLocaleString()})||!a(function(){j.toLocaleString.call([1,2])})),u,{toLocaleString:Me}),T[u]=P?O:L,r||P||p(j,ve,L)}}else t.exports=function(){}},{"./_an-instance":8,"./_array-copy-within":10,"./_array-fill":11,"./_array-includes":13,"./_array-methods":14,"./_classof":19,"./_ctx":27,"./_descriptors":31,"./_export":35,"./_fails":37,"./_global":43,"./_has":44,"./_hide":45,"./_is-array-iter":51,"./_is-object":54,"./_iter-detect":59,"./_iterators":61,"./_library":62,"./_object-create":73,"./_object-dp":74,"./_object-gopd":77,"./_object-gopn":79,"./_object-gpo":81,"./_property-desc":92,"./_redefine-all":93,"./_set-species":102,"./_species-constructor":106,"./_to-absolute-index":116,"./_to-index":117,"./_to-integer":118,"./_to-length":120,"./_to-object":121,"./_to-primitive":122,"./_typed":125,"./_typed-buffer":124,"./_uid":126,"./_wks":131,"./core.get-iterator-method":132,"./es6.array.iterator":144}],124:[function(e,t,n){"use strict";function r(e,t,n){var r,o,a,i=new Array(n),s=8*n-t-1,l=(1<<s)-1,u=l>>1,c=23===t?F(2,-24)-F(2,-77):0,f=0,p=e<0||0===e&&1/e<0?1:0;for(e=D(e),e!=e||e===R?(o=e!=e?1:0,r=l):(r=H(G(e)/U),e*(a=F(2,-r))<1&&(r--,a*=2),e+=r+u>=1?c/a:c*F(2,1-u),e*a>=2&&(r++,a/=2),r+u>=l?(o=0,r=l):r+u>=1?(o=(e*a-1)*F(2,t),r+=u):(o=e*F(2,u-1)*F(2,t),r=0));t>=8;i[f++]=255&o,o/=256,t-=8);for(r=r<<t|o,s+=t;s>0;i[f++]=255&r,r/=256,s-=8);return i[--f]|=128*p,i}function o(e,t,n){var r,o=8*n-t-1,a=(1<<o)-1,i=a>>1,s=o-7,l=n-1,u=e[l--],c=127&u;for(u>>=7;s>0;c=256*c+e[l],l--,s-=8);for(r=c&(1<<-s)-1,c>>=-s,s+=t;s>0;r=256*r+e[l],l--,s-=8);if(0===c)c=1-i;else{if(c===a)return r?NaN:u?-R:R;r+=F(2,t),c-=i}return(u?-1:1)*r*F(2,c-t)}function a(e){return e[3]<<24|e[2]<<16|e[1]<<8|e[0]}function i(e){return[255&e]}function s(e){return[255&e,e>>8&255]}function l(e){return[255&e,e>>8&255,e>>16&255,e>>24&255]}function u(e){return r(e,52,8)}function c(e){return r(e,23,4)}function f(e,t,n){k(e[C],t,{get:function(){return this[n]}})}function p(e,t,n,r){var o=+n,a=A(o);if(a+t>e[B])throw T(O);var i=e[W]._b,s=a+e[Y],l=i.slice(s,s+t);return r?l:l.reverse()}function d(e,t,n,r,o,a){var i=+n,s=A(i);if(s+t>e[B])throw T(O);for(var l=e[W]._b,u=s+e[Y],c=r(+o),f=0;f<t;f++)l[u+f]=c[a?f:t-f-1]}var v=e("./_global"),y=e("./_descriptors"),_=e("./_library"),h=e("./_typed"),m=e("./_hide"),g=e("./_redefine-all"),b=e("./_fails"),x=e("./_an-instance"),w=e("./_to-integer"),j=e("./_to-length"),A=e("./_to-index"),S=e("./_object-gopn").f,k=e("./_object-dp").f,E=e("./_array-fill"),I=e("./_set-to-string-tag"),C="prototype",O="Wrong index!",P=v.ArrayBuffer,L=v.DataView,M=v.Math,T=v.RangeError,R=v.Infinity,N=P,D=M.abs,F=M.pow,H=M.floor,G=M.log,U=M.LN2,W=y?"_b":"buffer",B=y?"_l":"byteLength",Y=y?"_o":"byteOffset";if(h.ABV){if(!b(function(){P(1)})||!b(function(){new P(-1)})||b(function(){return new P,new P(1.5),new P(NaN),"ArrayBuffer"!=P.name})){P=function(e){return x(this,P),new N(A(e))};for(var z,q=P[C]=N[C],X=S(N),V=0;X.length>V;)(z=X[V++])in P||m(P,z,N[z]);_||(q.constructor=P)}var K=new L(new P(2)),Q=L[C].setInt8;K.setInt8(0,2147483648),K.setInt8(1,2147483649),!K.getInt8(0)&&K.getInt8(1)||g(L[C],{setInt8:function(e,t){Q.call(this,e,t<<24>>24)},setUint8:function(e,t){Q.call(this,e,t<<24>>24)}},!0)}else P=function(e){x(this,P,"ArrayBuffer");var t=A(e);this._b=E.call(new Array(t),0),this[B]=t},L=function(e,t,n){x(this,L,"DataView"),x(e,P,"DataView");var r=e[B],o=w(t);if(o<0||o>r)throw T("Wrong offset!");if(n=void 0===n?r-o:j(n),o+n>r)throw T("Wrong length!");this[W]=e,this[Y]=o,this[B]=n},y&&(f(P,"byteLength","_l"),f(L,"buffer","_b"),f(L,"byteLength","_l"),f(L,"byteOffset","_o")),g(L[C],{getInt8:function(e){return p(this,1,e)[0]<<24>>24},getUint8:function(e){return p(this,1,e)[0]},getInt16:function(e){var t=p(this,2,e,arguments[1]);return(t[1]<<8|t[0])<<16>>16},getUint16:function(e){var t=p(this,2,e,arguments[1]);return t[1]<<8|t[0]},getInt32:function(e){return a(p(this,4,e,arguments[1]))},getUint32:function(e){return a(p(this,4,e,arguments[1]))>>>0},getFloat32:function(e){return o(p(this,4,e,arguments[1]),23,4)},getFloat64:function(e){return o(p(this,8,e,arguments[1]),52,8)},setInt8:function(e,t){d(this,1,e,i,t)},setUint8:function(e,t){d(this,1,e,i,t)},setInt16:function(e,t){d(this,2,e,s,t,arguments[2])},setUint16:function(e,t){d(this,2,e,s,t,arguments[2])},setInt32:function(e,t){d(this,4,e,l,t,arguments[2])},setUint32:function(e,t){d(this,4,e,l,t,arguments[2])},setFloat32:function(e,t){d(this,4,e,c,t,arguments[2])},setFloat64:function(e,t){d(this,8,e,u,t,arguments[2])}});I(P,"ArrayBuffer"),I(L,"DataView"),m(L[C],h.VIEW,!0),n.ArrayBuffer=P,n.DataView=L},{"./_an-instance":8,"./_array-fill":11,"./_descriptors":31,"./_fails":37,"./_global":43,"./_hide":45,"./_library":62,"./_object-dp":74,"./_object-gopn":79,"./_redefine-all":93,"./_set-to-string-tag":103,"./_to-index":117,"./_to-integer":118,"./_to-length":120,"./_typed":125}],125:[function(e,t,n){for(var r,o=e("./_global"),a=e("./_hide"),i=e("./_uid"),s=i("typed_array"),l=i("view"),u=!(!o.ArrayBuffer||!o.DataView),c=u,f=0,p="Int8Array,Uint8Array,Uint8ClampedArray,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array".split(",");f<9;)(r=o[p[f++]])?(a(r.prototype,s,!0),a(r.prototype,l,!0)):c=!1;t.exports={ABV:u,CONSTR:c,TYPED:s,VIEW:l}},{"./_global":43,"./_hide":45,"./_uid":126}],126:[function(e,t,n){var r=0,o=Math.random();t.exports=function(e){return"Symbol(".concat(void 0===e?"":e,")_",(++r+o).toString(36))}},{}],127:[function(e,t,n){var r=e("./_global"),o=r.navigator;t.exports=o&&o.userAgent||""},{"./_global":43}],128:[function(e,t,n){var r=e("./_is-object");t.exports=function(e,t){if(!r(e)||e._t!==t)throw TypeError("Incompatible receiver, "+t+" required!");return e}},{"./_is-object":54}],129:[function(e,t,n){var r=e("./_global"),o=e("./_core"),a=e("./_library"),i=e("./_wks-ext"),s=e("./_object-dp").f;t.exports=function(e){var t=o.Symbol||(o.Symbol=a?{}:r.Symbol||{});"_"==e.charAt(0)||e in t||s(t,e,{value:i.f(e)})}},{"./_core":25,"./_global":43,"./_library":62,"./_object-dp":74,"./_wks-ext":130}],130:[function(e,t,n){n.f=e("./_wks")},{"./_wks":131}],131:[function(e,t,n){var r=e("./_shared")("wks"),o=e("./_uid"),a=e("./_global").Symbol,i="function"==typeof a;(t.exports=function(e){return r[e]||(r[e]=i&&a[e]||(i?a:o)("Symbol."+e))}).store=r},{"./_global":43,"./_shared":105,"./_uid":126}],132:[function(e,t,n){var r=e("./_classof"),o=e("./_wks")("iterator"),a=e("./_iterators");t.exports=e("./_core").getIteratorMethod=function(e){if(void 0!=e)return e[o]||e["@@iterator"]||a[r(e)]}},{"./_classof":19,"./_core":25,"./_iterators":61,"./_wks":131}],133:[function(e,t,n){
+         var r=e("./_export"),o=e("./_replacer")(/[\\^$*+?.()|[\]{}]/g,"\\$&");r(r.S,"RegExp",{escape:function(e){return o(e)}})},{"./_export":35,"./_replacer":97}],134:[function(e,t,n){var r=e("./_export");r(r.P,"Array",{copyWithin:e("./_array-copy-within")}),e("./_add-to-unscopables")("copyWithin")},{"./_add-to-unscopables":6,"./_array-copy-within":10,"./_export":35}],135:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-methods")(4);r(r.P+r.F*!e("./_strict-method")([].every,!0),"Array",{every:function(e){return o(this,e,arguments[1])}})},{"./_array-methods":14,"./_export":35,"./_strict-method":107}],136:[function(e,t,n){var r=e("./_export");r(r.P,"Array",{fill:e("./_array-fill")}),e("./_add-to-unscopables")("fill")},{"./_add-to-unscopables":6,"./_array-fill":11,"./_export":35}],137:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-methods")(2);r(r.P+r.F*!e("./_strict-method")([].filter,!0),"Array",{filter:function(e){return o(this,e,arguments[1])}})},{"./_array-methods":14,"./_export":35,"./_strict-method":107}],138:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-methods")(6),a="findIndex",i=!0;a in[]&&Array(1)[a](function(){i=!1}),r(r.P+r.F*i,"Array",{findIndex:function(e){return o(this,e,arguments.length>1?arguments[1]:void 0)}}),e("./_add-to-unscopables")(a)},{"./_add-to-unscopables":6,"./_array-methods":14,"./_export":35}],139:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-methods")(5),a=!0;"find"in[]&&Array(1).find(function(){a=!1}),r(r.P+r.F*a,"Array",{find:function(e){return o(this,e,arguments.length>1?arguments[1]:void 0)}}),e("./_add-to-unscopables")("find")},{"./_add-to-unscopables":6,"./_array-methods":14,"./_export":35}],140:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-methods")(0),a=e("./_strict-method")([].forEach,!0);r(r.P+r.F*!a,"Array",{forEach:function(e){return o(this,e,arguments[1])}})},{"./_array-methods":14,"./_export":35,"./_strict-method":107}],141:[function(e,t,n){"use strict";var r=e("./_ctx"),o=e("./_export"),a=e("./_to-object"),i=e("./_iter-call"),s=e("./_is-array-iter"),l=e("./_to-length"),u=e("./_create-property"),c=e("./core.get-iterator-method");o(o.S+o.F*!e("./_iter-detect")(function(e){Array.from(e)}),"Array",{from:function(e){var t,n,o,f,p=a(e),d="function"==typeof this?this:Array,v=arguments.length,y=v>1?arguments[1]:void 0,_=void 0!==y,h=0,m=c(p);if(_&&(y=r(y,v>2?arguments[2]:void 0,2)),void 0==m||d==Array&&s(m))for(t=l(p.length),n=new d(t);t>h;h++)u(n,h,_?y(p[h],h):p[h]);else for(f=m.call(p),n=new d;!(o=f.next()).done;h++)u(n,h,_?i(f,y,[o.value,h],!0):o.value);return n.length=h,n}})},{"./_create-property":26,"./_ctx":27,"./_export":35,"./_is-array-iter":51,"./_iter-call":56,"./_iter-detect":59,"./_to-length":120,"./_to-object":121,"./core.get-iterator-method":132}],142:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-includes")(!1),a=[].indexOf,i=!!a&&1/[1].indexOf(1,-0)<0;r(r.P+r.F*(i||!e("./_strict-method")(a)),"Array",{indexOf:function(e){return i?a.apply(this,arguments)||0:o(this,e,arguments[1])}})},{"./_array-includes":13,"./_export":35,"./_strict-method":107}],143:[function(e,t,n){var r=e("./_export");r(r.S,"Array",{isArray:e("./_is-array")})},{"./_export":35,"./_is-array":52}],144:[function(e,t,n){"use strict";var r=e("./_add-to-unscopables"),o=e("./_iter-step"),a=e("./_iterators"),i=e("./_to-iobject");t.exports=e("./_iter-define")(Array,"Array",function(e,t){this._t=i(e),this._i=0,this._k=t},function(){var e=this._t,t=this._k,n=this._i++;return!e||n>=e.length?(this._t=void 0,o(1)):"keys"==t?o(0,n):"values"==t?o(0,e[n]):o(0,[n,e[n]])},"values"),a.Arguments=a.Array,r("keys"),r("values"),r("entries")},{"./_add-to-unscopables":6,"./_iter-define":58,"./_iter-step":60,"./_iterators":61,"./_to-iobject":119}],145:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-iobject"),a=[].join;r(r.P+r.F*(e("./_iobject")!=Object||!e("./_strict-method")(a)),"Array",{join:function(e){return a.call(o(this),void 0===e?",":e)}})},{"./_export":35,"./_iobject":50,"./_strict-method":107,"./_to-iobject":119}],146:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-iobject"),a=e("./_to-integer"),i=e("./_to-length"),s=[].lastIndexOf,l=!!s&&1/[1].lastIndexOf(1,-0)<0;r(r.P+r.F*(l||!e("./_strict-method")(s)),"Array",{lastIndexOf:function(e){if(l)return s.apply(this,arguments)||0;var t=o(this),n=i(t.length),r=n-1;for(arguments.length>1&&(r=Math.min(r,a(arguments[1]))),r<0&&(r=n+r);r>=0;r--)if(r in t&&t[r]===e)return r||0;return-1}})},{"./_export":35,"./_strict-method":107,"./_to-integer":118,"./_to-iobject":119,"./_to-length":120}],147:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-methods")(1);r(r.P+r.F*!e("./_strict-method")([].map,!0),"Array",{map:function(e){return o(this,e,arguments[1])}})},{"./_array-methods":14,"./_export":35,"./_strict-method":107}],148:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_create-property");r(r.S+r.F*e("./_fails")(function(){function e(){}return!(Array.of.call(e)instanceof e)}),"Array",{of:function(){for(var e=0,t=arguments.length,n=new("function"==typeof this?this:Array)(t);t>e;)o(n,e,arguments[e++]);return n.length=t,n}})},{"./_create-property":26,"./_export":35,"./_fails":37}],149:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-reduce");r(r.P+r.F*!e("./_strict-method")([].reduceRight,!0),"Array",{reduceRight:function(e){return o(this,e,arguments.length,arguments[1],!0)}})},{"./_array-reduce":15,"./_export":35,"./_strict-method":107}],150:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-reduce");r(r.P+r.F*!e("./_strict-method")([].reduce,!0),"Array",{reduce:function(e){return o(this,e,arguments.length,arguments[1],!1)}})},{"./_array-reduce":15,"./_export":35,"./_strict-method":107}],151:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_html"),a=e("./_cof"),i=e("./_to-absolute-index"),s=e("./_to-length"),l=[].slice;r(r.P+r.F*e("./_fails")(function(){o&&l.call(o)}),"Array",{slice:function(e,t){var n=s(this.length),r=a(this);if(t=void 0===t?n:t,"Array"==r)return l.call(this,e,t);for(var o=i(e,n),u=i(t,n),c=s(u-o),f=new Array(c),p=0;p<c;p++)f[p]="String"==r?this.charAt(o+p):this[o+p];return f}})},{"./_cof":20,"./_export":35,"./_fails":37,"./_html":46,"./_to-absolute-index":116,"./_to-length":120}],152:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-methods")(3);r(r.P+r.F*!e("./_strict-method")([].some,!0),"Array",{some:function(e){return o(this,e,arguments[1])}})},{"./_array-methods":14,"./_export":35,"./_strict-method":107}],153:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_a-function"),a=e("./_to-object"),i=e("./_fails"),s=[].sort,l=[1,2,3];r(r.P+r.F*(i(function(){l.sort(void 0)})||!i(function(){l.sort(null)})||!e("./_strict-method")(s)),"Array",{sort:function(e){return void 0===e?s.call(a(this)):s.call(a(this),o(e))}})},{"./_a-function":4,"./_export":35,"./_fails":37,"./_strict-method":107,"./_to-object":121}],154:[function(e,t,n){e("./_set-species")("Array")},{"./_set-species":102}],155:[function(e,t,n){var r=e("./_export");r(r.S,"Date",{now:function(){return(new Date).getTime()}})},{"./_export":35}],156:[function(e,t,n){var r=e("./_export"),o=e("./_date-to-iso-string");r(r.P+r.F*(Date.prototype.toISOString!==o),"Date",{toISOString:o})},{"./_date-to-iso-string":28,"./_export":35}],157:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-object"),a=e("./_to-primitive");r(r.P+r.F*e("./_fails")(function(){return null!==new Date(NaN).toJSON()||1!==Date.prototype.toJSON.call({toISOString:function(){return 1}})}),"Date",{toJSON:function(e){var t=o(this),n=a(t);return"number"!=typeof n||isFinite(n)?t.toISOString():null}})},{"./_export":35,"./_fails":37,"./_to-object":121,"./_to-primitive":122}],158:[function(e,t,n){var r=e("./_wks")("toPrimitive"),o=Date.prototype;r in o||e("./_hide")(o,r,e("./_date-to-primitive"))},{"./_date-to-primitive":29,"./_hide":45,"./_wks":131}],159:[function(e,t,n){var r=Date.prototype,o=r.toString,a=r.getTime;new Date(NaN)+""!="Invalid Date"&&e("./_redefine")(r,"toString",function(){var e=a.call(this);return e===e?o.call(this):"Invalid Date"})},{"./_redefine":94}],160:[function(e,t,n){var r=e("./_export");r(r.P,"Function",{bind:e("./_bind")})},{"./_bind":18,"./_export":35}],161:[function(e,t,n){"use strict";var r=e("./_is-object"),o=e("./_object-gpo"),a=e("./_wks")("hasInstance"),i=Function.prototype;a in i||e("./_object-dp").f(i,a,{value:function(e){if("function"!=typeof this||!r(e))return!1;if(!r(this.prototype))return e instanceof this;for(;e=o(e);)if(this.prototype===e)return!0;return!1}})},{"./_is-object":54,"./_object-dp":74,"./_object-gpo":81,"./_wks":131}],162:[function(e,t,n){var r=e("./_object-dp").f,o=Function.prototype,a=/^\s*function ([^ (]*)/;"name"in o||e("./_descriptors")&&r(o,"name",{configurable:!0,get:function(){try{return(""+this).match(a)[1]}catch(e){return""}}})},{"./_descriptors":31,"./_object-dp":74}],163:[function(e,t,n){"use strict";var r=e("./_collection-strong"),o=e("./_validate-collection");t.exports=e("./_collection")("Map",function(e){return function(){return e(this,arguments.length>0?arguments[0]:void 0)}},{get:function(e){var t=r.getEntry(o(this,"Map"),e);return t&&t.v},set:function(e,t){return r.def(o(this,"Map"),0===e?0:e,t)}},r,!0)},{"./_collection":24,"./_collection-strong":21,"./_validate-collection":128}],164:[function(e,t,n){var r=e("./_export"),o=e("./_math-log1p"),a=Math.sqrt,i=Math.acosh;r(r.S+r.F*!(i&&710==Math.floor(i(Number.MAX_VALUE))&&i(1/0)==1/0),"Math",{acosh:function(e){return(e=+e)<1?NaN:e>94906265.62425156?Math.log(e)+Math.LN2:o(e-1+a(e-1)*a(e+1))}})},{"./_export":35,"./_math-log1p":65}],165:[function(e,t,n){function r(e){return isFinite(e=+e)&&0!=e?e<0?-r(-e):Math.log(e+Math.sqrt(e*e+1)):e}var o=e("./_export"),a=Math.asinh;o(o.S+o.F*!(a&&1/a(0)>0),"Math",{asinh:r})},{"./_export":35}],166:[function(e,t,n){var r=e("./_export"),o=Math.atanh;r(r.S+r.F*!(o&&1/o(-0)<0),"Math",{atanh:function(e){return 0==(e=+e)?e:Math.log((1+e)/(1-e))/2}})},{"./_export":35}],167:[function(e,t,n){var r=e("./_export"),o=e("./_math-sign");r(r.S,"Math",{cbrt:function(e){return o(e=+e)*Math.pow(Math.abs(e),1/3)}})},{"./_export":35,"./_math-sign":67}],168:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{clz32:function(e){return(e>>>=0)?31-Math.floor(Math.log(e+.5)*Math.LOG2E):32}})},{"./_export":35}],169:[function(e,t,n){var r=e("./_export"),o=Math.exp;r(r.S,"Math",{cosh:function(e){return(o(e=+e)+o(-e))/2}})},{"./_export":35}],170:[function(e,t,n){var r=e("./_export"),o=e("./_math-expm1");r(r.S+r.F*(o!=Math.expm1),"Math",{expm1:o})},{"./_export":35,"./_math-expm1":63}],171:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{fround:e("./_math-fround")})},{"./_export":35,"./_math-fround":64}],172:[function(e,t,n){var r=e("./_export"),o=Math.abs;r(r.S,"Math",{hypot:function(e,t){for(var n,r,a=0,i=0,s=arguments.length,l=0;i<s;)n=o(arguments[i++]),l<n?(r=l/n,a=a*r*r+1,l=n):n>0?(r=n/l,a+=r*r):a+=n;return l===1/0?1/0:l*Math.sqrt(a)}})},{"./_export":35}],173:[function(e,t,n){var r=e("./_export"),o=Math.imul;r(r.S+r.F*e("./_fails")(function(){return-5!=o(4294967295,5)||2!=o.length}),"Math",{imul:function(e,t){var n=+e,r=+t,o=65535&n,a=65535&r;return 0|o*a+((65535&n>>>16)*a+o*(65535&r>>>16)<<16>>>0)}})},{"./_export":35,"./_fails":37}],174:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{log10:function(e){return Math.log(e)*Math.LOG10E}})},{"./_export":35}],175:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{log1p:e("./_math-log1p")})},{"./_export":35,"./_math-log1p":65}],176:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{log2:function(e){return Math.log(e)/Math.LN2}})},{"./_export":35}],177:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{sign:e("./_math-sign")})},{"./_export":35,"./_math-sign":67}],178:[function(e,t,n){var r=e("./_export"),o=e("./_math-expm1"),a=Math.exp;r(r.S+r.F*e("./_fails")(function(){return-2e-17!=!Math.sinh(-2e-17)}),"Math",{sinh:function(e){return Math.abs(e=+e)<1?(o(e)-o(-e))/2:(a(e-1)-a(-e-1))*(Math.E/2)}})},{"./_export":35,"./_fails":37,"./_math-expm1":63}],179:[function(e,t,n){var r=e("./_export"),o=e("./_math-expm1"),a=Math.exp;r(r.S,"Math",{tanh:function(e){var t=o(e=+e),n=o(-e);return t==1/0?1:n==1/0?-1:(t-n)/(a(e)+a(-e))}})},{"./_export":35,"./_math-expm1":63}],180:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{trunc:function(e){return(e>0?Math.floor:Math.ceil)(e)}})},{"./_export":35}],181:[function(e,t,n){"use strict";var r=e("./_global"),o=e("./_has"),a=e("./_cof"),i=e("./_inherit-if-required"),s=e("./_to-primitive"),l=e("./_fails"),u=e("./_object-gopn").f,c=e("./_object-gopd").f,f=e("./_object-dp").f,p=e("./_string-trim").trim,d=r.Number,v=d,y=d.prototype,_="Number"==a(e("./_object-create")(y)),h="trim"in String.prototype,m=function(e){var t=s(e,!1);if("string"==typeof t&&t.length>2){t=h?t.trim():p(t,3);var n,r,o,a=t.charCodeAt(0);if(43===a||45===a){if(88===(n=t.charCodeAt(2))||120===n)return NaN}else if(48===a){switch(t.charCodeAt(1)){case 66:case 98:r=2,o=49;break;case 79:case 111:r=8,o=55;break;default:return+t}for(var i,l=t.slice(2),u=0,c=l.length;u<c;u++)if((i=l.charCodeAt(u))<48||i>o)return NaN;return parseInt(l,r)}}return+t};if(!d(" 0o1")||!d("0b1")||d("+0x1")){d=function(e){var t=arguments.length<1?0:e,n=this;return n instanceof d&&(_?l(function(){y.valueOf.call(n)}):"Number"!=a(n))?i(new v(m(t)),n,d):m(t)};for(var g,b=e("./_descriptors")?u(v):"MAX_VALUE,MIN_VALUE,NaN,NEGATIVE_INFINITY,POSITIVE_INFINITY,EPSILON,isFinite,isInteger,isNaN,isSafeInteger,MAX_SAFE_INTEGER,MIN_SAFE_INTEGER,parseFloat,parseInt,isInteger".split(","),x=0;b.length>x;x++)o(v,g=b[x])&&!o(d,g)&&f(d,g,c(v,g));d.prototype=y,y.constructor=d,e("./_redefine")(r,"Number",d)}},{"./_cof":20,"./_descriptors":31,"./_fails":37,"./_global":43,"./_has":44,"./_inherit-if-required":48,"./_object-create":73,"./_object-dp":74,"./_object-gopd":77,"./_object-gopn":79,"./_redefine":94,"./_string-trim":113,"./_to-primitive":122}],182:[function(e,t,n){var r=e("./_export");r(r.S,"Number",{EPSILON:Math.pow(2,-52)})},{"./_export":35}],183:[function(e,t,n){var r=e("./_export"),o=e("./_global").isFinite;r(r.S,"Number",{isFinite:function(e){return"number"==typeof e&&o(e)}})},{"./_export":35,"./_global":43}],184:[function(e,t,n){var r=e("./_export");r(r.S,"Number",{isInteger:e("./_is-integer")})},{"./_export":35,"./_is-integer":53}],185:[function(e,t,n){var r=e("./_export");r(r.S,"Number",{isNaN:function(e){return e!=e}})},{"./_export":35}],186:[function(e,t,n){var r=e("./_export"),o=e("./_is-integer"),a=Math.abs;r(r.S,"Number",{isSafeInteger:function(e){return o(e)&&a(e)<=9007199254740991}})},{"./_export":35,"./_is-integer":53}],187:[function(e,t,n){var r=e("./_export");r(r.S,"Number",{MAX_SAFE_INTEGER:9007199254740991})},{"./_export":35}],188:[function(e,t,n){var r=e("./_export");r(r.S,"Number",{MIN_SAFE_INTEGER:-9007199254740991})},{"./_export":35}],189:[function(e,t,n){
+         var r=e("./_export"),o=e("./_parse-float");r(r.S+r.F*(Number.parseFloat!=o),"Number",{parseFloat:o})},{"./_export":35,"./_parse-float":88}],190:[function(e,t,n){var r=e("./_export"),o=e("./_parse-int");r(r.S+r.F*(Number.parseInt!=o),"Number",{parseInt:o})},{"./_export":35,"./_parse-int":89}],191:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-integer"),a=e("./_a-number-value"),i=e("./_string-repeat"),s=1..toFixed,l=Math.floor,u=[0,0,0,0,0,0],c="Number.toFixed: incorrect invocation!",f=function(e,t){for(var n=-1,r=t;++n<6;)r+=e*u[n],u[n]=r%1e7,r=l(r/1e7)},p=function(e){for(var t=6,n=0;--t>=0;)n+=u[t],u[t]=l(n/e),n=n%e*1e7},d=function(){for(var e=6,t="";--e>=0;)if(""!==t||0===e||0!==u[e]){var n=String(u[e]);t=""===t?n:t+i.call("0",7-n.length)+n}return t},v=function(e,t,n){return 0===t?n:t%2==1?v(e,t-1,n*e):v(e*e,t/2,n)},y=function(e){for(var t=0,n=e;n>=4096;)t+=12,n/=4096;for(;n>=2;)t+=1,n/=2;return t};r(r.P+r.F*(!!s&&("0.000"!==8e-5.toFixed(3)||"1"!==.9.toFixed(0)||"1.25"!==1.255.toFixed(2)||"1000000000000000128"!==(0xde0b6b3a7640080).toFixed(0))||!e("./_fails")(function(){s.call({})})),"Number",{toFixed:function(e){var t,n,r,s,l=a(this,c),u=o(e),_="",h="0";if(u<0||u>20)throw RangeError(c);if(l!=l)return"NaN";if(l<=-1e21||l>=1e21)return String(l);if(l<0&&(_="-",l=-l),l>1e-21)if(t=y(l*v(2,69,1))-69,n=t<0?l*v(2,-t,1):l/v(2,t,1),n*=4503599627370496,(t=52-t)>0){for(f(0,n),r=u;r>=7;)f(1e7,0),r-=7;for(f(v(10,r,1),0),r=t-1;r>=23;)p(1<<23),r-=23;p(1<<r),f(1,1),p(2),h=d()}else f(0,n),f(1<<-t,0),h=d()+i.call("0",u);return u>0?(s=h.length,h=_+(s<=u?"0."+i.call("0",u-s)+h:h.slice(0,s-u)+"."+h.slice(s-u))):h=_+h,h}})},{"./_a-number-value":5,"./_export":35,"./_fails":37,"./_string-repeat":112,"./_to-integer":118}],192:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_fails"),a=e("./_a-number-value"),i=1..toPrecision;r(r.P+r.F*(o(function(){return"1"!==i.call(1,void 0)})||!o(function(){i.call({})})),"Number",{toPrecision:function(e){var t=a(this,"Number#toPrecision: incorrect invocation!");return void 0===e?i.call(t):i.call(t,e)}})},{"./_a-number-value":5,"./_export":35,"./_fails":37}],193:[function(e,t,n){var r=e("./_export");r(r.S+r.F,"Object",{assign:e("./_object-assign")})},{"./_export":35,"./_object-assign":72}],194:[function(e,t,n){var r=e("./_export");r(r.S,"Object",{create:e("./_object-create")})},{"./_export":35,"./_object-create":73}],195:[function(e,t,n){var r=e("./_export");r(r.S+r.F*!e("./_descriptors"),"Object",{defineProperties:e("./_object-dps")})},{"./_descriptors":31,"./_export":35,"./_object-dps":75}],196:[function(e,t,n){var r=e("./_export");r(r.S+r.F*!e("./_descriptors"),"Object",{defineProperty:e("./_object-dp").f})},{"./_descriptors":31,"./_export":35,"./_object-dp":74}],197:[function(e,t,n){var r=e("./_is-object"),o=e("./_meta").onFreeze;e("./_object-sap")("freeze",function(e){return function(t){return e&&r(t)?e(o(t)):t}})},{"./_is-object":54,"./_meta":68,"./_object-sap":85}],198:[function(e,t,n){var r=e("./_to-iobject"),o=e("./_object-gopd").f;e("./_object-sap")("getOwnPropertyDescriptor",function(){return function(e,t){return o(r(e),t)}})},{"./_object-gopd":77,"./_object-sap":85,"./_to-iobject":119}],199:[function(e,t,n){e("./_object-sap")("getOwnPropertyNames",function(){return e("./_object-gopn-ext").f})},{"./_object-gopn-ext":78,"./_object-sap":85}],200:[function(e,t,n){var r=e("./_to-object"),o=e("./_object-gpo");e("./_object-sap")("getPrototypeOf",function(){return function(e){return o(r(e))}})},{"./_object-gpo":81,"./_object-sap":85,"./_to-object":121}],201:[function(e,t,n){var r=e("./_is-object");e("./_object-sap")("isExtensible",function(e){return function(t){return!!r(t)&&(!e||e(t))}})},{"./_is-object":54,"./_object-sap":85}],202:[function(e,t,n){var r=e("./_is-object");e("./_object-sap")("isFrozen",function(e){return function(t){return!r(t)||!!e&&e(t)}})},{"./_is-object":54,"./_object-sap":85}],203:[function(e,t,n){var r=e("./_is-object");e("./_object-sap")("isSealed",function(e){return function(t){return!r(t)||!!e&&e(t)}})},{"./_is-object":54,"./_object-sap":85}],204:[function(e,t,n){var r=e("./_export");r(r.S,"Object",{is:e("./_same-value")})},{"./_export":35,"./_same-value":98}],205:[function(e,t,n){var r=e("./_to-object"),o=e("./_object-keys");e("./_object-sap")("keys",function(){return function(e){return o(r(e))}})},{"./_object-keys":83,"./_object-sap":85,"./_to-object":121}],206:[function(e,t,n){var r=e("./_is-object"),o=e("./_meta").onFreeze;e("./_object-sap")("preventExtensions",function(e){return function(t){return e&&r(t)?e(o(t)):t}})},{"./_is-object":54,"./_meta":68,"./_object-sap":85}],207:[function(e,t,n){var r=e("./_is-object"),o=e("./_meta").onFreeze;e("./_object-sap")("seal",function(e){return function(t){return e&&r(t)?e(o(t)):t}})},{"./_is-object":54,"./_meta":68,"./_object-sap":85}],208:[function(e,t,n){var r=e("./_export");r(r.S,"Object",{setPrototypeOf:e("./_set-proto").set})},{"./_export":35,"./_set-proto":101}],209:[function(e,t,n){"use strict";var r=e("./_classof"),o={};o[e("./_wks")("toStringTag")]="z",o+""!="[object z]"&&e("./_redefine")(Object.prototype,"toString",function(){return"[object "+r(this)+"]"},!0)},{"./_classof":19,"./_redefine":94,"./_wks":131}],210:[function(e,t,n){var r=e("./_export"),o=e("./_parse-float");r(r.G+r.F*(parseFloat!=o),{parseFloat:o})},{"./_export":35,"./_parse-float":88}],211:[function(e,t,n){var r=e("./_export"),o=e("./_parse-int");r(r.G+r.F*(parseInt!=o),{parseInt:o})},{"./_export":35,"./_parse-int":89}],212:[function(e,t,n){"use strict";var r,o,a,i,s=e("./_library"),l=e("./_global"),u=e("./_ctx"),c=e("./_classof"),f=e("./_export"),p=e("./_is-object"),d=e("./_a-function"),v=e("./_an-instance"),y=e("./_for-of"),_=e("./_species-constructor"),h=e("./_task").set,m=e("./_microtask")(),g=e("./_new-promise-capability"),b=e("./_perform"),x=e("./_user-agent"),w=e("./_promise-resolve"),j=l.TypeError,A=l.process,S=A&&A.versions,k=S&&S.v8||"",E=l.Promise,I="process"==c(A),C=function(){},O=o=g.f,P=!!function(){try{var t=E.resolve(1),n=(t.constructor={})[e("./_wks")("species")]=function(e){e(C,C)};return(I||"function"==typeof PromiseRejectionEvent)&&t.then(C)instanceof n&&0!==k.indexOf("6.6")&&-1===x.indexOf("Chrome/66")}catch(e){}}(),L=function(e){var t;return!(!p(e)||"function"!=typeof(t=e.then))&&t},M=function(e,t){if(!e._n){e._n=!0;var n=e._c;m(function(){for(var r=e._v,o=1==e._s,a=0;n.length>a;)!function(t){var n,a,i,s=o?t.ok:t.fail,l=t.resolve,u=t.reject,c=t.domain;try{s?(o||(2==e._h&&N(e),e._h=1),!0===s?n=r:(c&&c.enter(),n=s(r),c&&(c.exit(),i=!0)),n===t.promise?u(j("Promise-chain cycle")):(a=L(n))?a.call(n,l,u):l(n)):u(r)}catch(e){c&&!i&&c.exit(),u(e)}}(n[a++]);e._c=[],e._n=!1,t&&!e._h&&T(e)})}},T=function(e){h.call(l,function(){var t,n,r,o=e._v,a=R(e);if(a&&(t=b(function(){I?A.emit("unhandledRejection",o,e):(n=l.onunhandledrejection)?n({promise:e,reason:o}):(r=l.console)&&r.error&&r.error("Unhandled promise rejection",o)}),e._h=I||R(e)?2:1),e._a=void 0,a&&t.e)throw t.v})},R=function(e){return 1!==e._h&&0===(e._a||e._c).length},N=function(e){h.call(l,function(){var t;I?A.emit("rejectionHandled",e):(t=l.onrejectionhandled)&&t({promise:e,reason:e._v})})},D=function(e){var t=this;t._d||(t._d=!0,t=t._w||t,t._v=e,t._s=2,t._a||(t._a=t._c.slice()),M(t,!0))},F=function(e){var t,n=this;if(!n._d){n._d=!0,n=n._w||n;try{if(n===e)throw j("Promise can't be resolved itself");(t=L(e))?m(function(){var r={_w:n,_d:!1};try{t.call(e,u(F,r,1),u(D,r,1))}catch(e){D.call(r,e)}}):(n._v=e,n._s=1,M(n,!1))}catch(e){D.call({_w:n,_d:!1},e)}}};P||(E=function(e){v(this,E,"Promise","_h"),d(e),r.call(this);try{e(u(F,this,1),u(D,this,1))}catch(e){D.call(this,e)}},r=function(e){this._c=[],this._a=void 0,this._s=0,this._d=!1,this._v=void 0,this._h=0,this._n=!1},r.prototype=e("./_redefine-all")(E.prototype,{then:function(e,t){var n=O(_(this,E));return n.ok="function"!=typeof e||e,n.fail="function"==typeof t&&t,n.domain=I?A.domain:void 0,this._c.push(n),this._a&&this._a.push(n),this._s&&M(this,!1),n.promise},catch:function(e){return this.then(void 0,e)}}),a=function(){var e=new r;this.promise=e,this.resolve=u(F,e,1),this.reject=u(D,e,1)},g.f=O=function(e){return e===E||e===i?new a(e):o(e)}),f(f.G+f.W+f.F*!P,{Promise:E}),e("./_set-to-string-tag")(E,"Promise"),e("./_set-species")("Promise"),i=e("./_core").Promise,f(f.S+f.F*!P,"Promise",{reject:function(e){var t=O(this);return(0,t.reject)(e),t.promise}}),f(f.S+f.F*(s||!P),"Promise",{resolve:function(e){return w(s&&this===i?E:this,e)}}),f(f.S+f.F*!(P&&e("./_iter-detect")(function(e){E.all(e).catch(C)})),"Promise",{all:function(e){var t=this,n=O(t),r=n.resolve,o=n.reject,a=b(function(){var n=[],a=0,i=1;y(e,!1,function(e){var s=a++,l=!1;n.push(void 0),i++,t.resolve(e).then(function(e){l||(l=!0,n[s]=e,--i||r(n))},o)}),--i||r(n)});return a.e&&o(a.v),n.promise},race:function(e){var t=this,n=O(t),r=n.reject,o=b(function(){y(e,!1,function(e){t.resolve(e).then(n.resolve,r)})});return o.e&&r(o.v),n.promise}})},{"./_a-function":4,"./_an-instance":8,"./_classof":19,"./_core":25,"./_ctx":27,"./_export":35,"./_for-of":41,"./_global":43,"./_is-object":54,"./_iter-detect":59,"./_library":62,"./_microtask":70,"./_new-promise-capability":71,"./_perform":90,"./_promise-resolve":91,"./_redefine-all":93,"./_set-species":102,"./_set-to-string-tag":103,"./_species-constructor":106,"./_task":115,"./_user-agent":127,"./_wks":131}],213:[function(e,t,n){var r=e("./_export"),o=e("./_a-function"),a=e("./_an-object"),i=(e("./_global").Reflect||{}).apply,s=Function.apply;r(r.S+r.F*!e("./_fails")(function(){i(function(){})}),"Reflect",{apply:function(e,t,n){var r=o(e),l=a(n);return i?i(r,t,l):s.call(r,t,l)}})},{"./_a-function":4,"./_an-object":9,"./_export":35,"./_fails":37,"./_global":43}],214:[function(e,t,n){var r=e("./_export"),o=e("./_object-create"),a=e("./_a-function"),i=e("./_an-object"),s=e("./_is-object"),l=e("./_fails"),u=e("./_bind"),c=(e("./_global").Reflect||{}).construct,f=l(function(){function e(){}return!(c(function(){},[],e)instanceof e)}),p=!l(function(){c(function(){})});r(r.S+r.F*(f||p),"Reflect",{construct:function(e,t){a(e),i(t);var n=arguments.length<3?e:a(arguments[2]);if(p&&!f)return c(e,t,n);if(e==n){switch(t.length){case 0:return new e;case 1:return new e(t[0]);case 2:return new e(t[0],t[1]);case 3:return new e(t[0],t[1],t[2]);case 4:return new e(t[0],t[1],t[2],t[3])}var r=[null];return r.push.apply(r,t),new(u.apply(e,r))}var l=n.prototype,d=o(s(l)?l:Object.prototype),v=Function.apply.call(e,d,t);return s(v)?v:d}})},{"./_a-function":4,"./_an-object":9,"./_bind":18,"./_export":35,"./_fails":37,"./_global":43,"./_is-object":54,"./_object-create":73}],215:[function(e,t,n){var r=e("./_object-dp"),o=e("./_export"),a=e("./_an-object"),i=e("./_to-primitive");o(o.S+o.F*e("./_fails")(function(){Reflect.defineProperty(r.f({},1,{value:1}),1,{value:2})}),"Reflect",{defineProperty:function(e,t,n){a(e),t=i(t,!0),a(n);try{return r.f(e,t,n),!0}catch(e){return!1}}})},{"./_an-object":9,"./_export":35,"./_fails":37,"./_object-dp":74,"./_to-primitive":122}],216:[function(e,t,n){var r=e("./_export"),o=e("./_object-gopd").f,a=e("./_an-object");r(r.S,"Reflect",{deleteProperty:function(e,t){var n=o(a(e),t);return!(n&&!n.configurable)&&delete e[t]}})},{"./_an-object":9,"./_export":35,"./_object-gopd":77}],217:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_an-object"),a=function(e){this._t=o(e),this._i=0;var t,n=this._k=[];for(t in e)n.push(t)};e("./_iter-create")(a,"Object",function(){var e,t=this,n=t._k;do{if(t._i>=n.length)return{value:void 0,done:!0}}while(!((e=n[t._i++])in t._t));return{value:e,done:!1}}),r(r.S,"Reflect",{enumerate:function(e){return new a(e)}})},{"./_an-object":9,"./_export":35,"./_iter-create":57}],218:[function(e,t,n){var r=e("./_object-gopd"),o=e("./_export"),a=e("./_an-object");o(o.S,"Reflect",{getOwnPropertyDescriptor:function(e,t){return r.f(a(e),t)}})},{"./_an-object":9,"./_export":35,"./_object-gopd":77}],219:[function(e,t,n){var r=e("./_export"),o=e("./_object-gpo"),a=e("./_an-object");r(r.S,"Reflect",{getPrototypeOf:function(e){return o(a(e))}})},{"./_an-object":9,"./_export":35,"./_object-gpo":81}],220:[function(e,t,n){function r(e,t){var n,s,c=arguments.length<3?e:arguments[2];return u(e)===c?e[t]:(n=o.f(e,t))?i(n,"value")?n.value:void 0!==n.get?n.get.call(c):void 0:l(s=a(e))?r(s,t,c):void 0}var o=e("./_object-gopd"),a=e("./_object-gpo"),i=e("./_has"),s=e("./_export"),l=e("./_is-object"),u=e("./_an-object");s(s.S,"Reflect",{get:r})},{"./_an-object":9,"./_export":35,"./_has":44,"./_is-object":54,"./_object-gopd":77,"./_object-gpo":81}],221:[function(e,t,n){var r=e("./_export");r(r.S,"Reflect",{has:function(e,t){return t in e}})},{"./_export":35}],222:[function(e,t,n){var r=e("./_export"),o=e("./_an-object"),a=Object.isExtensible;r(r.S,"Reflect",{isExtensible:function(e){return o(e),!a||a(e)}})},{"./_an-object":9,"./_export":35}],223:[function(e,t,n){var r=e("./_export");r(r.S,"Reflect",{ownKeys:e("./_own-keys")})},{"./_export":35,"./_own-keys":87}],224:[function(e,t,n){var r=e("./_export"),o=e("./_an-object"),a=Object.preventExtensions;r(r.S,"Reflect",{preventExtensions:function(e){o(e);try{return a&&a(e),!0}catch(e){return!1}}})},{"./_an-object":9,"./_export":35}],225:[function(e,t,n){var r=e("./_export"),o=e("./_set-proto");o&&r(r.S,"Reflect",{setPrototypeOf:function(e,t){o.check(e,t);try{return o.set(e,t),!0}catch(e){return!1}}})},{"./_export":35,"./_set-proto":101}],226:[function(e,t,n){function r(e,t,n){var l,p,d=arguments.length<4?e:arguments[3],v=a.f(c(e),t);if(!v){if(f(p=i(e)))return r(p,t,n,d);v=u(0)}if(s(v,"value")){if(!1===v.writable||!f(d))return!1;if(l=a.f(d,t)){if(l.get||l.set||!1===l.writable)return!1;l.value=n,o.f(d,t,l)}else o.f(d,t,u(0,n));return!0}return void 0!==v.set&&(v.set.call(d,n),!0)}var o=e("./_object-dp"),a=e("./_object-gopd"),i=e("./_object-gpo"),s=e("./_has"),l=e("./_export"),u=e("./_property-desc"),c=e("./_an-object"),f=e("./_is-object");l(l.S,"Reflect",{set:r})},{"./_an-object":9,"./_export":35,"./_has":44,"./_is-object":54,"./_object-dp":74,"./_object-gopd":77,"./_object-gpo":81,"./_property-desc":92}],227:[function(e,t,n){var r=e("./_global"),o=e("./_inherit-if-required"),a=e("./_object-dp").f,i=e("./_object-gopn").f,s=e("./_is-regexp"),l=e("./_flags"),u=r.RegExp,c=u,f=u.prototype,p=/a/g,d=/a/g,v=new u(p)!==p;if(e("./_descriptors")&&(!v||e("./_fails")(function(){return d[e("./_wks")("match")]=!1,u(p)!=p||u(d)==d||"/a/i"!=u(p,"i")}))){u=function(e,t){var n=this instanceof u,r=s(e),a=void 0===t;return!n&&r&&e.constructor===u&&a?e:o(v?new c(r&&!a?e.source:e,t):c((r=e instanceof u)?e.source:e,r&&a?l.call(e):t),n?this:f,u)};for(var y=i(c),_=0;y.length>_;)!function(e){e in u||a(u,e,{configurable:!0,get:function(){return c[e]},set:function(t){c[e]=t}})}(y[_++]);f.constructor=u,u.prototype=f,e("./_redefine")(r,"RegExp",u)}e("./_set-species")("RegExp")},{"./_descriptors":31,"./_fails":37,"./_flags":39,"./_global":43,"./_inherit-if-required":48,"./_is-regexp":55,
+         "./_object-dp":74,"./_object-gopn":79,"./_redefine":94,"./_set-species":102,"./_wks":131}],228:[function(e,t,n){"use strict";var r=e("./_regexp-exec");e("./_export")({target:"RegExp",proto:!0,forced:r!==/./.exec},{exec:r})},{"./_export":35,"./_regexp-exec":96}],229:[function(e,t,n){e("./_descriptors")&&"g"!=/./g.flags&&e("./_object-dp").f(RegExp.prototype,"flags",{configurable:!0,get:e("./_flags")})},{"./_descriptors":31,"./_flags":39,"./_object-dp":74}],230:[function(e,t,n){"use strict";var r=e("./_an-object"),o=e("./_to-length"),a=e("./_advance-string-index"),i=e("./_regexp-exec-abstract");e("./_fix-re-wks")("match",1,function(e,t,n,s){return[function(n){var r=e(this),o=void 0==n?void 0:n[t];return void 0!==o?o.call(n,r):new RegExp(n)[t](String(r))},function(e){var t=s(n,e,this);if(t.done)return t.value;var l=r(e),u=String(this);if(!l.global)return i(l,u);var c=l.unicode;l.lastIndex=0;for(var f,p=[],d=0;null!==(f=i(l,u));){var v=String(f[0]);p[d]=v,""===v&&(l.lastIndex=a(u,o(l.lastIndex),c)),d++}return 0===d?null:p}]})},{"./_advance-string-index":7,"./_an-object":9,"./_fix-re-wks":38,"./_regexp-exec-abstract":95,"./_to-length":120}],231:[function(e,t,n){"use strict";var r=e("./_an-object"),o=e("./_to-object"),a=e("./_to-length"),i=e("./_to-integer"),s=e("./_advance-string-index"),l=e("./_regexp-exec-abstract"),u=Math.max,c=Math.min,f=Math.floor,p=/\$([$&`']|\d\d?|<[^>]*>)/g,d=/\$([$&`']|\d\d?)/g,v=function(e){return void 0===e?e:String(e)};e("./_fix-re-wks")("replace",2,function(e,t,n,y){function _(e,t,r,a,i,s){var l=r+e.length,u=a.length,c=d;return void 0!==i&&(i=o(i),c=p),n.call(s,c,function(n,o){var s;switch(o.charAt(0)){case"$":return"$";case"&":return e;case"`":return t.slice(0,r);case"'":return t.slice(l);case"<":s=i[o.slice(1,-1)];break;default:var c=+o;if(0===c)return n;if(c>u){var p=f(c/10);return 0===p?n:p<=u?void 0===a[p-1]?o.charAt(1):a[p-1]+o.charAt(1):n}s=a[c-1]}return void 0===s?"":s})}return[function(r,o){var a=e(this),i=void 0==r?void 0:r[t];return void 0!==i?i.call(r,a,o):n.call(String(a),r,o)},function(e,t){var o=y(n,e,this,t);if(o.done)return o.value;var f=r(e),p=String(this),d="function"==typeof t;d||(t=String(t));var h=f.global;if(h){var m=f.unicode;f.lastIndex=0}for(var g=[];;){var b=l(f,p);if(null===b)break;if(g.push(b),!h)break;""===String(b[0])&&(f.lastIndex=s(p,a(f.lastIndex),m))}for(var x="",w=0,j=0;j<g.length;j++){b=g[j];for(var A=String(b[0]),S=u(c(i(b.index),p.length),0),k=[],E=1;E<b.length;E++)k.push(v(b[E]));var I=b.groups;if(d){var C=[A].concat(k,S,p);void 0!==I&&C.push(I);var O=String(t.apply(void 0,C))}else O=_(A,p,S,k,I,t);S>=w&&(x+=p.slice(w,S)+O,w=S+A.length)}return x+p.slice(w)}]})},{"./_advance-string-index":7,"./_an-object":9,"./_fix-re-wks":38,"./_regexp-exec-abstract":95,"./_to-integer":118,"./_to-length":120,"./_to-object":121}],232:[function(e,t,n){"use strict";var r=e("./_an-object"),o=e("./_same-value"),a=e("./_regexp-exec-abstract");e("./_fix-re-wks")("search",1,function(e,t,n,i){return[function(n){var r=e(this),o=void 0==n?void 0:n[t];return void 0!==o?o.call(n,r):new RegExp(n)[t](String(r))},function(e){var t=i(n,e,this);if(t.done)return t.value;var s=r(e),l=String(this),u=s.lastIndex;o(u,0)||(s.lastIndex=0);var c=a(s,l);return o(s.lastIndex,u)||(s.lastIndex=u),null===c?-1:c.index}]})},{"./_an-object":9,"./_fix-re-wks":38,"./_regexp-exec-abstract":95,"./_same-value":98}],233:[function(e,t,n){"use strict";var r=e("./_is-regexp"),o=e("./_an-object"),a=e("./_species-constructor"),i=e("./_advance-string-index"),s=e("./_to-length"),l=e("./_regexp-exec-abstract"),u=e("./_regexp-exec"),c=e("./_fails"),f=Math.min,p=[].push,d="length",v=!c(function(){RegExp(4294967295,"y")});e("./_fix-re-wks")("split",2,function(e,t,n,c){var y;return y="c"=="abbc".split(/(b)*/)[1]||4!="test".split(/(?:)/,-1)[d]||2!="ab".split(/(?:ab)*/)[d]||4!=".".split(/(.?)(.?)/)[d]||".".split(/()()/)[d]>1||"".split(/.?/)[d]?function(e,t){var o=String(this);if(void 0===e&&0===t)return[];if(!r(e))return n.call(o,e,t);for(var a,i,s,l=[],c=(e.ignoreCase?"i":"")+(e.multiline?"m":"")+(e.unicode?"u":"")+(e.sticky?"y":""),f=0,v=void 0===t?4294967295:t>>>0,y=new RegExp(e.source,c+"g");(a=u.call(y,o))&&!((i=y.lastIndex)>f&&(l.push(o.slice(f,a.index)),a[d]>1&&a.index<o[d]&&p.apply(l,a.slice(1)),s=a[0][d],f=i,l[d]>=v));)y.lastIndex===a.index&&y.lastIndex++;return f===o[d]?!s&&y.test("")||l.push(""):l.push(o.slice(f)),l[d]>v?l.slice(0,v):l}:"0".split(void 0,0)[d]?function(e,t){return void 0===e&&0===t?[]:n.call(this,e,t)}:n,[function(n,r){var o=e(this),a=void 0==n?void 0:n[t];return void 0!==a?a.call(n,o,r):y.call(String(o),n,r)},function(e,t){var r=c(y,e,this,t,y!==n);if(r.done)return r.value;var u=o(e),p=String(this),d=a(u,RegExp),_=u.unicode,h=(u.ignoreCase?"i":"")+(u.multiline?"m":"")+(u.unicode?"u":"")+(v?"y":"g"),m=new d(v?u:"^(?:"+u.source+")",h),g=void 0===t?4294967295:t>>>0;if(0===g)return[];if(0===p.length)return null===l(m,p)?[p]:[];for(var b=0,x=0,w=[];x<p.length;){m.lastIndex=v?x:0;var j,A=l(m,v?p:p.slice(x));if(null===A||(j=f(s(m.lastIndex+(v?0:x)),p.length))===b)x=i(p,x,_);else{if(w.push(p.slice(b,x)),w.length===g)return w;for(var S=1;S<=A.length-1;S++)if(w.push(A[S]),w.length===g)return w;x=b=j}}return w.push(p.slice(b)),w}]})},{"./_advance-string-index":7,"./_an-object":9,"./_fails":37,"./_fix-re-wks":38,"./_is-regexp":55,"./_regexp-exec":96,"./_regexp-exec-abstract":95,"./_species-constructor":106,"./_to-length":120}],234:[function(e,t,n){"use strict";e("./es6.regexp.flags");var r=e("./_an-object"),o=e("./_flags"),a=e("./_descriptors"),i=/./.toString,s=function(t){e("./_redefine")(RegExp.prototype,"toString",t,!0)};e("./_fails")(function(){return"/a/b"!=i.call({source:"a",flags:"b"})})?s(function(){var e=r(this);return"/".concat(e.source,"/","flags"in e?e.flags:!a&&e instanceof RegExp?o.call(e):void 0)}):"toString"!=i.name&&s(function(){return i.call(this)})},{"./_an-object":9,"./_descriptors":31,"./_fails":37,"./_flags":39,"./_redefine":94,"./es6.regexp.flags":229}],235:[function(e,t,n){"use strict";var r=e("./_collection-strong"),o=e("./_validate-collection");t.exports=e("./_collection")("Set",function(e){return function(){return e(this,arguments.length>0?arguments[0]:void 0)}},{add:function(e){return r.def(o(this,"Set"),e=0===e?0:e,e)}},r)},{"./_collection":24,"./_collection-strong":21,"./_validate-collection":128}],236:[function(e,t,n){"use strict";e("./_string-html")("anchor",function(e){return function(t){return e(this,"a","name",t)}})},{"./_string-html":110}],237:[function(e,t,n){"use strict";e("./_string-html")("big",function(e){return function(){return e(this,"big","","")}})},{"./_string-html":110}],238:[function(e,t,n){"use strict";e("./_string-html")("blink",function(e){return function(){return e(this,"blink","","")}})},{"./_string-html":110}],239:[function(e,t,n){"use strict";e("./_string-html")("bold",function(e){return function(){return e(this,"b","","")}})},{"./_string-html":110}],240:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_string-at")(!1);r(r.P,"String",{codePointAt:function(e){return o(this,e)}})},{"./_export":35,"./_string-at":108}],241:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-length"),a=e("./_string-context"),i="".endsWith;r(r.P+r.F*e("./_fails-is-regexp")("endsWith"),"String",{endsWith:function(e){var t=a(this,e,"endsWith"),n=arguments.length>1?arguments[1]:void 0,r=o(t.length),s=void 0===n?r:Math.min(o(n),r),l=String(e);return i?i.call(t,l,s):t.slice(s-l.length,s)===l}})},{"./_export":35,"./_fails-is-regexp":36,"./_string-context":109,"./_to-length":120}],242:[function(e,t,n){"use strict";e("./_string-html")("fixed",function(e){return function(){return e(this,"tt","","")}})},{"./_string-html":110}],243:[function(e,t,n){"use strict";e("./_string-html")("fontcolor",function(e){return function(t){return e(this,"font","color",t)}})},{"./_string-html":110}],244:[function(e,t,n){"use strict";e("./_string-html")("fontsize",function(e){return function(t){return e(this,"font","size",t)}})},{"./_string-html":110}],245:[function(e,t,n){var r=e("./_export"),o=e("./_to-absolute-index"),a=String.fromCharCode,i=String.fromCodePoint;r(r.S+r.F*(!!i&&1!=i.length),"String",{fromCodePoint:function(e){for(var t,n=[],r=arguments.length,i=0;r>i;){if(t=+arguments[i++],o(t,1114111)!==t)throw RangeError(t+" is not a valid code point");n.push(t<65536?a(t):a(55296+((t-=65536)>>10),t%1024+56320))}return n.join("")}})},{"./_export":35,"./_to-absolute-index":116}],246:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_string-context");r(r.P+r.F*e("./_fails-is-regexp")("includes"),"String",{includes:function(e){return!!~o(this,e,"includes").indexOf(e,arguments.length>1?arguments[1]:void 0)}})},{"./_export":35,"./_fails-is-regexp":36,"./_string-context":109}],247:[function(e,t,n){"use strict";e("./_string-html")("italics",function(e){return function(){return e(this,"i","","")}})},{"./_string-html":110}],248:[function(e,t,n){"use strict";var r=e("./_string-at")(!0);e("./_iter-define")(String,"String",function(e){this._t=String(e),this._i=0},function(){var e,t=this._t,n=this._i;return n>=t.length?{value:void 0,done:!0}:(e=r(t,n),this._i+=e.length,{value:e,done:!1})})},{"./_iter-define":58,"./_string-at":108}],249:[function(e,t,n){"use strict";e("./_string-html")("link",function(e){return function(t){return e(this,"a","href",t)}})},{"./_string-html":110}],250:[function(e,t,n){var r=e("./_export"),o=e("./_to-iobject"),a=e("./_to-length");r(r.S,"String",{raw:function(e){for(var t=o(e.raw),n=a(t.length),r=arguments.length,i=[],s=0;n>s;)i.push(String(t[s++])),s<r&&i.push(String(arguments[s]));return i.join("")}})},{"./_export":35,"./_to-iobject":119,"./_to-length":120}],251:[function(e,t,n){var r=e("./_export");r(r.P,"String",{repeat:e("./_string-repeat")})},{"./_export":35,"./_string-repeat":112}],252:[function(e,t,n){"use strict";e("./_string-html")("small",function(e){return function(){return e(this,"small","","")}})},{"./_string-html":110}],253:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-length"),a=e("./_string-context"),i="".startsWith;r(r.P+r.F*e("./_fails-is-regexp")("startsWith"),"String",{startsWith:function(e){var t=a(this,e,"startsWith"),n=o(Math.min(arguments.length>1?arguments[1]:void 0,t.length)),r=String(e);return i?i.call(t,r,n):t.slice(n,n+r.length)===r}})},{"./_export":35,"./_fails-is-regexp":36,"./_string-context":109,"./_to-length":120}],254:[function(e,t,n){"use strict";e("./_string-html")("strike",function(e){return function(){return e(this,"strike","","")}})},{"./_string-html":110}],255:[function(e,t,n){"use strict";e("./_string-html")("sub",function(e){return function(){return e(this,"sub","","")}})},{"./_string-html":110}],256:[function(e,t,n){"use strict";e("./_string-html")("sup",function(e){return function(){return e(this,"sup","","")}})},{"./_string-html":110}],257:[function(e,t,n){"use strict";e("./_string-trim")("trim",function(e){return function(){return e(this,3)}})},{"./_string-trim":113}],258:[function(e,t,n){"use strict";var r=e("./_global"),o=e("./_has"),a=e("./_descriptors"),i=e("./_export"),s=e("./_redefine"),l=e("./_meta").KEY,u=e("./_fails"),c=e("./_shared"),f=e("./_set-to-string-tag"),p=e("./_uid"),d=e("./_wks"),v=e("./_wks-ext"),y=e("./_wks-define"),_=e("./_enum-keys"),h=e("./_is-array"),m=e("./_an-object"),g=e("./_is-object"),b=e("./_to-iobject"),x=e("./_to-primitive"),w=e("./_property-desc"),j=e("./_object-create"),A=e("./_object-gopn-ext"),S=e("./_object-gopd"),k=e("./_object-dp"),E=e("./_object-keys"),I=S.f,C=k.f,O=A.f,P=r.Symbol,L=r.JSON,M=L&&L.stringify,T=d("_hidden"),R=d("toPrimitive"),N={}.propertyIsEnumerable,D=c("symbol-registry"),F=c("symbols"),H=c("op-symbols"),G=Object.prototype,U="function"==typeof P,W=r.QObject,B=!W||!W.prototype||!W.prototype.findChild,Y=a&&u(function(){return 7!=j(C({},"a",{get:function(){return C(this,"a",{value:7}).a}})).a})?function(e,t,n){var r=I(G,t);r&&delete G[t],C(e,t,n),r&&e!==G&&C(G,t,r)}:C,z=function(e){var t=F[e]=j(P.prototype);return t._k=e,t},q=U&&"symbol"==typeof P.iterator?function(e){return"symbol"==typeof e}:function(e){return e instanceof P},X=function(e,t,n){return e===G&&X(H,t,n),m(e),t=x(t,!0),m(n),o(F,t)?(n.enumerable?(o(e,T)&&e[T][t]&&(e[T][t]=!1),n=j(n,{enumerable:w(0,!1)})):(o(e,T)||C(e,T,w(1,{})),e[T][t]=!0),Y(e,t,n)):C(e,t,n)},V=function(e,t){m(e);for(var n,r=_(t=b(t)),o=0,a=r.length;a>o;)X(e,n=r[o++],t[n]);return e},K=function(e,t){return void 0===t?j(e):V(j(e),t)},Q=function(e){var t=N.call(this,e=x(e,!0));return!(this===G&&o(F,e)&&!o(H,e))&&(!(t||!o(this,e)||!o(F,e)||o(this,T)&&this[T][e])||t)},J=function(e,t){if(e=b(e),t=x(t,!0),e!==G||!o(F,t)||o(H,t)){var n=I(e,t);return!n||!o(F,t)||o(e,T)&&e[T][t]||(n.enumerable=!0),n}},Z=function(e){for(var t,n=O(b(e)),r=[],a=0;n.length>a;)o(F,t=n[a++])||t==T||t==l||r.push(t);return r},$=function(e){for(var t,n=e===G,r=O(n?H:b(e)),a=[],i=0;r.length>i;)!o(F,t=r[i++])||n&&!o(G,t)||a.push(F[t]);return a};U||(P=function(){if(this instanceof P)throw TypeError("Symbol is not a constructor!");var e=p(arguments.length>0?arguments[0]:void 0),t=function(n){this===G&&t.call(H,n),o(this,T)&&o(this[T],e)&&(this[T][e]=!1),Y(this,e,w(1,n))};return a&&B&&Y(G,e,{configurable:!0,set:t}),z(e)},s(P.prototype,"toString",function(){return this._k}),S.f=J,k.f=X,e("./_object-gopn").f=A.f=Z,e("./_object-pie").f=Q,e("./_object-gops").f=$,a&&!e("./_library")&&s(G,"propertyIsEnumerable",Q,!0),v.f=function(e){return z(d(e))}),i(i.G+i.W+i.F*!U,{Symbol:P});for(var ee="hasInstance,isConcatSpreadable,iterator,match,replace,search,species,split,toPrimitive,toStringTag,unscopables".split(","),te=0;ee.length>te;)d(ee[te++]);for(var ne=E(d.store),re=0;ne.length>re;)y(ne[re++]);i(i.S+i.F*!U,"Symbol",{for:function(e){return o(D,e+="")?D[e]:D[e]=P(e)},keyFor:function(e){if(!q(e))throw TypeError(e+" is not a symbol!");for(var t in D)if(D[t]===e)return t},useSetter:function(){B=!0},useSimple:function(){B=!1}}),i(i.S+i.F*!U,"Object",{create:K,defineProperty:X,defineProperties:V,getOwnPropertyDescriptor:J,getOwnPropertyNames:Z,getOwnPropertySymbols:$}),L&&i(i.S+i.F*(!U||u(function(){var e=P();return"[null]"!=M([e])||"{}"!=M({a:e})||"{}"!=M(Object(e))})),"JSON",{stringify:function(e){for(var t,n,r=[e],o=1;arguments.length>o;)r.push(arguments[o++]);if(n=t=r[1],(g(t)||void 0!==e)&&!q(e))return h(t)||(t=function(e,t){if("function"==typeof n&&(t=n.call(this,e,t)),!q(t))return t}),r[1]=t,M.apply(L,r)}}),P.prototype[R]||e("./_hide")(P.prototype,R,P.prototype.valueOf),f(P,"Symbol"),f(Math,"Math",!0),f(r.JSON,"JSON",!0)},{"./_an-object":9,"./_descriptors":31,"./_enum-keys":34,"./_export":35,"./_fails":37,"./_global":43,"./_has":44,"./_hide":45,"./_is-array":52,"./_is-object":54,"./_library":62,"./_meta":68,"./_object-create":73,"./_object-dp":74,"./_object-gopd":77,"./_object-gopn":79,"./_object-gopn-ext":78,"./_object-gops":80,"./_object-keys":83,"./_object-pie":84,"./_property-desc":92,"./_redefine":94,"./_set-to-string-tag":103,"./_shared":105,
+         "./_to-iobject":119,"./_to-primitive":122,"./_uid":126,"./_wks":131,"./_wks-define":129,"./_wks-ext":130}],259:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_typed"),a=e("./_typed-buffer"),i=e("./_an-object"),s=e("./_to-absolute-index"),l=e("./_to-length"),u=e("./_is-object"),c=e("./_global").ArrayBuffer,f=e("./_species-constructor"),p=a.ArrayBuffer,d=a.DataView,v=o.ABV&&c.isView,y=p.prototype.slice,_=o.VIEW;r(r.G+r.W+r.F*(c!==p),{ArrayBuffer:p}),r(r.S+r.F*!o.CONSTR,"ArrayBuffer",{isView:function(e){return v&&v(e)||u(e)&&_ in e}}),r(r.P+r.U+r.F*e("./_fails")(function(){return!new p(2).slice(1,void 0).byteLength}),"ArrayBuffer",{slice:function(e,t){if(void 0!==y&&void 0===t)return y.call(i(this),e);for(var n=i(this).byteLength,r=s(e,n),o=s(void 0===t?n:t,n),a=new(f(this,p))(l(o-r)),u=new d(this),c=new d(a),v=0;r<o;)c.setUint8(v++,u.getUint8(r++));return a}}),e("./_set-species")("ArrayBuffer")},{"./_an-object":9,"./_export":35,"./_fails":37,"./_global":43,"./_is-object":54,"./_set-species":102,"./_species-constructor":106,"./_to-absolute-index":116,"./_to-length":120,"./_typed":125,"./_typed-buffer":124}],260:[function(e,t,n){var r=e("./_export");r(r.G+r.W+r.F*!e("./_typed").ABV,{DataView:e("./_typed-buffer").DataView})},{"./_export":35,"./_typed":125,"./_typed-buffer":124}],261:[function(e,t,n){e("./_typed-array")("Float32",4,function(e){return function(t,n,r){return e(this,t,n,r)}})},{"./_typed-array":123}],262:[function(e,t,n){e("./_typed-array")("Float64",8,function(e){return function(t,n,r){return e(this,t,n,r)}})},{"./_typed-array":123}],263:[function(e,t,n){e("./_typed-array")("Int16",2,function(e){return function(t,n,r){return e(this,t,n,r)}})},{"./_typed-array":123}],264:[function(e,t,n){e("./_typed-array")("Int32",4,function(e){return function(t,n,r){return e(this,t,n,r)}})},{"./_typed-array":123}],265:[function(e,t,n){e("./_typed-array")("Int8",1,function(e){return function(t,n,r){return e(this,t,n,r)}})},{"./_typed-array":123}],266:[function(e,t,n){e("./_typed-array")("Uint16",2,function(e){return function(t,n,r){return e(this,t,n,r)}})},{"./_typed-array":123}],267:[function(e,t,n){e("./_typed-array")("Uint32",4,function(e){return function(t,n,r){return e(this,t,n,r)}})},{"./_typed-array":123}],268:[function(e,t,n){e("./_typed-array")("Uint8",1,function(e){return function(t,n,r){return e(this,t,n,r)}})},{"./_typed-array":123}],269:[function(e,t,n){e("./_typed-array")("Uint8",1,function(e){return function(t,n,r){return e(this,t,n,r)}},!0)},{"./_typed-array":123}],270:[function(e,t,n){"use strict";var r,o=e("./_global"),a=e("./_array-methods")(0),i=e("./_redefine"),s=e("./_meta"),l=e("./_object-assign"),u=e("./_collection-weak"),c=e("./_is-object"),f=e("./_validate-collection"),p=e("./_validate-collection"),d=!o.ActiveXObject&&"ActiveXObject"in o,v=s.getWeak,y=Object.isExtensible,_=u.ufstore,h=function(e){return function(){return e(this,arguments.length>0?arguments[0]:void 0)}},m={get:function(e){if(c(e)){var t=v(e);return!0===t?_(f(this,"WeakMap")).get(e):t?t[this._i]:void 0}},set:function(e,t){return u.def(f(this,"WeakMap"),e,t)}},g=t.exports=e("./_collection")("WeakMap",h,m,u,!0,!0);p&&d&&(r=u.getConstructor(h,"WeakMap"),l(r.prototype,m),s.NEED=!0,a(["delete","has","get","set"],function(e){var t=g.prototype,n=t[e];i(t,e,function(t,o){if(c(t)&&!y(t)){this._f||(this._f=new r);var a=this._f[e](t,o);return"set"==e?this:a}return n.call(this,t,o)})}))},{"./_array-methods":14,"./_collection":24,"./_collection-weak":23,"./_global":43,"./_is-object":54,"./_meta":68,"./_object-assign":72,"./_redefine":94,"./_validate-collection":128}],271:[function(e,t,n){"use strict";var r=e("./_collection-weak"),o=e("./_validate-collection");e("./_collection")("WeakSet",function(e){return function(){return e(this,arguments.length>0?arguments[0]:void 0)}},{add:function(e){return r.def(o(this,"WeakSet"),e,!0)}},r,!1,!0)},{"./_collection":24,"./_collection-weak":23,"./_validate-collection":128}],272:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_flatten-into-array"),a=e("./_to-object"),i=e("./_to-length"),s=e("./_a-function"),l=e("./_array-species-create");r(r.P,"Array",{flatMap:function(e){var t,n,r=a(this);return s(e),t=i(r.length),n=l(r,0),o(n,r,r,t,0,1,e,arguments[1]),n}}),e("./_add-to-unscopables")("flatMap")},{"./_a-function":4,"./_add-to-unscopables":6,"./_array-species-create":17,"./_export":35,"./_flatten-into-array":40,"./_to-length":120,"./_to-object":121}],273:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_flatten-into-array"),a=e("./_to-object"),i=e("./_to-length"),s=e("./_to-integer"),l=e("./_array-species-create");r(r.P,"Array",{flatten:function(){var e=arguments[0],t=a(this),n=i(t.length),r=l(t,0);return o(r,t,t,n,0,void 0===e?1:s(e)),r}}),e("./_add-to-unscopables")("flatten")},{"./_add-to-unscopables":6,"./_array-species-create":17,"./_export":35,"./_flatten-into-array":40,"./_to-integer":118,"./_to-length":120,"./_to-object":121}],274:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-includes")(!0);r(r.P,"Array",{includes:function(e){return o(this,e,arguments.length>1?arguments[1]:void 0)}}),e("./_add-to-unscopables")("includes")},{"./_add-to-unscopables":6,"./_array-includes":13,"./_export":35}],275:[function(e,t,n){var r=e("./_export"),o=e("./_microtask")(),a=e("./_global").process,i="process"==e("./_cof")(a);r(r.G,{asap:function(e){var t=i&&a.domain;o(t?t.bind(e):e)}})},{"./_cof":20,"./_export":35,"./_global":43,"./_microtask":70}],276:[function(e,t,n){var r=e("./_export"),o=e("./_cof");r(r.S,"Error",{isError:function(e){return"Error"===o(e)}})},{"./_cof":20,"./_export":35}],277:[function(e,t,n){var r=e("./_export");r(r.G,{global:e("./_global")})},{"./_export":35,"./_global":43}],278:[function(e,t,n){e("./_set-collection-from")("Map")},{"./_set-collection-from":99}],279:[function(e,t,n){e("./_set-collection-of")("Map")},{"./_set-collection-of":100}],280:[function(e,t,n){var r=e("./_export");r(r.P+r.R,"Map",{toJSON:e("./_collection-to-json")("Map")})},{"./_collection-to-json":22,"./_export":35}],281:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{clamp:function(e,t,n){return Math.min(n,Math.max(t,e))}})},{"./_export":35}],282:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{DEG_PER_RAD:Math.PI/180})},{"./_export":35}],283:[function(e,t,n){var r=e("./_export"),o=180/Math.PI;r(r.S,"Math",{degrees:function(e){return e*o}})},{"./_export":35}],284:[function(e,t,n){var r=e("./_export"),o=e("./_math-scale"),a=e("./_math-fround");r(r.S,"Math",{fscale:function(e,t,n,r,i){return a(o(e,t,n,r,i))}})},{"./_export":35,"./_math-fround":64,"./_math-scale":66}],285:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{iaddh:function(e,t,n,r){var o=e>>>0,a=t>>>0,i=n>>>0;return a+(r>>>0)+((o&i|(o|i)&~(o+i>>>0))>>>31)|0}})},{"./_export":35}],286:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{imulh:function(e,t){var n=+e,r=+t,o=65535&n,a=65535&r,i=n>>16,s=r>>16,l=(i*a>>>0)+(o*a>>>16);return i*s+(l>>16)+((o*s>>>0)+(65535&l)>>16)}})},{"./_export":35}],287:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{isubh:function(e,t,n,r){var o=e>>>0,a=t>>>0,i=n>>>0;return a-(r>>>0)-((~o&i|~(o^i)&o-i>>>0)>>>31)|0}})},{"./_export":35}],288:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{RAD_PER_DEG:180/Math.PI})},{"./_export":35}],289:[function(e,t,n){var r=e("./_export"),o=Math.PI/180;r(r.S,"Math",{radians:function(e){return e*o}})},{"./_export":35}],290:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{scale:e("./_math-scale")})},{"./_export":35,"./_math-scale":66}],291:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{signbit:function(e){return(e=+e)!=e?e:0==e?1/e==1/0:e>0}})},{"./_export":35}],292:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{umulh:function(e,t){var n=+e,r=+t,o=65535&n,a=65535&r,i=n>>>16,s=r>>>16,l=(i*a>>>0)+(o*a>>>16);return i*s+(l>>>16)+((o*s>>>0)+(65535&l)>>>16)}})},{"./_export":35}],293:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-object"),a=e("./_a-function"),i=e("./_object-dp");e("./_descriptors")&&r(r.P+e("./_object-forced-pam"),"Object",{__defineGetter__:function(e,t){i.f(o(this),e,{get:a(t),enumerable:!0,configurable:!0})}})},{"./_a-function":4,"./_descriptors":31,"./_export":35,"./_object-dp":74,"./_object-forced-pam":76,"./_to-object":121}],294:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-object"),a=e("./_a-function"),i=e("./_object-dp");e("./_descriptors")&&r(r.P+e("./_object-forced-pam"),"Object",{__defineSetter__:function(e,t){i.f(o(this),e,{set:a(t),enumerable:!0,configurable:!0})}})},{"./_a-function":4,"./_descriptors":31,"./_export":35,"./_object-dp":74,"./_object-forced-pam":76,"./_to-object":121}],295:[function(e,t,n){var r=e("./_export"),o=e("./_object-to-array")(!0);r(r.S,"Object",{entries:function(e){return o(e)}})},{"./_export":35,"./_object-to-array":86}],296:[function(e,t,n){var r=e("./_export"),o=e("./_own-keys"),a=e("./_to-iobject"),i=e("./_object-gopd"),s=e("./_create-property");r(r.S,"Object",{getOwnPropertyDescriptors:function(e){for(var t,n,r=a(e),l=i.f,u=o(r),c={},f=0;u.length>f;)void 0!==(n=l(r,t=u[f++]))&&s(c,t,n);return c}})},{"./_create-property":26,"./_export":35,"./_object-gopd":77,"./_own-keys":87,"./_to-iobject":119}],297:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-object"),a=e("./_to-primitive"),i=e("./_object-gpo"),s=e("./_object-gopd").f;e("./_descriptors")&&r(r.P+e("./_object-forced-pam"),"Object",{__lookupGetter__:function(e){var t,n=o(this),r=a(e,!0);do{if(t=s(n,r))return t.get}while(n=i(n))}})},{"./_descriptors":31,"./_export":35,"./_object-forced-pam":76,"./_object-gopd":77,"./_object-gpo":81,"./_to-object":121,"./_to-primitive":122}],298:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-object"),a=e("./_to-primitive"),i=e("./_object-gpo"),s=e("./_object-gopd").f;e("./_descriptors")&&r(r.P+e("./_object-forced-pam"),"Object",{__lookupSetter__:function(e){var t,n=o(this),r=a(e,!0);do{if(t=s(n,r))return t.set}while(n=i(n))}})},{"./_descriptors":31,"./_export":35,"./_object-forced-pam":76,"./_object-gopd":77,"./_object-gpo":81,"./_to-object":121,"./_to-primitive":122}],299:[function(e,t,n){var r=e("./_export"),o=e("./_object-to-array")(!1);r(r.S,"Object",{values:function(e){return o(e)}})},{"./_export":35,"./_object-to-array":86}],300:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_global"),a=e("./_core"),i=e("./_microtask")(),s=e("./_wks")("observable"),l=e("./_a-function"),u=e("./_an-object"),c=e("./_an-instance"),f=e("./_redefine-all"),p=e("./_hide"),d=e("./_for-of"),v=d.RETURN,y=function(e){return null==e?void 0:l(e)},_=function(e){var t=e._c;t&&(e._c=void 0,t())},h=function(e){return void 0===e._o},m=function(e){h(e)||(e._o=void 0,_(e))},g=function(e,t){u(e),this._c=void 0,this._o=e,e=new b(this);try{var n=t(e),r=n;null!=n&&("function"==typeof n.unsubscribe?n=function(){r.unsubscribe()}:l(n),this._c=n)}catch(t){return void e.error(t)}h(this)&&_(this)};g.prototype=f({},{unsubscribe:function(){m(this)}});var b=function(e){this._s=e};b.prototype=f({},{next:function(e){var t=this._s;if(!h(t)){var n=t._o;try{var r=y(n.next);if(r)return r.call(n,e)}catch(e){try{m(t)}finally{throw e}}}},error:function(e){var t=this._s;if(h(t))throw e;var n=t._o;t._o=void 0;try{var r=y(n.error);if(!r)throw e;e=r.call(n,e)}catch(e){try{_(t)}finally{throw e}}return _(t),e},complete:function(e){var t=this._s;if(!h(t)){var n=t._o;t._o=void 0;try{var r=y(n.complete);e=r?r.call(n,e):void 0}catch(e){try{_(t)}finally{throw e}}return _(t),e}}});var x=function(e){c(this,x,"Observable","_f")._f=l(e)};f(x.prototype,{subscribe:function(e){return new g(e,this._f)},forEach:function(e){var t=this;return new(a.Promise||o.Promise)(function(n,r){l(e);var o=t.subscribe({next:function(t){try{return e(t)}catch(e){r(e),o.unsubscribe()}},error:r,complete:n})})}}),f(x,{from:function(e){var t="function"==typeof this?this:x,n=y(u(e)[s]);if(n){var r=u(n.call(e));return r.constructor===t?r:new t(function(e){return r.subscribe(e)})}return new t(function(t){var n=!1;return i(function(){if(!n){try{if(d(e,!1,function(e){if(t.next(e),n)return v})===v)return}catch(e){if(n)throw e;return void t.error(e)}t.complete()}}),function(){n=!0}})},of:function(){for(var e=0,t=arguments.length,n=new Array(t);e<t;)n[e]=arguments[e++];return new("function"==typeof this?this:x)(function(e){var t=!1;return i(function(){if(!t){for(var r=0;r<n.length;++r)if(e.next(n[r]),t)return;e.complete()}}),function(){t=!0}})}}),p(x.prototype,s,function(){return this}),r(r.G,{Observable:x}),e("./_set-species")("Observable")},{"./_a-function":4,"./_an-instance":8,"./_an-object":9,"./_core":25,"./_export":35,"./_for-of":41,"./_global":43,"./_hide":45,"./_microtask":70,"./_redefine-all":93,"./_set-species":102,"./_wks":131}],301:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_core"),a=e("./_global"),i=e("./_species-constructor"),s=e("./_promise-resolve");r(r.P+r.R,"Promise",{finally:function(e){var t=i(this,o.Promise||a.Promise),n="function"==typeof e;return this.then(n?function(n){return s(t,e()).then(function(){return n})}:e,n?function(n){return s(t,e()).then(function(){throw n})}:e)}})},{"./_core":25,"./_export":35,"./_global":43,"./_promise-resolve":91,"./_species-constructor":106}],302:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_new-promise-capability"),a=e("./_perform");r(r.S,"Promise",{try:function(e){var t=o.f(this),n=a(e);return(n.e?t.reject:t.resolve)(n.v),t.promise}})},{"./_export":35,"./_new-promise-capability":71,"./_perform":90}],303:[function(e,t,n){var r=e("./_metadata"),o=e("./_an-object"),a=r.key,i=r.set;r.exp({defineMetadata:function(e,t,n,r){i(e,t,o(n),a(r))}})},{"./_an-object":9,"./_metadata":69}],304:[function(e,t,n){var r=e("./_metadata"),o=e("./_an-object"),a=r.key,i=r.map,s=r.store;r.exp({deleteMetadata:function(e,t){var n=arguments.length<3?void 0:a(arguments[2]),r=i(o(t),n,!1);if(void 0===r||!r.delete(e))return!1;if(r.size)return!0;var l=s.get(t);return l.delete(n),!!l.size||s.delete(t)}})},{"./_an-object":9,"./_metadata":69}],305:[function(e,t,n){var r=e("./es6.set"),o=e("./_array-from-iterable"),a=e("./_metadata"),i=e("./_an-object"),s=e("./_object-gpo"),l=a.keys,u=a.key,c=function(e,t){var n=l(e,t),a=s(e);if(null===a)return n;var i=c(a,t);return i.length?n.length?o(new r(n.concat(i))):i:n};a.exp({getMetadataKeys:function(e){return c(i(e),arguments.length<2?void 0:u(arguments[1]))}})},{"./_an-object":9,"./_array-from-iterable":12,"./_metadata":69,"./_object-gpo":81,"./es6.set":235}],306:[function(e,t,n){var r=e("./_metadata"),o=e("./_an-object"),a=e("./_object-gpo"),i=r.has,s=r.get,l=r.key,u=function(e,t,n){if(i(e,t,n))return s(e,t,n);var r=a(t);return null!==r?u(e,r,n):void 0};r.exp({getMetadata:function(e,t){return u(e,o(t),arguments.length<3?void 0:l(arguments[2]))}})},{"./_an-object":9,"./_metadata":69,"./_object-gpo":81}],307:[function(e,t,n){var r=e("./_metadata"),o=e("./_an-object"),a=r.keys,i=r.key;r.exp({getOwnMetadataKeys:function(e){
+         return a(o(e),arguments.length<2?void 0:i(arguments[1]))}})},{"./_an-object":9,"./_metadata":69}],308:[function(e,t,n){var r=e("./_metadata"),o=e("./_an-object"),a=r.get,i=r.key;r.exp({getOwnMetadata:function(e,t){return a(e,o(t),arguments.length<3?void 0:i(arguments[2]))}})},{"./_an-object":9,"./_metadata":69}],309:[function(e,t,n){var r=e("./_metadata"),o=e("./_an-object"),a=e("./_object-gpo"),i=r.has,s=r.key,l=function(e,t,n){if(i(e,t,n))return!0;var r=a(t);return null!==r&&l(e,r,n)};r.exp({hasMetadata:function(e,t){return l(e,o(t),arguments.length<3?void 0:s(arguments[2]))}})},{"./_an-object":9,"./_metadata":69,"./_object-gpo":81}],310:[function(e,t,n){var r=e("./_metadata"),o=e("./_an-object"),a=r.has,i=r.key;r.exp({hasOwnMetadata:function(e,t){return a(e,o(t),arguments.length<3?void 0:i(arguments[2]))}})},{"./_an-object":9,"./_metadata":69}],311:[function(e,t,n){var r=e("./_metadata"),o=e("./_an-object"),a=e("./_a-function"),i=r.key,s=r.set;r.exp({metadata:function(e,t){return function(n,r){s(e,t,(void 0!==r?o:a)(n),i(r))}}})},{"./_a-function":4,"./_an-object":9,"./_metadata":69}],312:[function(e,t,n){e("./_set-collection-from")("Set")},{"./_set-collection-from":99}],313:[function(e,t,n){e("./_set-collection-of")("Set")},{"./_set-collection-of":100}],314:[function(e,t,n){var r=e("./_export");r(r.P+r.R,"Set",{toJSON:e("./_collection-to-json")("Set")})},{"./_collection-to-json":22,"./_export":35}],315:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_string-at")(!0);r(r.P,"String",{at:function(e){return o(this,e)}})},{"./_export":35,"./_string-at":108}],316:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_defined"),a=e("./_to-length"),i=e("./_is-regexp"),s=e("./_flags"),l=RegExp.prototype,u=function(e,t){this._r=e,this._s=t};e("./_iter-create")(u,"RegExp String",function(){var e=this._r.exec(this._s);return{value:e,done:null===e}}),r(r.P,"String",{matchAll:function(e){if(o(this),!i(e))throw TypeError(e+" is not a regexp!");var t=String(this),n="flags"in l?String(e.flags):s.call(e),r=new RegExp(e.source,~n.indexOf("g")?n:"g"+n);return r.lastIndex=a(e.lastIndex),new u(r,t)}})},{"./_defined":30,"./_export":35,"./_flags":39,"./_is-regexp":55,"./_iter-create":57,"./_to-length":120}],317:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_string-pad"),a=e("./_user-agent"),i=/Version\/10\.\d+(\.\d+)?( Mobile\/\w+)? Safari\//.test(a);r(r.P+r.F*i,"String",{padEnd:function(e){return o(this,e,arguments.length>1?arguments[1]:void 0,!1)}})},{"./_export":35,"./_string-pad":111,"./_user-agent":127}],318:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_string-pad"),a=e("./_user-agent"),i=/Version\/10\.\d+(\.\d+)?( Mobile\/\w+)? Safari\//.test(a);r(r.P+r.F*i,"String",{padStart:function(e){return o(this,e,arguments.length>1?arguments[1]:void 0,!0)}})},{"./_export":35,"./_string-pad":111,"./_user-agent":127}],319:[function(e,t,n){"use strict";e("./_string-trim")("trimLeft",function(e){return function(){return e(this,1)}},"trimStart")},{"./_string-trim":113}],320:[function(e,t,n){"use strict";e("./_string-trim")("trimRight",function(e){return function(){return e(this,2)}},"trimEnd")},{"./_string-trim":113}],321:[function(e,t,n){e("./_wks-define")("asyncIterator")},{"./_wks-define":129}],322:[function(e,t,n){e("./_wks-define")("observable")},{"./_wks-define":129}],323:[function(e,t,n){var r=e("./_export");r(r.S,"System",{global:e("./_global")})},{"./_export":35,"./_global":43}],324:[function(e,t,n){e("./_set-collection-from")("WeakMap")},{"./_set-collection-from":99}],325:[function(e,t,n){e("./_set-collection-of")("WeakMap")},{"./_set-collection-of":100}],326:[function(e,t,n){e("./_set-collection-from")("WeakSet")},{"./_set-collection-from":99}],327:[function(e,t,n){e("./_set-collection-of")("WeakSet")},{"./_set-collection-of":100}],328:[function(e,t,n){for(var r=e("./es6.array.iterator"),o=e("./_object-keys"),a=e("./_redefine"),i=e("./_global"),s=e("./_hide"),l=e("./_iterators"),u=e("./_wks"),c=u("iterator"),f=u("toStringTag"),p=l.Array,d={CSSRuleList:!0,CSSStyleDeclaration:!1,CSSValueList:!1,ClientRectList:!1,DOMRectList:!1,DOMStringList:!1,DOMTokenList:!0,DataTransferItemList:!1,FileList:!1,HTMLAllCollection:!1,HTMLCollection:!1,HTMLFormElement:!1,HTMLSelectElement:!1,MediaList:!0,MimeTypeArray:!1,NamedNodeMap:!1,NodeList:!0,PaintRequestList:!1,Plugin:!1,PluginArray:!1,SVGLengthList:!1,SVGNumberList:!1,SVGPathSegList:!1,SVGPointList:!1,SVGStringList:!1,SVGTransformList:!1,SourceBufferList:!1,StyleSheetList:!0,TextTrackCueList:!1,TextTrackList:!1,TouchList:!1},v=o(d),y=0;y<v.length;y++){var _,h=v[y],m=d[h],g=i[h],b=g&&g.prototype;if(b&&(b[c]||s(b,c,p),b[f]||s(b,f,h),l[h]=p,m))for(_ in r)b[_]||a(b,_,r[_],!0)}},{"./_global":43,"./_hide":45,"./_iterators":61,"./_object-keys":83,"./_redefine":94,"./_wks":131,"./es6.array.iterator":144}],329:[function(e,t,n){var r=e("./_export"),o=e("./_task");r(r.G+r.B,{setImmediate:o.set,clearImmediate:o.clear})},{"./_export":35,"./_task":115}],330:[function(e,t,n){var r=e("./_global"),o=e("./_export"),a=e("./_user-agent"),i=[].slice,s=/MSIE .\./.test(a),l=function(e){return function(t,n){var r=arguments.length>2,o=!!r&&i.call(arguments,2);return e(r?function(){("function"==typeof t?t:Function(t)).apply(this,o)}:t,n)}};o(o.G+o.B+o.F*s,{setTimeout:l(r.setTimeout),setInterval:l(r.setInterval)})},{"./_export":35,"./_global":43,"./_user-agent":127}],331:[function(e,t,n){e("./modules/es6.symbol"),e("./modules/es6.object.create"),e("./modules/es6.object.define-property"),e("./modules/es6.object.define-properties"),e("./modules/es6.object.get-own-property-descriptor"),e("./modules/es6.object.get-prototype-of"),e("./modules/es6.object.keys"),e("./modules/es6.object.get-own-property-names"),e("./modules/es6.object.freeze"),e("./modules/es6.object.seal"),e("./modules/es6.object.prevent-extensions"),e("./modules/es6.object.is-frozen"),e("./modules/es6.object.is-sealed"),e("./modules/es6.object.is-extensible"),e("./modules/es6.object.assign"),e("./modules/es6.object.is"),e("./modules/es6.object.set-prototype-of"),e("./modules/es6.object.to-string"),e("./modules/es6.function.bind"),e("./modules/es6.function.name"),e("./modules/es6.function.has-instance"),e("./modules/es6.parse-int"),e("./modules/es6.parse-float"),e("./modules/es6.number.constructor"),e("./modules/es6.number.to-fixed"),e("./modules/es6.number.to-precision"),e("./modules/es6.number.epsilon"),e("./modules/es6.number.is-finite"),e("./modules/es6.number.is-integer"),e("./modules/es6.number.is-nan"),e("./modules/es6.number.is-safe-integer"),e("./modules/es6.number.max-safe-integer"),e("./modules/es6.number.min-safe-integer"),e("./modules/es6.number.parse-float"),e("./modules/es6.number.parse-int"),e("./modules/es6.math.acosh"),e("./modules/es6.math.asinh"),e("./modules/es6.math.atanh"),e("./modules/es6.math.cbrt"),e("./modules/es6.math.clz32"),e("./modules/es6.math.cosh"),e("./modules/es6.math.expm1"),e("./modules/es6.math.fround"),e("./modules/es6.math.hypot"),e("./modules/es6.math.imul"),e("./modules/es6.math.log10"),e("./modules/es6.math.log1p"),e("./modules/es6.math.log2"),e("./modules/es6.math.sign"),e("./modules/es6.math.sinh"),e("./modules/es6.math.tanh"),e("./modules/es6.math.trunc"),e("./modules/es6.string.from-code-point"),e("./modules/es6.string.raw"),e("./modules/es6.string.trim"),e("./modules/es6.string.iterator"),e("./modules/es6.string.code-point-at"),e("./modules/es6.string.ends-with"),e("./modules/es6.string.includes"),e("./modules/es6.string.repeat"),e("./modules/es6.string.starts-with"),e("./modules/es6.string.anchor"),e("./modules/es6.string.big"),e("./modules/es6.string.blink"),e("./modules/es6.string.bold"),e("./modules/es6.string.fixed"),e("./modules/es6.string.fontcolor"),e("./modules/es6.string.fontsize"),e("./modules/es6.string.italics"),e("./modules/es6.string.link"),e("./modules/es6.string.small"),e("./modules/es6.string.strike"),e("./modules/es6.string.sub"),e("./modules/es6.string.sup"),e("./modules/es6.date.now"),e("./modules/es6.date.to-json"),e("./modules/es6.date.to-iso-string"),e("./modules/es6.date.to-string"),e("./modules/es6.date.to-primitive"),e("./modules/es6.array.is-array"),e("./modules/es6.array.from"),e("./modules/es6.array.of"),e("./modules/es6.array.join"),e("./modules/es6.array.slice"),e("./modules/es6.array.sort"),e("./modules/es6.array.for-each"),e("./modules/es6.array.map"),e("./modules/es6.array.filter"),e("./modules/es6.array.some"),e("./modules/es6.array.every"),e("./modules/es6.array.reduce"),e("./modules/es6.array.reduce-right"),e("./modules/es6.array.index-of"),e("./modules/es6.array.last-index-of"),e("./modules/es6.array.copy-within"),e("./modules/es6.array.fill"),e("./modules/es6.array.find"),e("./modules/es6.array.find-index"),e("./modules/es6.array.species"),e("./modules/es6.array.iterator"),e("./modules/es6.regexp.constructor"),e("./modules/es6.regexp.exec"),e("./modules/es6.regexp.to-string"),e("./modules/es6.regexp.flags"),e("./modules/es6.regexp.match"),e("./modules/es6.regexp.replace"),e("./modules/es6.regexp.search"),e("./modules/es6.regexp.split"),e("./modules/es6.promise"),e("./modules/es6.map"),e("./modules/es6.set"),e("./modules/es6.weak-map"),e("./modules/es6.weak-set"),e("./modules/es6.typed.array-buffer"),e("./modules/es6.typed.data-view"),e("./modules/es6.typed.int8-array"),e("./modules/es6.typed.uint8-array"),e("./modules/es6.typed.uint8-clamped-array"),e("./modules/es6.typed.int16-array"),e("./modules/es6.typed.uint16-array"),e("./modules/es6.typed.int32-array"),e("./modules/es6.typed.uint32-array"),e("./modules/es6.typed.float32-array"),e("./modules/es6.typed.float64-array"),e("./modules/es6.reflect.apply"),e("./modules/es6.reflect.construct"),e("./modules/es6.reflect.define-property"),e("./modules/es6.reflect.delete-property"),e("./modules/es6.reflect.enumerate"),e("./modules/es6.reflect.get"),e("./modules/es6.reflect.get-own-property-descriptor"),e("./modules/es6.reflect.get-prototype-of"),e("./modules/es6.reflect.has"),e("./modules/es6.reflect.is-extensible"),e("./modules/es6.reflect.own-keys"),e("./modules/es6.reflect.prevent-extensions"),e("./modules/es6.reflect.set"),e("./modules/es6.reflect.set-prototype-of"),e("./modules/es7.array.includes"),e("./modules/es7.array.flat-map"),e("./modules/es7.array.flatten"),e("./modules/es7.string.at"),e("./modules/es7.string.pad-start"),e("./modules/es7.string.pad-end"),e("./modules/es7.string.trim-left"),e("./modules/es7.string.trim-right"),e("./modules/es7.string.match-all"),e("./modules/es7.symbol.async-iterator"),e("./modules/es7.symbol.observable"),e("./modules/es7.object.get-own-property-descriptors"),e("./modules/es7.object.values"),e("./modules/es7.object.entries"),e("./modules/es7.object.define-getter"),e("./modules/es7.object.define-setter"),e("./modules/es7.object.lookup-getter"),e("./modules/es7.object.lookup-setter"),e("./modules/es7.map.to-json"),e("./modules/es7.set.to-json"),e("./modules/es7.map.of"),e("./modules/es7.set.of"),e("./modules/es7.weak-map.of"),e("./modules/es7.weak-set.of"),e("./modules/es7.map.from"),e("./modules/es7.set.from"),e("./modules/es7.weak-map.from"),e("./modules/es7.weak-set.from"),e("./modules/es7.global"),e("./modules/es7.system.global"),e("./modules/es7.error.is-error"),e("./modules/es7.math.clamp"),e("./modules/es7.math.deg-per-rad"),e("./modules/es7.math.degrees"),e("./modules/es7.math.fscale"),e("./modules/es7.math.iaddh"),e("./modules/es7.math.isubh"),e("./modules/es7.math.imulh"),e("./modules/es7.math.rad-per-deg"),e("./modules/es7.math.radians"),e("./modules/es7.math.scale"),e("./modules/es7.math.umulh"),e("./modules/es7.math.signbit"),e("./modules/es7.promise.finally"),e("./modules/es7.promise.try"),e("./modules/es7.reflect.define-metadata"),e("./modules/es7.reflect.delete-metadata"),e("./modules/es7.reflect.get-metadata"),e("./modules/es7.reflect.get-metadata-keys"),e("./modules/es7.reflect.get-own-metadata"),e("./modules/es7.reflect.get-own-metadata-keys"),e("./modules/es7.reflect.has-metadata"),e("./modules/es7.reflect.has-own-metadata"),e("./modules/es7.reflect.metadata"),e("./modules/es7.asap"),e("./modules/es7.observable"),e("./modules/web.timers"),e("./modules/web.immediate"),e("./modules/web.dom.iterable"),t.exports=e("./modules/_core")},{"./modules/_core":25,"./modules/es6.array.copy-within":134,"./modules/es6.array.every":135,"./modules/es6.array.fill":136,"./modules/es6.array.filter":137,"./modules/es6.array.find":139,"./modules/es6.array.find-index":138,"./modules/es6.array.for-each":140,"./modules/es6.array.from":141,"./modules/es6.array.index-of":142,"./modules/es6.array.is-array":143,"./modules/es6.array.iterator":144,"./modules/es6.array.join":145,"./modules/es6.array.last-index-of":146,"./modules/es6.array.map":147,"./modules/es6.array.of":148,"./modules/es6.array.reduce":150,"./modules/es6.array.reduce-right":149,"./modules/es6.array.slice":151,"./modules/es6.array.some":152,"./modules/es6.array.sort":153,"./modules/es6.array.species":154,"./modules/es6.date.now":155,"./modules/es6.date.to-iso-string":156,"./modules/es6.date.to-json":157,"./modules/es6.date.to-primitive":158,"./modules/es6.date.to-string":159,"./modules/es6.function.bind":160,"./modules/es6.function.has-instance":161,"./modules/es6.function.name":162,"./modules/es6.map":163,"./modules/es6.math.acosh":164,"./modules/es6.math.asinh":165,"./modules/es6.math.atanh":166,"./modules/es6.math.cbrt":167,"./modules/es6.math.clz32":168,"./modules/es6.math.cosh":169,"./modules/es6.math.expm1":170,"./modules/es6.math.fround":171,"./modules/es6.math.hypot":172,"./modules/es6.math.imul":173,"./modules/es6.math.log10":174,"./modules/es6.math.log1p":175,"./modules/es6.math.log2":176,"./modules/es6.math.sign":177,"./modules/es6.math.sinh":178,"./modules/es6.math.tanh":179,"./modules/es6.math.trunc":180,"./modules/es6.number.constructor":181,"./modules/es6.number.epsilon":182,"./modules/es6.number.is-finite":183,"./modules/es6.number.is-integer":184,"./modules/es6.number.is-nan":185,"./modules/es6.number.is-safe-integer":186,"./modules/es6.number.max-safe-integer":187,"./modules/es6.number.min-safe-integer":188,"./modules/es6.number.parse-float":189,"./modules/es6.number.parse-int":190,"./modules/es6.number.to-fixed":191,"./modules/es6.number.to-precision":192,"./modules/es6.object.assign":193,"./modules/es6.object.create":194,"./modules/es6.object.define-properties":195,"./modules/es6.object.define-property":196,"./modules/es6.object.freeze":197,"./modules/es6.object.get-own-property-descriptor":198,"./modules/es6.object.get-own-property-names":199,"./modules/es6.object.get-prototype-of":200,"./modules/es6.object.is":204,"./modules/es6.object.is-extensible":201,"./modules/es6.object.is-frozen":202,"./modules/es6.object.is-sealed":203,"./modules/es6.object.keys":205,"./modules/es6.object.prevent-extensions":206,"./modules/es6.object.seal":207,"./modules/es6.object.set-prototype-of":208,"./modules/es6.object.to-string":209,"./modules/es6.parse-float":210,
+         "./modules/es6.parse-int":211,"./modules/es6.promise":212,"./modules/es6.reflect.apply":213,"./modules/es6.reflect.construct":214,"./modules/es6.reflect.define-property":215,"./modules/es6.reflect.delete-property":216,"./modules/es6.reflect.enumerate":217,"./modules/es6.reflect.get":220,"./modules/es6.reflect.get-own-property-descriptor":218,"./modules/es6.reflect.get-prototype-of":219,"./modules/es6.reflect.has":221,"./modules/es6.reflect.is-extensible":222,"./modules/es6.reflect.own-keys":223,"./modules/es6.reflect.prevent-extensions":224,"./modules/es6.reflect.set":226,"./modules/es6.reflect.set-prototype-of":225,"./modules/es6.regexp.constructor":227,"./modules/es6.regexp.exec":228,"./modules/es6.regexp.flags":229,"./modules/es6.regexp.match":230,"./modules/es6.regexp.replace":231,"./modules/es6.regexp.search":232,"./modules/es6.regexp.split":233,"./modules/es6.regexp.to-string":234,"./modules/es6.set":235,"./modules/es6.string.anchor":236,"./modules/es6.string.big":237,"./modules/es6.string.blink":238,"./modules/es6.string.bold":239,"./modules/es6.string.code-point-at":240,"./modules/es6.string.ends-with":241,"./modules/es6.string.fixed":242,"./modules/es6.string.fontcolor":243,"./modules/es6.string.fontsize":244,"./modules/es6.string.from-code-point":245,"./modules/es6.string.includes":246,"./modules/es6.string.italics":247,"./modules/es6.string.iterator":248,"./modules/es6.string.link":249,"./modules/es6.string.raw":250,"./modules/es6.string.repeat":251,"./modules/es6.string.small":252,"./modules/es6.string.starts-with":253,"./modules/es6.string.strike":254,"./modules/es6.string.sub":255,"./modules/es6.string.sup":256,"./modules/es6.string.trim":257,"./modules/es6.symbol":258,"./modules/es6.typed.array-buffer":259,"./modules/es6.typed.data-view":260,"./modules/es6.typed.float32-array":261,"./modules/es6.typed.float64-array":262,"./modules/es6.typed.int16-array":263,"./modules/es6.typed.int32-array":264,"./modules/es6.typed.int8-array":265,"./modules/es6.typed.uint16-array":266,"./modules/es6.typed.uint32-array":267,"./modules/es6.typed.uint8-array":268,"./modules/es6.typed.uint8-clamped-array":269,"./modules/es6.weak-map":270,"./modules/es6.weak-set":271,"./modules/es7.array.flat-map":272,"./modules/es7.array.flatten":273,"./modules/es7.array.includes":274,"./modules/es7.asap":275,"./modules/es7.error.is-error":276,"./modules/es7.global":277,"./modules/es7.map.from":278,"./modules/es7.map.of":279,"./modules/es7.map.to-json":280,"./modules/es7.math.clamp":281,"./modules/es7.math.deg-per-rad":282,"./modules/es7.math.degrees":283,"./modules/es7.math.fscale":284,"./modules/es7.math.iaddh":285,"./modules/es7.math.imulh":286,"./modules/es7.math.isubh":287,"./modules/es7.math.rad-per-deg":288,"./modules/es7.math.radians":289,"./modules/es7.math.scale":290,"./modules/es7.math.signbit":291,"./modules/es7.math.umulh":292,"./modules/es7.object.define-getter":293,"./modules/es7.object.define-setter":294,"./modules/es7.object.entries":295,"./modules/es7.object.get-own-property-descriptors":296,"./modules/es7.object.lookup-getter":297,"./modules/es7.object.lookup-setter":298,"./modules/es7.object.values":299,"./modules/es7.observable":300,"./modules/es7.promise.finally":301,"./modules/es7.promise.try":302,"./modules/es7.reflect.define-metadata":303,"./modules/es7.reflect.delete-metadata":304,"./modules/es7.reflect.get-metadata":306,"./modules/es7.reflect.get-metadata-keys":305,"./modules/es7.reflect.get-own-metadata":308,"./modules/es7.reflect.get-own-metadata-keys":307,"./modules/es7.reflect.has-metadata":309,"./modules/es7.reflect.has-own-metadata":310,"./modules/es7.reflect.metadata":311,"./modules/es7.set.from":312,"./modules/es7.set.of":313,"./modules/es7.set.to-json":314,"./modules/es7.string.at":315,"./modules/es7.string.match-all":316,"./modules/es7.string.pad-end":317,"./modules/es7.string.pad-start":318,"./modules/es7.string.trim-left":319,"./modules/es7.string.trim-right":320,"./modules/es7.symbol.async-iterator":321,"./modules/es7.symbol.observable":322,"./modules/es7.system.global":323,"./modules/es7.weak-map.from":324,"./modules/es7.weak-map.of":325,"./modules/es7.weak-set.from":326,"./modules/es7.weak-set.of":327,"./modules/web.dom.iterable":328,"./modules/web.immediate":329,"./modules/web.timers":330}],332:[function(e,t,n){function r(){throw new Error("setTimeout has not been defined")}function o(){throw new Error("clearTimeout has not been defined")}function a(e){if(f===setTimeout)return setTimeout(e,0);if((f===r||!f)&&setTimeout)return f=setTimeout,setTimeout(e,0);try{return f(e,0)}catch(t){try{return f.call(null,e,0)}catch(t){return f.call(this,e,0)}}}function i(e){if(p===clearTimeout)return clearTimeout(e);if((p===o||!p)&&clearTimeout)return p=clearTimeout,clearTimeout(e);try{return p(e)}catch(t){try{return p.call(null,e)}catch(t){return p.call(this,e)}}}function s(){_&&v&&(_=!1,v.length?y=v.concat(y):h=-1,y.length&&l())}function l(){if(!_){var e=a(s);_=!0;for(var t=y.length;t;){for(v=y,y=[];++h<t;)v&&v[h].run();h=-1,t=y.length}v=null,_=!1,i(e)}}function u(e,t){this.fun=e,this.array=t}function c(){}var f,p,d=t.exports={};!function(){try{f="function"==typeof setTimeout?setTimeout:r}catch(e){f=r}try{p="function"==typeof clearTimeout?clearTimeout:o}catch(e){p=o}}();var v,y=[],_=!1,h=-1;d.nextTick=function(e){var t=new Array(arguments.length-1);if(arguments.length>1)for(var n=1;n<arguments.length;n++)t[n-1]=arguments[n];y.push(new u(e,t)),1!==y.length||_||a(l)},u.prototype.run=function(){this.fun.apply(null,this.array)},d.title="browser",d.browser=!0,d.env={},d.argv=[],d.version="",d.versions={},d.on=c,d.addListener=c,d.once=c,d.off=c,d.removeListener=c,d.removeAllListeners=c,d.emit=c,d.prependListener=c,d.prependOnceListener=c,d.listeners=function(e){return[]},d.binding=function(e){throw new Error("process.binding is not supported")},d.cwd=function(){return"/"},d.chdir=function(e){throw new Error("process.chdir is not supported")},d.umask=function(){return 0}},{}],333:[function(e,t,n){"use strict";function r(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}function o(){var e="xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g,function(e){var t=16*Math.random()|0;return("x"==e?t:3&t|8).toString(16)});return u.set(c,e),e}function a(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{},t="localhost"===location.hostname||"127.0.0.1"===location.hostname,n=t?"Local":"Remote";window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)},ga.l=+new Date,ga("create","UA-83005064-2",t?{clientId:e.InstanceGUID||u.get(c)||o()}:"auto"),ga("set","appName","WebTerminal"),ga("set","appVersion",s.VERSION),ga("set","screenName",n),e.zv&&ga("set","appInstallerId",e.zv),ga("send","pageview",n)}Object.defineProperty(n,"__esModule",{value:!0}),n.collect=a;var i=e("../index"),s=r(i),l=e("../storage"),u=r(l),c="terminal-guid"},{"../index":340,"../storage":361}],334:[function(e,t,n){"use strict";function r(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}function o(){this.visible=!1,this.element=document.createElement("div"),this.element.className="hintBox",this.element.style.display="none",u.output.appendChild(this.element),this.maxVariantLength=10,this.displayUnder=!0,this.displayInLine=!0,this.lastSeek=1,this.firstDisplay=!0,this.variants=[],this.variant=0}Object.defineProperty(n,"__esModule",{value:!0});var a=e("../output"),i=r(a),s=e("../input/caret"),l=r(s),u=e("../elements");o.prototype.add=function(){var e=this,t=arguments.length>0&&void 0!==arguments[0]?arguments[0]:[];t instanceof Array||(t=[t]),this.reset(),this.variants=t.map(function(t){return t.length>e.maxVariantLength&&(e.maxVariantLength=t.length),{value:t,element:null}}),this.variants.length?(this.update(),this.show()):this.hide()},o.prototype.reset=function(){this.element.textContent="",this.variants=[],this.variant=0,this.lastSeek=0,this.maxVariantLength=0,this.firstDisplay=!0},o.prototype.get=function(){return(this.variants[this.variant]||{}).value||""},o.prototype.next=function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:1,t=this.variant;this.variant=(this.variant+e+this.variants.length)%this.variants.length,t!==this.variant&&(this.lastSeek=this.variant-t),this.updateVariants()},o.prototype.updateVariants=function(){function e(e){var t=!0,r=!1,o=void 0;try{for(var a,i=n[Symbol.iterator]();!(t=(a=i.next()).done);t=!0){var s=a.value;if(s.element===e)return s}}catch(e){r=!0,o=e}finally{try{!t&&i.return&&i.return()}finally{if(r)throw o}}return null}var t=this;if(this.visible){var n=this.variants.slice(this.variant,this.variant+5),r=this.displayUnder?"top":"bottom",o=!0,a=!1,s=void 0;try{for(var l,u=this.element.childNodes[Symbol.iterator]();!(o=(l=u.next()).done);o=!0){(function(){var n=l.value;if(e(n)||n.DECAY)return"continue";n.DECAY=!0,n.style[r]=parseFloat(n.style[r])-t.lastSeek*i.SYMBOL_HEIGHT+"px",n.style.opacity=0,setTimeout(function(){n.parentNode&&n.parentNode.removeChild(n)},300)})()}}catch(e){a=!0,s=e}finally{try{!o&&u.return&&u.return()}finally{if(a)throw s}}for(var c=0;c<n.length;c++)!function(e){var o=n[e];if(!o.element||o.element.DECAY){var a=Math.sign(t.lastSeek)*Math.min(Math.abs(t.lastSeek),5);o.element=document.createElement("div"),o.element.textContent=o.value,t.firstDisplay||(o.element.style.opacity=0),o.element.style[r]=(e+a)*i.SYMBOL_HEIGHT+"px",t.element.appendChild(o.element)}setTimeout(function(t){return function(){t.style[r]=e*i.SYMBOL_HEIGHT+"px",t.style.opacity=1}}(o.element),25)}(c)}},o.prototype.update=function(){if(this.visible){var e=i.getLinesNumber(),t=i.getTopLineIndex()+l.getY(),n=l.getX(),r=Math.min(this.maxVariantLength,Math.ceil(i.WIDTH/2)),o=Math.min(5,this.variants.length);this.displayInLine=n+r<i.WIDTH,this.displayUnder=t+o+1<Math.max(e,i.HEIGHT),this.element.style.top=((this.displayUnder?t+1:t-o)+(this.displayInLine?this.displayUnder?-1:1:0))*i.SYMBOL_HEIGHT+"px",this.element.style.left=Math.min(n,i.WIDTH-r)*i.SYMBOL_WIDTH+"px",this.element.style.width=r*i.SYMBOL_WIDTH+"px",this.element.style.height=o*i.SYMBOL_HEIGHT+"px",this.updateVariants(),this.firstDisplay=!1}},o.prototype.show=function(){this.visible||(this.visible=!0,this.update(),this.element.style.display="block")},o.prototype.hide=function(){this.visible&&(this.visible=!1,this.element.style.display="none")},n.default=new o},{"../elements":338,"../input/caret":342,"../output":356}],335:[function(e,t,n){"use strict";function r(e){return e&&e.__esModule?e:{default:e}}function o(e){function t(e,n){var a=arguments.length>2&&void 0!==arguments[2]?arguments[2]:null,i=arguments.length>3&&void 0!==arguments[3]?arguments[3]:null;if(r[e])return[];r[e]=!0;var s=o[e],u=[];if(!s)return console.error("No state "+e),[];var c=!0,f=!1,p=void 0;try{for(var d,v=s[Symbol.iterator]();!(c=(d=v.next()).done);c=!0){var y=d.value;if(null===y[0]){if(0===y[1])break;u=u.concat(t(y[1],n));break}if(!0!==y[0]&&0!==y[0]&&((y[0].type===l.TYPE_CHAR||y[0].type===l.TYPE_ID)&&!(a&&y[0].value.class&&y[0].value.class!==a||i&&y[0].value.type&&y[0].value.type!==i))){if(y[0].type===l.TYPE_CHAR){if(""!==n&&0!==(("string"==typeof y[0].value?y[0].value:y[0].value.value)||"").indexOf(n))continue;if(0===y[1])continue;var _=t(y[1],n.substr(1),y[0].value.class||a,y[0].value.type||i),h=!0,m=!1,g=void 0;try{for(var b,x=_[Symbol.iterator]();!(h=(b=x.next()).done);h=!0){var w=b.value;w[0]&&w[0].value&&u.push([y[0].value].concat(w))}}catch(e){m=!0,g=e}finally{try{!h&&x.return&&x.return()}finally{if(m)throw g}}}if(y[0].type===l.TYPE_ID)if(""!==n&&"string"==typeof y[0].value.value){if(y[0].value.value===n)break;0===y[0].value.value.indexOf(n)&&u.push([{value:y[0].value.value.substr(n.length),class:y[0].value.class,type:y[0].value.type}])}else u.push([y[0].value])}}}catch(e){f=!0,p=e}finally{try{!c&&v.return&&v.return()}finally{if(f)throw p}}return u}var n=arguments.length>1&&void 0!==arguments[1]?arguments[1]:"",r=[],o=(0,s.getAutomaton)();return t(e,n)}function a(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:[];d.default.add(e)}function i(e){var t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:[],r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:[],o=!1,i=n.CURRENT=_+=1,s=[];if(d.default.reset(),e){var l=!0,u=!1,c=void 0;try{for(var f,p=t[Symbol.iterator]();!(l=(f=p.next()).done);l=!0){var v=f.value;if(v[0].value){var h=v.map(function(e){return e.value}).join("");h.length&&(o=!0,s.push(h))}else v[0].type&&"function"==typeof y.default[v[0].type]&&(y.default[v[0].type](r.slice(),function(e){i===_&&a(e)}),o=!0)}}catch(e){u=!0,c=e}finally{try{!l&&p.return&&p.return()}finally{if(u)throw c}}}s.length&&d.default.add(s),o&&e||d.default.hide()}Object.defineProperty(n,"__esModule",{value:!0}),n.CURRENT=void 0,n.suggest=o,n.showSuggestions=i;var s=e("../parser"),l=e("../parser/pushdownAutomaton"),u=e("../init"),c=e("../input"),f=function(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}(c),p=e("./hint"),d=r(p),v=e("./types"),y=r(v),_=n.CURRENT=0;(0,u.onInit)(function(){return f.onKeyDown(function(e){if(17===e.keyCode){if(!d.default.visible)return;d.default.next(2===e.location?-1:1)}else if(9===e.keyCode){if(e.preventDefault(),!d.default.visible)return;var t=f.getValue(),n=f.getCaretPosition(),r=d.default.get();f.setValue(t.substr(0,n)+r+t.substr(n),n+r.length)}})})},{"../init":341,"../input":345,"../parser":357,"../parser/pushdownAutomaton":358,"./hint":334,"./types":336}],336:[function(e,t,n){"use strict";function r(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}function o(e,t){for(var n=[],r=e.length-1;r>=0&&e[r].type===t;r--)n.push(e[r].value);return n.length&&e.splice(e.length-n.length,n.length),n.reverse().join("")}Object.defineProperty(n,"__esModule",{value:!0});var a=e("../server"),i=r(a),s=e("../favorite"),l=r(s);n.default={classname:function(e,t){var n=o(e,"classname");i.send("ClassAutocomplete",n,function(e){e&&e.length>0&&t(e.split(",").map(function(e){var t=e.indexOf(".",n.length);return t>0?e.substring(n.length,t+1):e.substr(n.length)}).filter(function(e,t,n){return!n[t-1]||n[t-1]!==e}))})},global:function(e,t){var n=o(e,"global").substr(1);i.send("GlobalAutocomplete",n,function(e){e&&e.length>0&&t(e.split(",").map(function(e){var t=e.indexOf(".",n.length);return t>0?e.substring(n.length,t+1):e.substr(n.length)}).filter(function(e,t,n){return!n[t-1]||n[t-1]!==e}))})},publicClassMember:function(e,t){var n=o(e,"publicClassMember"),r=o(e,"classname");i.send("ClassMemberAutocomplete",{className:r,part:n},function(e){e&&e.length>0&&t(e.split(",").map(function(e){return e.substr(n.length)}))})},parameter:function(e,t){var n=o(e,"parameter").substr(1),r=o(e,"classname")
+         ;i.send("ParameterAutocomplete",{className:r,part:n},function(e){e&&e.length>0&&t(e.split(",").map(function(e){return e.substr(n.length)}))})},variable:function(e,t){var n=o(e,"variable");i.send("LocalAutocomplete",null,function(e){e&&t(Object.keys(e).filter(function(e){return 0===e.indexOf(n)&&e.length!==n.length}).map(function(e){return e.substr(n.length)}))})},favorites:function(e,t){var n=o(e,"favorites");t(Object.keys(l.list()).filter(function(e){return 0===e.indexOf(n)&&e.length!==n.length}).map(function(e){return e.substr(n.length)}))},member:function(e,t){var n=o(e,"member"),r=o(e,"variable");r&&i.send("MemberAutocomplete",{variable:r,part:n},function(e){e&&t(e.split(",").filter(function(e){return 0===e.indexOf(n)}).map(function(e){return e.substr(n.length)}))})},memberMethod:function(e,t){var n=o(e,"memberMethod"),r=o(e,"variable");r&&i.send("MemberAutocomplete",{variable:r,part:n,methodsOnly:1},function(e){e&&t(e.split(",").filter(function(e){return 0===e.indexOf(n)}).map(function(e){return e.substr(n.length)}))})},routine:function(e,t){var n=o(e,"routine");i.send("RoutineAutocomplete",n,function(e){e&&e.length>0&&t(e.split(",").filter(function(e){return!/\.[0-9]+$/.test(e)}).map(function(e){var t=e.indexOf(".",n.length);return t>0?e.substring(n.length,t+1):e.substr(n.length)}).filter(function(e,t,n){return!n[t-1]||n[t-1]!==e}))})}}},{"../favorite":339,"../server":360}],337:[function(e,t,n){"use strict";function r(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}function o(e){return void 0!==x[e]?x[e]:void 0===E[e]?null:E[e]}function a(e){e.has("language")&&d.setLocale(E.language),e.has("serverName")&&(document.title=E.serverName),f.set(g,JSON.stringify(E))}function i(e,t){var n=arguments.length>2&&void 0!==arguments[2]&&arguments[2];if(!A.hasOwnProperty(e))return d.get("confNoKey",e);if(A[e].values&&-1===A[e].values.indexOf(t))return d.get("confInvVal",e,A[e].values.map(function(e){return"\x1b[(constant)m"+e+"\x1b[0m"}).join(", "));var r=A[e].transform?A[e].transform(t):t,o=E[e];return!n&&A[e]&&A[e].global&&y.send(e+"ConfigSet",r,function(t){1!==t&&(E[e]=o,a(new Set([e])))}),E[e]=r,A[e].onSet&&A[e].onSet(r),a(new Set([e])),""}function s(e,t){!A.hasOwnProperty(e)||A[e].values&&-1===A[e].values.indexOf(t)||(x[e]=A[e].transform?A[e].transform(t):t)}function l(){for(var e in E)A[e]&&!A[e].global&&(E[e]=A[e].default);a(new Set(Object.keys(A)))}function u(){var e={};for(var t in E)e[t]={value:E[t],global:!!A[t].global};return e}Object.defineProperty(n,"__esModule",{value:!0}),n.get=o,n.set=i,n.setTemp=s,n.reset=l,n.list=u;var c=e("./storage"),f=r(c),p=e("./localization"),d=r(p),v=e("./server"),y=r(v),_=e("./output"),h=r(_),m=e("./init"),g="terminal-config",b=["true","false"],x={},w=function(e){return"true"===e},j=function(e){return parseInt(e)},A={defaultNamespace:{default:""},initMessage:{default:!0,values:b,transform:w},language:{default:d.suggestLocale(),values:d.getLocales()},maxHistorySize:{default:200,transform:j},serverName:{default:"",global:!0},sqlMaxResults:{default:777,transform:j},suggestions:{default:!0,values:b,transform:w},syntaxHighlight:{default:!0,values:b,transform:w},updateCheck:{default:!0,values:b,transform:w,onSet:function(e){return h.print(e?":)":":(")}}},S={};for(var k in A)S[k]=A[k].default;var E=Object.assign(Object.assign({},S),function(){var e=JSON.parse(f.get(g));for(var t in e)A.hasOwnProperty(t)||delete e[t];return e}()||{});(0,m.onInit)(function(){return d.setLocale(E.language)})},{"./init":341,"./localization":349,"./output":356,"./server":360,"./storage":361}],338:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.faviconLink=n.themeLink=n.input=n.output=n.terminal=void 0;var r=e("./lib"),o=function(e,t){var n=document.createElement(e);return t&&(n.className=t),n},a=n.terminal=o("div","terminal"),i=n.output=o("div","output"),s=(n.input=o("textarea","input"),n.themeLink=o("link")),l=n.faviconLink=o("link");l.setAttribute("rel","shortcut icon"),l.setAttribute("href",r.images.favicon),s.setAttribute("rel","stylesheet"),a.appendChild(i),(0,r.onWindowLoad)(function(){document.head.appendChild(l),document.head.appendChild(s),document.body.appendChild(a)})},{"./lib":347}],339:[function(e,t,n){"use strict";function r(e){return f[e]||""}function o(e,t){f[e]=t,s()}function a(){return Object.assign({},f)}function i(e){var t=!1;return e?(f.hasOwnProperty(e)&&(t=!0),delete f[e]):(Object.keys(f).length&&(t=!0),f={}),s(),t}function s(){u.set(c,JSON.stringify(f))}Object.defineProperty(n,"__esModule",{value:!0}),n.get=r,n.set=o,n.list=a,n.clear=i;var l=e("./storage"),u=function(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}(l),c="terminal-favorites",f=JSON.parse(u.get(c))||{}},{"./storage":361}],340:[function(e,t,n){"use strict";function r(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}function o(e){if(E)return void e(I);w.push(e)}function a(){E||(E=!0,w.forEach(function(e){return e(I)}))}function i(){(0,b.initDone)(this)}function s(e){"function"==typeof C&&(C([e]),C=null)}function l(){var e=y.get("beforeInit"),t=(0,x.getURLParams)();I=new i,f.printLine(e);var n=t.NS||t.ns||g.get("defaultNamespace"),r=null===location.search.match(/ns=[^&]*/i)?""===location.search?n?"?ns="+encodeURIComponent(n):"":location.search+(n?"&ns="+encodeURIComponent(n):""):n?location.search.replace(/ns=[^&]*/i,"ns="+encodeURIComponent(n)):location.search;(0,x.get)("auth"+r,function(t){if(!t.key)return void f.printLine(y.get("unSerRes"),JSON.stringify(t));try{f.print("\x1b[1;1H"+new Array(e.length+1).join(" ")+"\x1b[1;1H"),h.connect({key:t.key})}catch(e){f.printLine(y.get("jsErr",e.message))}})}Object.defineProperty(n,"__esModule",{value:!0}),n.onOutput=n.onUserInput=n.inputActivated=n.MODE=n.NAMESPACE=n.VERSION=void 0;var u="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e};n.onAuth=o,n.authDone=a,n.Terminal=i,n.promptCallback=s,e("babel-polyfill"),e("./network");var c=e("./output"),f=r(c),p=e("./input"),d=r(p),v=e("./localization"),y=r(v),_=e("./server"),h=r(_),m=e("./config"),g=r(m),b=e("./init"),x=e("./lib"),w=[],j=[],A=[],S=[],k=!1,E=!1,I=null;n.VERSION="4.9.1",n.NAMESPACE="USER",n.MODE=i.prototype.MODE_PROMPT,n.inputActivated=function(){if(k=!0,S.length){var e=!0,t=!1,n=void 0;try{for(var r,o=A[Symbol.iterator]();!(e=(r=o.next()).done);e=!0){var a=r.value;a.stream||a.callback(S)}}catch(e){t=!0,n=e}finally{try{!e&&o.return&&o.return()}finally{if(t)throw n}}S=[]}},n.onUserInput=function(e,t){j.forEach(function(n){return n(e,t)}),S=[],k=!1},n.onOutput=function(e){S.push(e);var t=!0,n=!1,r=void 0;try{for(var o,a=A[Symbol.iterator]();!(t=(o=a.next()).done);t=!0){var i=o.value;i.stream&&!k&&i.callback([e])}}catch(e){n=!0,r=e}finally{try{!t&&a.return&&a.return()}finally{if(n)throw r}}};window.onTerminalInit=o,i.prototype.MODE_PROMPT=1,i.prototype.MODE_SQL=2,i.prototype.MODE_READ=3,i.prototype.MODE_READ_CHAR=4,i.prototype.MODE_SPECIAL=5,i.prototype.onOutput=function(e,t){return e&&"function"!=typeof e||(t=e||function(){throw new Error("onOutput: no callback provided!")},e={}),void 0===e.stream&&(e.stream=!1),e.callback=t,A.push(e),t},i.prototype.onUserInput=function(e){if("function"!=typeof e)throw new Error("onUserInput: no callback provided!");return j.push(e),e},i.prototype.print=function(e){d.clearPrompt(),f.print(e),d.reprompt()};var C=null;i.prototype.execute=function(e,t,n){if("function"==typeof t&&(n=t),"object"!==(void 0===t?"undefined":u(t))&&(t={}),h.send("Execute",{command:e,echo:+(t.echo||0),prompt:+(t.prompt||0),bufferOutput:+("function"==typeof n)}),"function"==typeof n)return C=n},i.prototype.removeCallback=function(e){var t=void 0,n=!1;if(-1!==(t=j.indexOf(e)))return j.splice(t,1),!0;if("function"==typeof C)return C=null,!0;for(t=0;t<A.length;++t)A[t].callback===e&&(A.splice(t,1),--t,n=!0);return n},window[addEventListener?"addEventListener":"attachEvent"](addEventListener?"load":"onload",l)},{"./config":337,"./init":341,"./input":345,"./lib":347,"./localization":349,"./network":350,"./output":356,"./server":360,"babel-polyfill":1}],341:[function(e,t,n){"use strict";function r(e){if(i)return void e(s);a.push(e)}function o(e){s=e,i=!0,a.forEach(function(e){return e(s)})}Object.defineProperty(n,"__esModule",{value:!0}),n.onInit=r,n.initDone=o;var a=[],i=!1,s=null},{}],342:[function(e,t,n){"use strict";function r(){return f}function o(){return p}function a(){c.style.left=(f=(0,s.getCursorX)()-1)*s.SYMBOL_WIDTH+"px",c.style.top=(0,s.getTopLineIndex)()*s.SYMBOL_HEIGHT+(p=(0,s.getCursorY)()-1)*s.SYMBOL_HEIGHT+"px",u||c.parentNode||l.output.appendChild(c)}function i(){c.parentNode&&c.parentNode.removeChild(c)}Object.defineProperty(n,"__esModule",{value:!0}),n.getX=r,n.getY=o,n.update=a,n.hide=i;var s=e("../output"),l=e("../elements"),u=-1!==window.navigator.userAgent.indexOf("MSIE ")||-1!==window.navigator.userAgent.indexOf("Trident/"),c=document.createElement("div");c.className="caret";var f=0,p=0},{"../elements":338,"../output":356}],343:[function(e,t,n){"use strict";function r(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}Object.defineProperty(n,"__esModule",{value:!0});var o=e("./special"),a=function(e){return e&&e.__esModule?e:{default:e}}(o),i=e("./index"),s=r(i),l=e("../output"),u=r(l),c=e("../localization"),f=r(c),p=e("../server"),d=r(p),v=e("../index"),y=r(v),_=e("../config"),h=r(_);n.default={special:function(e,t){y.onUserInput(e,v.Terminal.prototype.MODE_SPECIAL);var n=(t[1]||{}).value,r=void 0;s.clear(),"function"==typeof a.default[n]?(u.print("\r\n"),r=a.default[n](t),u.print("\r\n")):void 0===n?u.print("\r\n"+f.get("askEnSpec")+"\r\n"):u.print("\r\n"+f.get("noSpecComm",n)+"\r\n"),!1!==r&&s.reprompt()},normal:function(e,t,n){y.onUserInput(e,n)},sql:function(e){var t=h.get("sqlMaxResults");y.onUserInput(e,v.Terminal.prototype.MODE_SQL),u.newLine(),d.send("SQL",{sql:e,max:t},function(e){if(e.error)u.printLine("\x1b[(wrong)m"+f.parse(e.error)+"\x1b[0m");else{e.headers=e.headers||[],e.data=e.data||[];var n=["<table><thead><tr><th>",e.headers.join("</th><th>"),"</th></tr></thead><tbody><tr>",e.data.slice(0,t).map(function(e){return"<td>"+(e||[]).join("</td><td>")+"</td>"}).join("</tr><tr>"),"</tr>",e.data.length>=t?'<tr><td colspan="'+e.headers.length+'">'+f.get("sqlMaxRows",t)+"</td></tr>":0===e.data.length?'<tr><td colspan="'+e.headers.length+'">'+f.get("sqlNoData")+"</td></tr>":"","</tbody></table>"];u.printLine("\r\n\x1b!<HTML>"+n.join("")+"</HTML>")}s.prompt(y.NAMESPACE+":SQL > ")})}}},{"../config":337,"../index":340,"../localization":349,"../output":356,"../server":360,"./index":345,"./special":346}],344:[function(e,t,n){"use strict";function r(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}function o(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:0;return e&&y.length&&(_=(_+y.length+e)%y.length),y[_]||""}function a(e){var t=y.length-1;y[t<0?0:t]=e}function i(){return _===y.length-1}function s(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"",t=y.length-1;_=t<0?0:t,e&&(y[_]=e)}function l(e){if(!e||y[y.length-2]===e)return void(_=y.length-1);y[y.length-1]=e,y.push(""),_=y.length-1,u()}function u(){f.set(v,JSON.stringify(y.slice(-d.get("maxHistorySize"))))}Object.defineProperty(n,"__esModule",{value:!0}),n.get=o,n.set=a,n.isLast=i,n.setLast=s,n.push=l;var c=e("../storage"),f=r(c),p=e("../config"),d=r(p),v="terminal-history",y=JSON.parse(f.get(v))||[""],_=y.length-1},{"../config":337,"../storage":361}],345:[function(e,t,n){"use strict";function r(e){return e&&e.__esModule?e:{default:e}}function o(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}function a(){return!!Y&&(""===document.getSelection().toString()&&(document.activeElement!==k.input&&(k.input.focus(),!0)))}function i(e){var t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{},r=arguments.length>2&&void 0!==arguments[2]?arguments[2]:null,o=!(arguments.length>3&&void 0!==arguments[3])||arguments[3];$=e?M.Terminal.prototype.MODE_PROMPT:M.Terminal.prototype.MODE_READ,Q=I.getCursorX(),K=I.getCurrentLineIndex(),J=arguments,n.PROMPT_CLEARED=z=!1,Z=o,T.inputActivated(),e&&I.print(e),n.ENABLED=Y=!0,V=I.getCursorX(),X=I.getCurrentLineIndex(),te="function"==typeof r?r:null,clearTimeout(ne),t.timeout&&(ne=setTimeout(x,1e3*t.timeout)),re=t.length?t.length:0,y()}function s(){Y&&(I.setCursorYToLineIndex(K),I.setCursorX(Q),I.immediatePlainPrint(new Array(J[0].length+k.input.value.length+1).join(" ")),I.setCursorYToLineIndex(K),I.setCursorX(Q),n.PROMPT_CLEARED=z=!0)}function l(){if(Y){var e=k.input.value,t=k.input.selectionEnd;i.apply(this,J),k.input.value=e,c(t),b()}}function u(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{},t=arguments[1];Y&&x(),$=M.Terminal.prototype.MODE_READ_CHAR,T.inputActivated(),y(),a(),O.hide();var n=function e(n){!1!==v(n,t)&&window.removeEventListener("keydown",e)};window.addEventListener("keydown",n),clearTimeout(ne),e.timeout&&(ne=setTimeout(function(){ne=0,window.removeEventListener("keydown",n),j(),t(-1)},1e3*e.timeout))}function c(e){if(a(),k.input.createTextRange){var t=k.input.createTextRange();t.move("character",e),t.select()}else void 0!==k.input.selectionStart&&k.input.setSelectionRange(e,e)}function f(){return void 0!==k.input.selectionEnd?k.input.selectionEnd:document.selection&&document.selection.createRange?document.selection.createRange().getBookmark().charCodeAt(2)-2:k.input.length}function p(e){if(!e.handled&&(e.handled=!0,67===e.keyCode&&e.ctrlKey&&M.MODE!==M.Terminal.prototype.MODE_SQL&&""===A()&&((0,D.send)("Interrupt",{}),e.cancelBubble=!0),Y&&!e.cancelBubble)){if(e.cancelBubble=!0,13===e.keyCode)return e.preventDefault(),void x();-1!==[35,36,37,39].indexOf(e.keyCode)&&setTimeout(function(){b(),_()},1),38!==e.keyCode&&40!==e.keyCode||(L.isLast()&&L.set(k.input.value),k.input.value=L.get(e.keyCode-39),b(),_(),setTimeout(function(){return c(k.input.value.length)},1)),ae.forEach(function(t){return t(e)})}}function d(e){ae.push(e)}function v(e,t){if(e.stopPropagation(),e.preventDefault(),-1!==[16,17,18].indexOf(e.keyCode))return!1;var n=String.fromCharCode(e.keyCode)[e.shiftKey?"toUpperCase":"toLowerCase"](),r=n.charCodeAt(0),o=$;j(),r>31&&I.print(n),(0,M.onUserInput)(String.fromCharCode(r),o),t(r)}function y(){
+         ee=0,k.input.value="",k.input.style.textIndent=(V-1)*I.SYMBOL_WIDTH+"px",k.input.style.top=X*I.SYMBOL_HEIGHT+"px",k.output.appendChild(k.input),b()}function _(){oe.forEach(function(e){return e(k.input.value,k.input.selectionStart)})}function h(e){oe.push(e)}function m(e,t){k.input.value=e,t&&c(t),b()}function g(){return k.input.value}function b(){if(Y){var e=Z&&H.get("syntaxHighlight"),t=Z&&H.get("suggestions");I.setCursorYToLineIndex(X),I.setCursorX(V);for(var n=void 0===k.input.selectionStart?k.input.value.length:k.input.selectionStart,r=void 0===k.input.selectionEnd?k.input.value.length:k.input.selectionEnd,o=r-n,a=(0,R.process)(k.input.value,n,t,T.MODE===M.Terminal.prototype.MODE_SQL?"SQLMode":"CWTInput"),i=a.lexemes,s=a.suggestions,l=a.collector,u=0,c="",f=0;f<i.length;f++){var p=u<=n&&n<u+i[f].value.length,d=u<=r&&r<u+i[f].value.length;e&&i[f].class!==c&&(c=i[f].class,o>0&&n<u&&u<r||I.print("\x1b["+(""===c?0:"("+c+")")+"m")),p&&(I.print(i[f].value.substring(0,n-u)),O.update(),o>0&&I.print("\x1b[("+q+")m")),d?I.print(i[f].value.substring(p?n-u:0,r-u)):p&&I.print(i[f].value.substr(n-u)),d&&(o>0&&I.print("\x1b["+(""===c?0:"("+c+")")+"m"),I.print(i[f].value.substr(r-u))),p||d||I.print(i[f].value),u+=i[f].value.length}n===u&&O.update(),(c||u<ee)&&I.print("\x1b[0m"),u<ee&&I.print(new Array(ee-u+1).join(" ")),ee=u;var v=(I.getCurrentLineIndex()-X+1)*I.SYMBOL_HEIGHT;if(k.input.style.height!==v+"px"&&(k.input.style.height=v+"px"),Y&&re&&k.input.value.length>=re)return void x();ie=i,(0,N.showSuggestions)(t&&n>0&&k.input.value.length>0&&0===o,s,l)}}function x(){var e=k.input.value,t=(ie[0]||{}).value;if(L.push(e),B.default.hide(),Z&&"/"===t)return U.default.special(e,ie);U.default[T.MODE===M.Terminal.prototype.MODE_SQL?"sql":"normal"](e,ie,$),n.ENABLED=Y=!1,clearTimeout(ne),ne=0,te&&te(e),te=null,j()}function w(){k.input.value=""}function j(){$=0,k.input.parentNode&&k.input.parentNode.removeChild(k.input),n.ENABLED=Y=!1,O.hide()}function A(){var e="";return window.getSelection?e=window.getSelection().toString():document.selection&&"Control"!==document.selection.type&&(e=document.selection.createRange().text),e}Object.defineProperty(n,"__esModule",{value:!0}),n.PROMPT_CLEARED=n.ENABLED=void 0,n.focusInput=a,n.prompt=i,n.clearPrompt=s,n.reprompt=l,n.getKey=u,n.setCaretPosition=c,n.getCaretPosition=f,n.onKeyDown=d,n.onUpdate=h,n.setValue=m,n.getValue=g,n.update=b,n.clear=w,n.hideInput=j;var S=e("../elements"),k=o(S),E=e("../output"),I=o(E),C=e("./caret"),O=o(C),P=e("./history"),L=o(P),M=e("../index"),T=o(M),R=e("../parser"),N=e("../autocomplete"),D=e("../server"),F=e("../config"),H=o(F),G=e("./handlers"),U=r(G),W=e("../autocomplete/hint"),B=r(W),Y=n.ENABLED=!1,z=n.PROMPT_CLEARED=!1,q="selected",X=0,V=0,K=0,Q=0,J=[],Z=!1,$=0,ee=0,te=null,ne=0,re=0,oe=[],ae=[],ie=[];window.addEventListener("keydown",function(e){a(),p(e)},!0),window.addEventListener("click",a,!0),k.input.addEventListener("input",function(){/\r?\n/.test(k.input.value)&&(k.input.value=k.input.value.replace(/(?:\r?\n)+/g," ")),L.setLast(k.input.value),b(),_()}),k.input.addEventListener("keydown",function(e){p(e)});var se=[void 0,void 0];k.input.addEventListener("mousemove",function(){k.input.selectionStart===se[0]&&k.input.selectionEnd===se[1]||(se[0]=k.input.selectionStart,se[1]=k.input.selectionEnd,b())})},{"../autocomplete":335,"../autocomplete/hint":334,"../config":337,"../elements":338,"../index":340,"../output":356,"../parser":357,"../server":360,"./caret":342,"./handlers":343,"./history":344}],346:[function(e,t,n){"use strict";function r(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}function o(e,t,n){var r=e.length+2;for(var o in n)o.length>r&&(r=o.length);l.print("\x1b[1m"+e+"\x1b[0m\x1b["+r+"G  \x1b[1m"+t+"\x1b[0m\r\n");for(var a in n)l.print("\x1b[(constant)m"+a+"\x1b[0m\x1b["+r+"G= "+n[a]+"\r\n")}Object.defineProperty(n,"__esModule",{value:!0});var a=e("../localization"),i=r(a),s=e("../output"),l=r(s),u=e("../input"),c=r(u),f=e("../config"),p=r(f),d=e("../index"),v=r(d),y=e("../server"),_=r(y),h=e("../tracing"),m=r(h),g=e("../favorite"),b=r(g),x=e("../server/handlers"),w=e("../network");n.default={help:function(){l.print(i.get("help")+"\r\n")},clear:function(){l.reset()},config:function(e){var t=function(e,t,n){for(var r in e)if(e[r].global===n){var o="string"==typeof e[r].value&&0===e[r].value.length?'\x1b[(string)m""\x1b[0m':"\x1b[(constant)m"+e[r].value+"\x1b[0m";l.print("\x1b[(variable)m"+r+"\x1b[0m\x1b["+t+"G= "+o+"\r\n")}};if(e.length<4){var n=p.list(),r=0;for(var o in n)o.length>r&&(r=o.length);return r+=2,l.print(i.get("availConfLoc")+"\r\n"),t(n,r,!1),l.print(i.get("availConfGlob")+"\r\n"),t(n,r,!0),void l.print(i.get("confHintSet")+"\r\n")}if(e.filter(function(e){return"global"===e.class})[0])return void p.reset();if(e.length<5)return void l.print(i.get("confHintSet")+"\r\n");var a=e.filter(function(e){return"variable"===e.class})[0],s=e.filter(function(e){return"constant"===e.class||"string"===e.class})[0];if(!a||!s)return void l.print(i.get("confHintSet")+"\r\n");var u=p.set(a.value,"string"===s.class?s.value.substr(1,s.value.length-2):s.value);""!==u&&l.print(u+"\r\n")},favorite:function(e){if(e.length<4){var t=b.list();return Object.keys(t).length>0&&(o(i.get("favKey"),i.get("favVal"),t),l.newLine()),void l.print(i.get("favDesc")+"\r\n")}if("delete"!==e[3].value){if(e.length<6){var n=b.get(e[3].value);n?setTimeout(function(){return c.setValue(n)},1):l.print(i.get("noFav",e[3].value)+"\r\n")}var r=e.slice(5).map(function(e){return e.value}).join("");r&&e[3].value&&(b.set(e[3].value,r),l.print(i.get("favSet",e[3].value)+"\r\n"))}else if(e[4]&&" "===e[4].value&&e[5]){var a=b.clear(e[5].value);l.print(i.get("favDel"+(a?"OK":"NotOK"),e[5].value)+"\r\n")}else b.clear(),l.print(i.get("favDel")+"\r\n")},info:function(){l.print(i.get("info")+"\r\n")},logout:function(){var e=void 0;try{e=document.execCommand("ClearAuthenticationCache")}catch(e){}e||(e=function(e){if(e)return!!e&&(e.open("HEAD",location.href,!0,"logout",(new Date).getTime().toString()),e.send(""),!0)}(window.XMLHttpRequest?new window.XMLHttpRequest:window.ActiveXObject?new ActiveXObject("Microsoft.XMLHTTP"):null)),e?(l.printLine(i.get("logOut")),location.reload()):l.printLine(i.get("unLogOut"))},sql:function(){var e=v.MODE!==d.Terminal.prototype.MODE_SQL;return v.MODE=e?d.Terminal.prototype.MODE_SQL:d.Terminal.prototype.MODE_PROMPT,e?c.prompt(v.NAMESPACE+":SQL > "):(0,x.prompt)(v.NAMESPACE),!1},trace:function(e){if(e.length<4){l.print(i.get("tracingUsage")+"\r\n");var t=m.getList();return void(t&&l.print(i.get("traceSight",t)+"\r\n"))}if("stop"===e[3].value)return void _.send("StopTracing",{},function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{OK:!1};e.OK&&m.stop(),l.printAsync(i.get(e.OK?"traceStopOK":"traceStopNotOK")+"\r\n")});var n=e.slice(3).map(function(e){return e.value}).join("");_.send("Trace",n,function(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{OK:0};return e.OK?e.started?(m.start(n),void l.printAsync(i.get("traceStart",n)+"\r\n")):void(e.stopped&&(m.stop(n),l.printAsync(i.get("traceStop",n)+"\r\n"))):void l.printAsync(i.get("traceBad",n)+"\r\n")})},update:function(){(0,w.checkUpdate)(!0)}}},{"../config":337,"../favorite":339,"../index":340,"../input":345,"../localization":349,"../network":350,"../output":356,"../server":360,"../server/handlers":359,"../tracing":362}],347:[function(e,t,n){"use strict";function r(e){window.addEventListener?window.addEventListener("load",e):window.attachEvent("onload",e)}function o(e,t){var n=new XMLHttpRequest;n.onreadystatechange=function(){if(4===n.readyState)if(200===n.status){var e={error:"Parse error",data:n.responseText};try{e=JSON.parse(n.responseText)}catch(e){}t(e)}else t({error:"HTTP "+n.status+" error"})};try{n.open("GET",e+(-1===e.indexOf("?")?"?":"&")+"_="+(new Date).getTime(),!0),n.send()}catch(e){console.error(e)}}function a(){for(var e={},t=window.location.search.substring(1),n=t.split("&"),r=0;r<n.length;r++){var o=n[r].split("=");void 0===e[o[0]]?e[o[0]]=decodeURIComponent(o[1]):"string"==typeof e[o[0]]?e[o[0]]=[e[o[0]],decodeURIComponent(o[1])]:e[o[0]].push(decodeURIComponent(o[1]))}return e}Object.defineProperty(n,"__esModule",{value:!0}),n.onWindowLoad=r,n.get=o,n.getURLParams=a,String.prototype.splice=function(e,t,n){return this.slice(0,e)+n+this.slice(e+Math.abs(t))};n.images={favicon:"data:image/x-icon;base64,AAABAAEAEBAAAAAAAABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAD///8BAAAABQAAABEAAAAJAAAAAwAAAAMAAAAD////Af///wH///8B////Af///wH///8B////Af///wH///8B////AQAAAAcAAAAVLyoiXzcxJa09NijfPjcp4YiHhcWbm5ypioqLhWtrbF8vLy85AAAAIQAAAAP///8B////AXt7fBGFhYZHiomLRXFua0FEPzNPOjMkY1dSSceqqqr/vLy9/7a2t/+vr7D/kZGS4wAAABkAAAAbAAAAFf///wGXlZKPq6qg57GtlK2vqIqjsaySt6+qlcOvr5/1t7es/76+t//GxsT/zMzM98fIyIW8vLxDwcHBKY6Njg////8BioZ8j5aTjpkUERGjHRIS4SIVFM8oGRa9Mh8ZrUc0KatfTT2tdWROsYZ1XauciHGVt6aQl7uwnp/GxLPRuLi2gYyIfo+XlJCZCQgIzQAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8IBgX/Eg8O5bOwpXuOi4CPmZaSmQgIB80AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wICAfGqqKB3kY2Cj5yZlJkIBwfNAAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8FBATtpaKcd5SQhY+em5eZCAcHzQAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wUFBf8aGhr/Li0s65+dl3WXk4iPop+amQgHB80AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AQEB/xISEv8mJib/MjIy/zk3NumamJJ1m5eMj6WinZkHBwfPXV1d/wcHB/9PT0//V1dX/0tLS/8AAAD/BQUF/xkZGf8nJyf/MjIy/zw8PP9CPz3nlJKNdZ+bj5GopZ+ZBwcHz25ubv+qqqr/ODg4/zg4OP8pKSn/CAgI/xwcHP8oKCj/MzMz/zw8PP9DQ0P/SENB55COiXOin5KRq6iimQcHBs9gYGD/m5ub/wAAAP8AAAD/DQ0N/x0dHf8oKCj/MzMz/z09Pf9DQ0P/R0dH/0pFQ+WMioVzpaGUkaunoZ8ICAjPc3Nz/wcHB/0GBgb1FBMT7x4eHecqKSfhNTMx3T89OttIRUHZT0xH2VVSTNtwbWTflZOQibKwrYe4tanplpGCs4uDcamblIOto52Ot6Gcj7+fmo69nZmNs5qWi6mVkombjoyFjYaFgH9/f3xxfXx9Y3t8fi+npqYbsbKyU7m4uE2/v787srKxKY+OjxdtbW0H////Af///wH///8B////Af///wH///8B////Af///wH///8B//8AAPA/AAD8DwAAAA8AAAAAAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAAAAAAADwAA//8AAA=="}},{}],348:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.default={storageErr:{en:"Storage error: local storage is not supported by your browser. Please, consider updating your browser.",ru:"\u041e\u0448\u0438\u0431\u043a\u0430 \u0445\u0440\u0430\u043d\u0438\u043b\u0438\u0449\u0430: \u043b\u043e\u043a\u0430\u043b\u044c\u043d\u043e\u0435 \u0445\u0440\u0430\u043d\u0438\u043b\u0438\u0449\u0435 \u043d\u0435 \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u0438\u0432\u0430\u0435\u0442\u0441\u044f \u0431\u0440\u0430\u0443\u0437\u0435\u0440\u043e\u043c. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u043e\u0431\u043d\u043e\u0432\u0438\u0442\u0435 \u0432\u0430\u0448 \u0431\u0440\u0430\u0443\u0437\u0435\u0440."},noLocale:{en:'No such locale "%s".',ru:'\u041d\u0435\u0442 \u043b\u043e\u043a\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438 \u0434\u043b\u044f "%s"'},wsErr:{en:"WebSocket error: %s",ru:"\u041e\u0448\u0438\u0431\u043a\u0430 WebSocket: %s"},serParseErr:{en:"Unable to parse server response: %s",ru:"\u041d\u0435\u0432\u043e\u0437\u043c\u043e\u0436\u043d\u043e \u043e\u0431\u0440\u0430\u0431\u043e\u0442\u0430\u0442\u044c \u043e\u0442\u0432\u0435\u0442 \u0441\u0435\u0440\u0432\u0435\u0440\u0430: %s"},reConn:{en:"Attempting to restore session in %n seconds...",ru:"\u041f\u043e\u043f\u044b\u0442\u043a\u0430 \u0432\u043e\u0441\u0441\u0442\u0430\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u044f \u0441\u0435\u0441\u0441\u0438\u0438 \u0447\u0435\u0440\u0435\u0437 %n \u0441\u0435\u043a\u0443\u043d\u0434..."},seeYou:{en:"See you!",ru:"\u0414\u043e \u043d\u043e\u0432\u044b\u0445 \u0432\u0441\u0442\u0440\u0435\u0447!"},eInt:{en:"WebTerminal internal error %s",ru:"\u0412\u043d\u0443\u0442\u0440\u0435\u043d\u043d\u044f\u044f \u043e\u0448\u0438\u0431\u043a\u0430 \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b\u0430 %s"},noJob:{en:"Unable to start new Job",ru:"\u041d\u0435\u0432\u043e\u0437\u043c\u043e\u0436\u043d\u043e \u0437\u0430\u043f\u0443\u0441\u0442\u0438\u0442\u044c \u043d\u043e\u0432\u044b\u0439 Job"},wsConnLost:{en:"WebTerminal lost connection with server (code %n%s).",ru:"\u0412\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b \u043f\u043e\u0442\u0435\u0440\u044f\u043b \u0441\u043e\u0435\u0434\u0438\u043d\u0435\u043d\u0438\u0435 \u0441 \u0441\u0435\u0440\u0432\u0435\u0440\u043e\u043c (\u043a\u043e\u0434 %n%s)"},plRefPageSes:{en:"Please, refresh the web page to start a new session.",ru:"\u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u043e\u0431\u043d\u043e\u0432\u0438\u0442\u0435 \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0443 \u0447\u0442\u043e\u0431\u044b \u043d\u0430\u0447\u0430\u0442\u044c \u043d\u043e\u0432\u0443\u044e \u0441\u0435\u0441\u0441\u0438\u044e."},noUpdUrl:{en:"Unable to get update URL. Please, update \x1b!URL=%s (manually).",ru:"\u041d\u0435 \u043f\u043e\u043b\u0443\u0447\u0430\u0435\u0442\u0441\u044f \u043f\u043e\u043b\u0443\u0447\u0438\u0442\u044c URL \u043e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u044f. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u044b\u043f\u043e\u043b\u043d\u0438\u0442\u0435 \u043e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0435 \x1b!URL=%s (\u0432\u0440\u0443\u0447\u043d\u0443\u044e)."},updReady:{en:"\x1b[36mNew update is available.\x1b[0m \x1b!URL=%s (Click here) to install it now. Changelist:",ru:"\x1b[36m\u0414\u043e\u0441\u0442\u0443\u043f\u043d\u043e \u043e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0435.\x1b[0m \x1b!URL=%s (\u041d\u0430\u0436\u043c\u0438\u0442\u0435 \u0442\u0443\u0442) \u0447\u0442\u043e\u0431\u044b \u0443\u0441\u0442\u0430\u043d\u043e\u0432\u0438\u0442\u044c \u0435\u0433\u043e \u0441\u0435\u0439\u0447\u0430\u0441. \u0421\u043f\u0438\u0441\u043e\u043a \u0438\u0437\u043c\u0435\u043d\u0435\u043d\u0438\u0439:"},updStart:{en:"Updating WebTerminal... %s -> %s",ru:"WebTerminal \u043e\u0431\u043d\u043e\u0432\u043b\u044f\u0435\u0442\u0441\u044f... %s -> %s"},rSerUpd:{en:"Requesting server to update...",ru:"\u041f\u0440\u043e\u0441\u0438\u043c \u0441\u0435\u0440\u0432\u0435\u0440 \u043e\u0431\u043d\u043e\u0432\u0438\u0442\u044c\u0441\u044f..."},sUpdSt:{en:"Update started, please, \x1b[4mdo not close this window\x1b[0m.",ru:"\u041e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0435 \u043d\u0430\u0447\u0430\u043b\u043e\u0441\u044c, \u043f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \x1b[4m\u043d\u0435 \u0437\u0430\u043a\u0440\u044b\u0432\u0430\u0439\u0442\u0435 \u044d\u0442\u043e \u043e\u043a\u043d\u043e.\x1b[0m"},sUpdRURL:{en:"Requesting %s",ru:"\u0417\u0430\u043f\u0440\u0430\u0448\u0438\u0432\u0430\u0435\u043c %s"},sUpdGetOK:{en:"Response downloaded.",ru:"\u041e\u0442\u0432\u0435\u0442 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043d."},sUpdSCode:{en:"Unable to update WebTerminal: HTTPS request ended with the code %s.",
+         ru:"\u041d\u0435\u0432\u043e\u0437\u043c\u043e\u0436\u043d\u043e \u043e\u0431\u043d\u043e\u0432\u0438\u0442\u044c \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b: HTTPS-\u0437\u0430\u043f\u0440\u043e\u0441 \u0437\u0430\u0432\u0435\u0440\u0448\u0438\u043b\u0441\u044f \u0441 \u043a\u043e\u0434\u043e\u043c %s."},sUpdWTF:{en:"Writing WebTerminal's new version a temporary file...",ru:"\u0417\u0430\u043f\u0438\u0441\u044b\u0432\u0430\u0435\u043c \u043d\u043e\u0432\u0443\u044e \u0432\u0435\u0440\u0441\u0438\u044e \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b\u0430 \u0432\u043e \u0432\u0440\u0435\u043c\u0435\u043d\u043d\u044b\u0439 \u0444\u0430\u0439\u043b..."},sUpdErr:{en:"Update \x1b[31mfailed\x1b[0m! Error: %s",ru:"\u041e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0435 \x1b[31m\u043d\u0435 \u043f\u043e\u043b\u0443\u0447\u0438\u043b\u043e\u0441\u044c\x1b[0m! \u041e\u0448\u0438\u0431\u043a\u0430: %s"},sUpdRes:{en:"Update failed. Possibly, the new WebTerminal version is not compatible with your system anymore, or the update was not tested for this system. Please report this issue \x1b!URL=https://github.com/intersystems-community/webterminal/issues (here) and attach the update log. You can try waiting some time (finite or infinite) until this problem is identified and fixed.",ru:"\u041e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0435 \u043d\u0435 \u0443\u0434\u0430\u043b\u043e\u0441\u044c. \u0412\u043e\u0437\u043c\u043e\u0436\u043d\u043e, \u043d\u043e\u0432\u0430\u044f \u0432\u0435\u0440\u0441\u0438\u044f \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b\u0430 \u0431\u043e\u043b\u044c\u0448\u0435 \u043d\u0435 \u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u0430 \u0441 \u0432\u0430\u0448\u0435\u0439 \u0441\u0438\u0441\u0442\u0435\u043c\u043e\u0439, \u0438\u043b\u0438 \u043e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0435 \u043d\u0435 \u0431\u044b\u043b\u043e \u043f\u0440\u043e\u0442\u0435\u0441\u0442\u0438\u0440\u043e\u0432\u0430\u043d\u043e \u0434\u043b\u044f \u043d\u0435\u0451. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u043e\u0431\u0440\u0430\u0442\u0438\u0442\u0435\u0441\u044c \u0432 \x1b!URL=https://github.com/intersystems-community/webterminal/issues (\u043f\u043e\u0434\u0434\u0435\u0440\u0436\u043a\u0443) \u0441 \u0432\u043e\u043f\u0440\u043e\u0441\u043e\u043c, \u043f\u0440\u0438\u043a\u0440\u0435\u043f\u0438\u0432 \u043b\u043e\u0433 \u043e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u044f \u0438\u043b\u0438 \u043f\u043e\u0434\u043e\u0436\u0434\u0438\u0442\u0435 \u043d\u0435\u043a\u043e\u0442\u043e\u0440\u043e\u0435 \u043a\u043e\u043b\u0438\u0447\u0435\u0441\u0442\u0432\u043e \u0432\u0440\u0435\u043c\u0435\u043d\u0438 (\u043a\u043e\u043d\u0435\u0447\u043d\u043e\u0435 \u0438\u043b\u0438 \u0431\u0435\u0441\u043a\u043e\u043d\u0435\u0447\u043d\u043e\u0435), \u043f\u043e\u043a\u0430 \u043f\u0440\u043e\u0431\u043b\u0435\u043c\u0430 \u043d\u0435 \u0431\u0443\u0434\u0435\u0442 \u0432\u044b\u044f\u0432\u043b\u0435\u043d\u0430 \u0438 \u0438\u0441\u043f\u0440\u0430\u0432\u043b\u0435\u043d\u0430."},sUpdBack:{en:"Backing up current version to %s...",ru:"\u0421\u043e\u0445\u0440\u0430\u043d\u044f\u0435\u043c \u0440\u0435\u0437\u0435\u0440\u0432\u043d\u0443\u044e \u043a\u043e\u043f\u0438\u044e \u0442\u0435\u043a\u0443\u0449\u0435\u0439 \u0432\u0435\u0440\u0441\u0438\u0438 \u0432 %s..."},sUpdRemLoad:{en:"Deleting old version and importing a new one...",ru:"\u0423\u0434\u0430\u043b\u044f\u0435\u043c \u043f\u0440\u043e\u0448\u043b\u0443\u044e \u0432\u0435\u0440\u0441\u0438\u044e \u0438 \u0438\u043c\u043f\u043e\u0440\u0442\u0438\u0440\u0443\u0435\u043c \u043d\u043e\u0432\u0443\u044e..."},sUpdNoFile:{en:"No file %s",ru:"\u041d\u0435\u0442 \u0444\u0430\u0439\u043b\u0430 %s"},sUpdCleanLog:{en:"Deleting log file %s...",ru:"\u0423\u0434\u0430\u043b\u044f\u0435\u043c \u0444\u0430\u0439\u043b \u0441 \u043b\u043e\u0433\u0430\u043c\u0438 %s..."},sUpdClean:{en:"Deleting temporary file %s...",ru:"\u0423\u0434\u0430\u043b\u044f\u0435\u043c \u0432\u0440\u0435\u043c\u0435\u043d\u043d\u044b\u0439 \u0444\u0430\u0439\u043b %s..."},sUpdDone:{en:"Update completed! Please, \x1b!URL=javascript:location.reload() (reload) the page.",ru:"\u041e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0435 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043d\u043e! \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \x1b!URL=javascript:location.reload() (\u043e\u0431\u043d\u043e\u0432\u0438\u0442\u0435) \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0443."},askEnSpec:{en:"Please, enter the special command. Try entering \x1b[(special)m/help\x1b[0m first.",ru:"\u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \u0441\u043f\u0435\u0446\u0438\u0430\u043b\u044c\u043d\u0443\u044e \u043a\u043e\u043c\u0430\u043d\u0434\u0443. \u041d\u0430\u0447\u043d\u0438\u0442\u0435 \u0441 \u0432\u0432\u043e\u0434\u0430 \x1b[(special)m/help\x1b[0m, \u043d\u0430\u043f\u0440\u0438\u043c\u0435\u0440."},noSpecComm:{en:"There is no special command \x1b[(special)m/%s\x1b[0m. Please, enter \x1b[(special)m/help\x1b[0m to get a list of available commands.",ru:"\u0421\u043f\u0435\u0446\u0438\u0430\u043b\u044c\u043d\u0430\u044f \u043a\u043e\u043c\u0430\u043d\u0434\u0430 \x1b[(special)m/%s\x1b[0m \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \x1b[(special)m/help\x1b[0m \u0447\u0442\u043e\u0431\u044b \u0443\u0437\u043d\u0430\u0442\u044c \u0441\u043f\u0438\u0441\u043e\u043a \u0434\u043e\u0441\u0442\u0443\u043f\u043d\u044b\u0445 \u043a\u043e\u043c\u0430\u043d\u0434."},help:{en:"\x1b[1mCach\xe9 WEB Terminal \x1b[(keyword)mv4.9.1\x1b[0m\n\r\n\r\x1b[4mAvailable commands:\x1b[0m\n\r\x1b[(special)m/help\x1b[0m\x1b[20GDisplay the short documentation (like you just did).\n\r\x1b[(special)m/clear\x1b[0m\x1b[20GClears the screen and all the history.\n\r\x1b[(special)m/config\x1b[0m ...\x1b[20GAllows you to configure WebTerminal's behavior. Enter this command to get more information.\n\r\x1b[(special)m/favorite\x1b[0m ...\x1b[20GAllows you to save or restore any frequently used commands. Enter this command to get more information.\n\r\x1b[(special)m/info\x1b[0m\x1b[20GShow the information about the WebTerminal project.\n\r\x1b[(special)m/logout\x1b[0m\x1b[20GLog out the current WebTerminal user and prompt for the authentication again.\n\r\x1b[(special)m/sql\x1b[0m\x1b[20GSwitches terminal to SQL mode. Type SQL commands instead of ObjectScript. To exit SQL mode, enter this command again.\n\r\x1b[(special)m/trace\x1b[0m ...\x1b[20GEnables global/file tracing. Type this command to get more information.\n\r\x1b[(special)m/update\x1b[0m\x1b[20GChecks for available updates.\n\r\n\r\x1b[4mKeys:\x1b[0m\n\r\x1b[(special)mCtrl + C\x1b[0m\x1b[20GInterrupt the command execution.\n\r\x1b[(special)mTAB\x1b[0m\x1b[20GComplete the input with proposed autocomplete variant.\n\r\x1b[(special)mRight/left CTRL\x1b[0m\x1b[20GSwitch autocomplete variant when multiple are available.\n\r\n\rPress \x1b!URL=http://intersystems-community.github.io/webterminal/#docs (here) to see the full documentation.",ru:"\x1b[1mCach\xe9 WEB Terminal \x1b[(keyword)mv4.9.1\x1b[0m\n\r\n\r\x1b[4m\u0414\u043e\u0441\u0442\u0443\u043f\u043d\u044b\u0435 \u043a\u043e\u043c\u0430\u043d\u0434\u044b:\x1b[0m\n\r\x1b[(special)m/help\x1b[0m\x1b[20G\u041e\u0442\u043e\u0431\u0440\u0430\u0437\u0438\u0442\u044c \u043a\u043e\u0440\u043e\u0442\u043a\u0443\u044e \u0434\u043e\u043a\u0443\u043c\u0435\u043d\u0442\u0430\u0446\u0438\u044e (\u043a\u0430\u043a \u0432\u044b \u0442\u043e\u043b\u044c\u043a\u043e \u0447\u0442\u043e \u0441\u0434\u0435\u043b\u0430\u043b\u0438).\n\r\x1b[(special)m/clear\x1b[0m\x1b[20G\u041f\u043e\u043b\u043d\u043e\u0441\u0442\u044c\u044e \u043e\u0447\u0438\u0449\u0430\u0435\u0442 \u044d\u043a\u0440\u0430\u043d \u0438 \u0435\u0433\u043e \u0438\u0441\u0442\u043e\u0440\u0438\u044e.\n\r\x1b[(special)m/config\x1b[0m ...\x1b[20G\u041f\u043e\u0437\u0432\u043e\u043b\u044f\u0435\u0442 \u043d\u0430\u0441\u0442\u0440\u0430\u0438\u0432\u0430\u0442\u044c \u043f\u043e\u0432\u0435\u0434\u0435\u043d\u0438\u0435 \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b\u0430. \u0412\u0432\u0435\u0434\u0438\u0442\u0435 \u044d\u0442\u0443 \u043a\u043e\u043c\u0430\u043d\u0434\u0443, \u0447\u0442\u043e\u0431\u044b \u043f\u043e\u043b\u0443\u0447\u0438\u0442\u044c \u0431\u043e\u043b\u044c\u0448\u0435 \u0438\u043d\u0444\u043e\u0440\u043c\u0430\u0446\u0438\u0438.\n\r\x1b[(special)m/favorite\x1b[0m ...\x1b[20G\u041f\u043e\u0437\u0432\u043e\u043b\u044f\u0435\u0442 \u0441\u043e\u0445\u0440\u0430\u043d\u044f\u0442\u044c \u0438 \u0437\u0430\u0433\u0440\u0443\u0436\u0430\u0442\u044c \u043b\u044e\u0431\u044b\u0435 \u0447\u0430\u0441\u0442\u043e \u0438\u0441\u043f\u043e\u043b\u044c\u0437\u0443\u0435\u043c\u044b\u0435 \u043a\u043e\u043c\u0430\u043d\u0434\u044b. \u0412\u0432\u0435\u0434\u0438\u0442\u0435 \u044d\u0442\u0443 \u043a\u043e\u043c\u0430\u043d\u0434\u0443, \u0447\u0442\u043e\u0431\u044b \u043f\u043e\u043b\u0443\u0447\u0438\u0442\u044c \u0431\u043e\u043b\u044c\u0448\u0435 \u0438\u043d\u0444\u043e\u0440\u043c\u0430\u0446\u0438\u0438.\n\r\x1b[(special)m/info\x1b[0m\x1b[20G\u041f\u043e\u043a\u0430\u0437\u0430\u0442\u044c \u0438\u043d\u0444\u043e\u0440\u043c\u0430\u0446\u0438\u044e \u043f\u0440\u043e \u043f\u0440\u043e\u0435\u043a\u0442 \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b\u0430.\n\r\x1b[(special)m/logout\x1b[0m\x1b[20G\u0412\u044b\u0439\u0442\u0438 \u0438\u0437 \u0442\u0435\u043a\u0443\u0449\u0435\u0433\u043e \u0441\u0435\u0430\u043d\u0441\u0430 \u0438 \u0441\u043d\u043e\u0432\u0430 \u043f\u0440\u043e\u0439\u0442\u0438 \u0430\u0443\u0442\u0435\u043d\u0442\u0438\u0444\u0438\u043a\u0430\u0446\u0438\u044e.\n\r\x1b[(special)m/sql\x1b[0m\x1b[20G\u041f\u0435\u0440\u0435\u043a\u043b\u044e\u0447\u0438\u0442\u044c \u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b \u0432 \u0440\u0435\u0436\u0438\u043c SQL. \u0414\u0430\u043b\u0435\u0435 \u0432\u0432\u043e\u0434\u0438\u0442\u0435 SQL \u043a\u043e\u043c\u0430\u043d\u0434\u044b \u0432\u043c\u0435\u0441\u0442\u043e ObjectScript. \u0427\u0442\u043e\u0431\u044b \u0432\u044b\u0439\u0442\u0438 \u0438\u0437 \u0440\u0435\u0436\u0438\u043c\u0430 SQL, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \u044d\u0442\u0443 \u043a\u043e\u043c\u0430\u043d\u0434\u0443 \u0435\u0449\u0451 \u0440\u0430\u0437.\n\r\x1b[(special)m/trace\x1b[0m ...\x1b[20G\u0412\u043a\u043b\u044e\u0447\u0430\u0435\u0442 \u0442\u0440\u0430\u0441\u0441\u0438\u0440\u043e\u0432\u043a\u0443 \u0433\u043b\u043e\u0431\u0430\u043b\u0430/\u0444\u0430\u0439\u043b\u0430. \u0412\u0432\u0435\u0434\u0438\u0442\u0435 \u044d\u0442\u0443 \u043a\u043e\u043c\u0430\u043d\u0434\u0443, \u0447\u0442\u043e\u0431\u044b \u043f\u043e\u043b\u0443\u0447\u0438\u0442\u044c \u0431\u043e\u043b\u044c\u0448\u0435 \u0438\u043d\u0444\u043e\u0440\u043c\u0430\u0446\u0438\u0438.\n\r\x1b[(special)m/update\x1b[0m\x1b[20G\u041f\u0440\u043e\u0432\u0435\u0440\u044f\u0435\u0442 \u043d\u0430\u043b\u0438\u0447\u0438\u0435 \u043e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0439.\n\r\n\r\x1b[4m\u041a\u043b\u0430\u0432\u0438\u0448\u0438:\x1b[0m\n\r\x1b[(special)mCtrl + C\x1b[0m\x1b[20G\u041f\u0440\u0435\u0440\u0432\u0430\u0442\u044c \u0432\u044b\u043f\u043e\u043b\u043d\u0435\u043d\u0438\u0435 \u043a\u043e\u043c\u0430\u043d\u0434\u044b.\n\r\x1b[(special)mTAB\x1b[0m\x1b[20G\u0417\u0430\u0432\u0435\u0440\u0448\u0438\u0442\u044c \u0432\u0432\u043e\u0434 \u043f\u0440\u0435\u0434\u043b\u043e\u0436\u0435\u043d\u043d\u044b\u043c \u0432\u0430\u0440\u0438\u0430\u043d\u0442\u043e\u043c.\n\r\x1b[(special)m\u041f\u0440\u0430\u0432\u044b\u0439/\u043b\u0435\u0432\u044b\u0439 CTRL\x1b[0m\x1b[20G\u041f\u0435\u0440\u0435\u043a\u043b\u044e\u0447\u0438\u0442\u044c \u0432\u0430\u0440\u0438\u0430\u043d\u0442 \u0430\u0432\u0442\u043e\u0434\u043e\u043f\u043e\u043b\u043d\u0435\u043d\u0438\u044f, \u043a\u043e\u0433\u0434\u0430 \u0438\u0445 \u0434\u043e\u0441\u0442\u0443\u043f\u043d\u043e \u043d\u0435\u0441\u043a\u043e\u043b\u044c\u043a\u043e.\n\r\n\r\u041d\u0430\u0436\u043c\u0438\u0442\u0435 \x1b!URL=http://intersystems-community.github.io/webterminal/#docs (\u0437\u0434\u0435\u0441\u044c) \u0447\u0442\u043e\u0431\u044b \u043e\u0437\u043d\u0430\u043a\u043e\u043c\u0438\u0442\u044c\u0441\u044f \u0441 \u043f\u043e\u043b\u043d\u043e\u0439 \u0434\u043e\u043a\u0443\u043c\u0435\u043d\u0442\u0430\u0446\u0438\u0435\u0439."},info:{en:"Cach\xe9 WEB Terminal v4.9.1\n\rAuthor:\x1b[32G\x1b!URL=https://nikita.tk (Nikita Savchenko) (ZitRo)\n\rWebsite:\x1b[32G\x1b!URL=https://intersystems-community.github.io/webterminal (GitHub Pages)\n\rDocumentation:\x1b[32G\x1b!URL=http://intersystems-community.github.io/webterminal/#docs (GitHub Pages)\n\rRepository:\x1b[32G\x1b!URL=https://github.com/intersystems-community/webterminal (GitHub)\n\rBug/Feature Tracker:\x1b[32G\x1b!URL=https://github.com/intersystems-community/webterminal/issues (GitHub)\n\r2013-"+(new Date).getFullYear()+" \xa9 Nikita Savchenko",ru:"Cach\xe9 WEB Terminal v4.9.1\n\r\u0410\u0432\u0442\u043e\u0440:\x1b[32G\x1b!URL=https://nikita.tk (\u041d\u0438\u043a\u0438\u0442\u0430 \u0421\u0430\u0432\u0447\u0435\u043d\u043a\u043e) (ZitRo)\n\r\u0412\u0435\u0431\u0441\u0430\u0439\u0442:\x1b[32G\x1b!URL=https://intersystems-community.github.io/webterminal (\u0421\u0442\u0440\u0430\u043d\u0438\u0446\u0430 \u043f\u0440\u043e\u0435\u043a\u0442\u0430)\n\r\u0414\u043e\u043a\u0443\u043c\u0435\u043d\u0442\u0430\u0446\u0438\u044f:\x1b[32G\x1b!URL=http://intersystems-community.github.io/webterminal/#docs (\u041d\u0430 \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0435 \u043f\u0440\u043e\u0435\u043a\u0442\u0430)\n\r\u0420\u0435\u043f\u043e\u0437\u0438\u0442\u043e\u0440\u0438\u0439:\x1b[32G\x1b!URL=https://github.com/intersystems-community/webterminal (GitHub)\n\r\u0411\u0430\u0433/\u0424\u0438\u0447 \u0442\u0440\u0435\u043a\u0435\u0440:\x1b[32G\x1b!URL=https://github.com/intersystems-community/webterminal/issues (GitHub)\n\r2013-"+(new Date).getFullYear()+" \xa9 \u041d\u0438\u043a\u0438\u0442\u0430 \u0421\u0430\u0432\u0447\u0435\u043d\u043a\u043e"},beforeInit:{en:"Terminal load complete. Getting auth key...",ru:"\u0422\u0435\u0440\u043c\u0438\u043d\u0430\u043b \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043d. \u041f\u043e\u043b\u0443\u0447\u0435\u043d\u0438\u0435 \u043a\u043b\u044e\u0447\u0430 \u0434\u043b\u044f \u0430\u0432\u0442\u043e\u0440\u0438\u0437\u0430\u0446\u0438\u0438..."},unSerRes:{en:"Unknown server response: %s",ru:"\u041d\u0435\u043e\u043f\u043e\u0437\u043d\u0430\u043d\u043d\u044b\u0439 \u043e\u0442\u0432\u0435\u0442 \u0441\u0435\u0440\u0432\u0435\u0440\u0430: %s"},wsRefuse:{en:"Server refused WebSocket connection with the next message: %s",
+         ru:"\u0421\u0435\u0440\u0432\u0435\u0440 \u043e\u0442\u043a\u043b\u043e\u043d\u0438\u043b \u0441\u043e\u0435\u0434\u0438\u043d\u0435\u043d\u0438\u0435 \u0447\u0435\u0440\u0435\u0437 WebSocket \u0441\u043e \u0441\u043b\u0435\u0434\u0443\u044e\u0449\u0438\u043c \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0435\u043c: %s"},wsReadErr:{en:"WebSocket read error",ru:"\u041e\u0448\u0438\u0431\u043a\u0430 WebSocket \u043f\u0440\u0438 \u0447\u0442\u0435\u043d\u0438\u0438"},wsParseErr:{en:"WebSocket message parse error",ru:"\u041e\u0448\u0431\u0438\u043a\u0430 \u0434\u0435\u0441\u0435\u0440\u0435\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438 WebSocket-\u0444\u0440\u0435\u0439\u043c\u0430"},wsAbnormal:{en:"WebSocket abnormal exit occurred",ru:"\u041f\u0440\u043e\u0438\u0437\u043e\u0448\u043b\u043e \u043d\u0435\u0442\u0440\u0430\u0434\u0438\u0446\u0438\u043e\u043d\u043d\u043e\u0435 \u0437\u0430\u043a\u0440\u044b\u0442\u0438\u0435 WebSocket-\u0441\u043e\u0435\u0434\u0438\u043d\u0435\u043d\u0438\u044f"},availConfLoc:{en:"WebTerminal's local configuration (persists in the browser):",ru:"\u041b\u043e\u043a\u0430\u043b\u044c\u043d\u0430\u044f \u043a\u043e\u043d\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044f \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b\u0430 (\u0445\u0440\u0430\u043d\u0438\u0442\u0441\u044f \u0432 \u0431\u0440\u0430\u0443\u0437\u0435\u0440\u0435):"},availConfGlob:{en:"WebTerminal's global configuration (persists on the server):",ru:"\u0413\u043b\u043e\u0431\u0430\u043b\u044c\u043d\u0430\u044f \u043a\u043e\u043d\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044f \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b\u0430 (\u0445\u0440\u0430\u043d\u0438\u0442\u0441\u044f \u043d\u0430 \u0441\u0435\u0440\u0432\u0435\u0440\u0435):"},confHintSet:{en:"To change any option, enter \x1b[(special)m/config\x1b[0m \x1b[(variable)mkey\x1b[0m = \x1b[(constant)mvalue\x1b[0m. Enter \x1b[(special)m/config\x1b[0m \x1b[(global)mdefault\x1b[0m to reset \x1b[4mlocal\x1b[0m configuration.",ru:"\u0427\u0442\u043e\u0431\u044b \u0438\u0437\u043c\u0435\u043d\u0438\u0442\u044c \u043e\u043f\u0446\u0438\u044e, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \x1b[(special)m/config\x1b[0m \x1b[(variable)m\u043a\u043b\u044e\u0447\x1b[0m = \x1b[(constant)m\u0437\u043d\u0430\u0447\u0435\u043d\u0438\u0435\x1b[0m. \u0412\u0432\u0435\u0434\u0438\u0442\u0435 \x1b[(special)m/config\x1b[0m \x1b[(global)mdefault\x1b[0m \u0447\u0442\u043e\u0431\u044b \u0441\u0431\u0440\u043e\u0441\u0438\u0442\u044c \x1b[4m\u043b\u043e\u043a\u0430\u043b\u044c\u043d\u0443\u044e\x1b[0m \u043a\u043e\u043d\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044e."},confNoKey:{en:"No option \x1b[(variable)m%s\x1b[0m.",ru:"\u041d\u0435\u0442 \u043e\u043f\u0446\u0438\u0438 \x1b[(variable)m%s\x1b[0m."},confInvVal:{en:"Invalid value for \x1b[(variable)m%s\x1b[0m. Only the next values available: %s",ru:"\u041d\u0435\u0434\u043e\u043f\u0443\u0441\u0442\u0438\u043c\u043e\u0435 \u0437\u043d\u0430\u0447\u0435\u043d\u0438\u0435 \u0434\u043b\u044f \x1b[(variable)m%s\x1b[0m. \u0414\u043e\u043f\u0443\u0441\u0442\u0438\u043c\u044b \u0442\u043e\u043b\u044c\u043a\u043e \u0441\u043b\u0435\u0434\u0443\u044e\u0449\u0438\u0435 \u0437\u043d\u0430\u0447\u0435\u043d\u0438\u044f: %s"},firstLaunchMessage:{en:"Welcome to WebTerminal! Type \x1b[(special)m/help\x1b[0m special command to see how to use all the features.",ru:"\u0414\u043e\u0431\u0440\u043e \u043f\u043e\u0436\u0430\u043b\u043e\u0432\u0430\u0442\u044c \u0432 \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b! \u0412\u0432\u0435\u0434\u0438\u0442\u0435 \u0441\u043f\u0435\u0446\u0438\u0430\u043b\u044c\u043d\u0443\u044e \u043a\u043e\u043c\u0430\u043d\u0434\u0443 \x1b[(special)m/help\x1b[0m \u0447\u0442\u043e\u0431\u044b \u0443\u0437\u043d\u0430\u0442\u044c \u043e\u0431\u043e \u0432\u0441\u0435\u0445 \u0435\u0433\u043e \u043e\u0441\u043e\u0431\u0435\u043d\u043d\u043e\u0441\u0442\u044f\u0445."},badSQL:{en:"Mistake in SQL statement, %s",ru:"\u041e\u0448\u0438\u0431\u043a\u0430 \u0432 SQL-\u0437\u0430\u043f\u0440\u043e\u0441\u0435, %s"},sqlErr:{en:"SQL Error, %s",ru:"SQL \u043e\u0448\u0438\u0431\u043a\u0430, %s"},sqlMaxRows:{en:"The maximum number of rows displayed is %s. Adjust the limit by typing <span class='m special'>/config</span> <span class='m variable'>sqlMaxResults</span> = <span class='m constant'>100500</span> if you need more.",ru:"\u0412\u044b\u0432\u0435\u0434\u0435\u043d\u043e \u043c\u0430\u043a\u0441\u0438\u043c\u0443\u043c %s \u0440\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442\u043e\u0432. \u0415\u0441\u043b\u0438 \u043d\u0435\u043e\u0431\u0445\u043e\u0434\u0438\u043c\u043e \u043e\u0442\u043e\u0431\u0440\u0430\u0436\u0430\u0442\u044c \u0431\u043e\u043b\u044c\u0448\u0435 \u0440\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442\u043e\u0432, \u0432\u044b \u043c\u043e\u0436\u0435\u0442\u0435 \u0438\u0437\u043c\u0435\u043d\u0438\u0442\u044c \u044d\u0442\u043e\u0442 \u043b\u0438\u043c\u0438\u0442, \u043d\u0430\u0431\u0440\u0430\u0432 <span class='m special'>/config</span> <span class='m variable'>sqlMaxResults</span> = <span class='m constant'>100500</span>."},sqlNoData:{en:"Nothing to display",ru:"\u0422\u0443\u0442 \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435\u0442"},tracingUsage:{en:"To watch for changes in file, enter \x1b[(special)m/trace\x1b[0m \x1b[(string)m/path/to/file\x1b[0m.\r\nFor changes in global dimentions use \x1b[(special)m/trace\x1b[0m \x1b[(global)m^globalName\x1b[0m.\r\nTo stop watching for changes, enter \x1b[(special)m/trace\x1b[0m \x1b[(global)mstop\x1b[0m.",ru:"\u0427\u0442\u043e\u0431\u044b \u0441\u043b\u0435\u0434\u0438\u0442\u044c \u0437\u0430 \u0438\u0437\u043c\u0435\u043d\u0435\u043d\u0438\u044f\u043c\u0438 \u0432 \u0444\u0430\u0439\u043b\u0435, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \x1b[(special)m/trace\x1b[0m \x1b[(string)m/path/to/file\x1b[0m.\r\n\u0414\u043b\u044f \u043d\u0430\u0431\u043b\u044e\u0434\u0435\u043d\u0438\u044f \u0437\u0430 \u0438\u0437\u043c\u0435\u0440\u0435\u043d\u0438\u044f\u043c\u0438 \u0433\u043b\u043e\u0431\u0430\u043b\u043e\u0432 \u0438\u0441\u043f\u043e\u043b\u044c\u0437\u0443\u0439\u0442\u0435 \x1b[(special)m/trace\x1b[0m \x1b[(global)m^globalName\x1b[0m.\r\n\u0427\u0442\u043e\u0431\u044b \u043e\u0441\u0442\u0430\u043d\u043e\u0432\u0438\u0442\u044c \u043d\u0430\u0431\u043b\u044e\u0434\u0435\u043d\u0438\u0435, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \x1b[(special)m/trace\x1b[0m \x1b[(global)mstop\x1b[0m."},traceStopOK:{en:"Tracing stopped.",ru:"\u0412\u0441\u0435 \u043d\u0430\u0431\u043b\u044e\u0434\u0435\u043d\u0438\u044f \u043e\u0441\u0442\u0430\u043d\u043e\u0432\u043b\u0435\u043d\u044b."},traceStopNotOK:{en:"Nothing is being traced.",ru:"\u041d\u0435\u0442 \u0430\u043a\u0442\u0438\u0432\u043d\u044b\u0445 \u043d\u0430\u0431\u043b\u044e\u0434\u0435\u043d\u0438\u0439."},traceBad:{en:"Unable to trace %s.",ru:"\u041d\u0435\u0432\u043e\u0437\u043c\u043e\u0436\u043d\u043e \u0442\u0440\u0430\u0441\u0441\u0438\u0440\u043e\u0432\u0430\u0442\u044c %s."},traceStart:{en:"Starting tracing %s.",ru:"\u041d\u0430\u0447\u0438\u043d\u0430\u0435\u043c \u043d\u0430\u0431\u043b\u044e\u0434\u0430\u0442\u044c \u0437\u0430 %s."},traceStop:{en:"Stopping tracing %s.",ru:"\u0417\u0430\u0432\u0435\u0440\u0448\u0430\u0435\u043c \u043d\u0430\u0431\u043b\u044e\u0434\u0430\u0442\u044c \u0437\u0430 %s."},traceSight:{en:"Currently tracing %s.",ru:"\u041d\u0430 \u0434\u0430\u043d\u043d\u044b\u0439 \u043c\u043e\u043c\u0435\u043d\u0442 \u043d\u0430\u0431\u043b\u044e\u0434\u0430\u0435\u043c \u0437\u0430 %s."},favDesc:{en:"To save the command, enter \x1b[(special)m/favorite\x1b[0m \x1b[(constant)mname\x1b[0m \x1b[(keyword)mdo\x1b[0m \x1b[(string)many ObjectScript code\x1b[0m.\r\nTo load the command, enter \x1b[(special)m/favorite\x1b[0m \x1b[(constant)mname\x1b[0m.\r\nTo delete saved commands, use \x1b[(special)m/favorite\x1b[0m \x1b[(wrong)mdelete\x1b[0m \x1b[(constant)mname\x1b[0m.\r\nTo delete all saved commands, use just \x1b[(special)m/favorite\x1b[0m \x1b[(wrong)mdelete\x1b[0m.",ru:"\u0414\u043b\u044f \u0442\u043e\u0433\u043e \u0447\u0442\u043e\u0431\u044b \u0437\u0430\u043f\u043e\u043c\u043d\u0438\u0442\u044c \u043a\u043e\u043c\u0430\u043d\u0434\u0443, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \x1b[(special)m/favorite\x1b[0m \x1b[(constant)m\u0438\u043c\u044f\x1b[0m \x1b[(keyword)mdo\x1b[0m \x1b[(string)m\u043b\u044e\u0431\u043e\u0439 ObjectScript \u043a\u043e\u0434\x1b[0m.\r\n\u0414\u043b\u044f \u0442\u043e\u0433\u043e \u0447\u0442\u043e\u0431\u044b \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044c \u043a\u043e\u043c\u0430\u043d\u0434\u0443, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \x1b[(special)m/favorite\x1b[0m \x1b[(constant)m\u0438\u043c\u044f\x1b[0m.\r\n\u0427\u0442\u043e\u0431\u044b \u0443\u0434\u0430\u043b\u044f\u0442\u044c \u0441\u043e\u0445\u0440\u0430\u043d\u0451\u043d\u043d\u044b\u0435 \u043a\u043e\u043c\u0430\u043d\u0434\u044b, \u0438\u0441\u043f\u043e\u043b\u044c\u0437\u0443\u0439\u0442\u0435 \x1b[(special)m/favorite\x1b[0m \x1b[(wrong)mdelete\x1b[0m \x1b[(constant)m\u0438\u043c\u044f\x1b[0m.\r\n\u0427\u0442\u043e\u0431\u044b \u0443\u0434\u0430\u043b\u0438\u0442\u044c \u0432\u0441\u0435 \u043a\u043e\u043c\u0430\u043d\u0434\u044b, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \x1b[(special)m/favorite\x1b[0m \x1b[(wrong)mdelete\x1b[0m."},favs:{en:"Saved commands:",ru:"\u0421\u043e\u0445\u0440\u0430\u043d\u0451\u043d\u043d\u044b\u0435 \u043a\u043e\u043c\u0430\u043d\u0434\u044b:"},favSet:{en:"Command \x1b[(constant)m%s\x1b[0m saved.",ru:"\u041a\u043e\u043c\u0430\u043d\u0434\u0430 \x1b[(constant)m%s\x1b[0m \u0441\u043e\u0445\u0440\u0430\u043d\u0435\u043d\u0430."},favDelOK:{en:"Command \x1b[(constant)m%s\x1b[0m deleted.",ru:"\u041a\u043e\u043c\u043c\u0430\u043d\u0434\u0430 \x1b[(constant)m%s\x1b[0m \u0443\u0434\u0430\u043b\u0435\u043d\u0430."},favDelNotOK:{en:"No \x1b[(constant)m%s\x1b[0m command.",ru:"\u041a\u043e\u043c\u043c\u0430\u043d\u0434\u0430 \x1b[(constant)m%s\x1b[0m \u043d\u0435 \u0431\u044b\u043b\u0430 \u0437\u0430\u0434\u0430\u043d\u0430."},favDel:{en:"All commands are deleted.",ru:"\u0412\u0441\u0435 \u043a\u043e\u043c\u0430\u043d\u0434\u044b \u0443\u0434\u0430\u043b\u0435\u043d\u044b."},favKey:{en:"Name",ru:"\u0418\u043c\u044f"},favVal:{en:"Value",ru:"\u0417\u043d\u0430\u0447\u0435\u043d\u0438\u0435"},noFav:{en:"Command \x1b[(constant)m%s\x1b[0m has never been saved.",ru:"\u041a\u043e\u043c\u0430\u043d\u0434\u0430 \x1b[(constant)m%s\x1b[0m \u043d\u0435 \u0431\u044b\u043b\u0430 \u0441\u043e\u0445\u0440\u0430\u043d\u0435\u043d\u0430 \u0440\u0430\u043d\u0435\u0435."},jsErr:{en:"JavaScript error occurred: %s",ru:"\u041f\u0440\u043e\u0438\u0437\u043e\u0448\u043b\u0430 \u043e\u0448\u0438\u0431\u043a\u0430 JavaScript: %s"},wsNormalClose:{en:"Session ended.",ru:"\u0421\u0435\u0441\u0441\u0438\u044f \u0437\u0430\u043a\u043e\u043d\u0447\u0435\u043d\u0430."},logOut:{en:"Logging out...",ru:"\u0412\u044b\u0445\u043e\u0434\u0438\u043c..."},unLogOut:{en:"Your browser is too old or too weird to support log out functionality. Please, restart the browser manually.",ru:"\u0412\u0430\u0448 \u0431\u0440\u0430\u0443\u0437\u0435\u0440 \u0441\u043b\u0438\u0448\u043a\u043e\u043c \u0441\u0442\u0440\u0430\u043d\u043d\u044b\u0439 \u0438\u043b\u0438 \u0441\u0442\u0430\u0440\u044b\u0439, \u0438 \u043e\u043d \u043d\u0435 \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u0438\u0432\u0430\u0435\u0442 \u0444\u0443\u043d\u043a\u0446\u0438\u043e\u043d\u0430\u043b\u044c\u043d\u043e\u0441\u0442\u044c \u0432\u044b\u0445\u043e\u0434\u0430. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u043f\u0435\u0440\u0435\u0437\u0430\u043f\u0443\u0441\u0442\u0438\u0442\u0435 \u0431\u0440\u0430\u0443\u0437\u0435\u0440 \u0432\u0440\u0443\u0447\u043d\u0443\u044e."},unNS:{en:"Unable to change namespace to %s.",ru:"\u041d\u0435 \u043f\u043e\u043b\u0443\u0447\u0430\u0435\u0442\u0441\u044f \u043f\u043e\u043c\u0435\u043d\u044f\u0442\u044c \u043e\u0431\u043b\u0430\u0441\u0442\u044c \u043d\u0430 %s."},cpTerm:{en:"Terminal process was terminated.",ru:"\u041f\u0440\u043e\u0446\u0435\u0441\u0441 \u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b\u0430 \u0431\u044b\u043b \u0437\u0430\u0432\u0435\u0440\u0448\u0451\u043d."}}},{}],349:[function(e,t,n){"use strict";function r(){return function(){var e=[];for(var t in v.default){for(var n in v.default[t])e.push(n);return e}}()}function o(e){return"s"!==e&&"d"!==e&&v.default.hasOwnProperty(e)}function a(){var e=navigator.language;return y.length||(n.LOCALES=y=r()),-1===y.indexOf(e)&&(e=h),e}function i(){var e=f.get(_);return y.length||(n.LOCALES=y=r()),e&&-1!==y.indexOf(e)||(e=navigator.language,-1===y.indexOf(e)&&(e=h)),e}function s(e){return-1!==y.indexOf(e)?(g=e,f.set(_,e),!0):((0,p.printLine)(l("noLocale",e)),!1)}function l(e){for(var t=arguments.length,n=Array(t>1?t-1:0),r=1;r<t;r++)n[r-1]=arguments[r];var o=-1;return(v.default[e]?v.default[e][g]||"["+e+"."+g+"?]":"["+e+"?]").replace(/%[sn]/g,function(e){return void 0!==n[++o]?"s"===e.charAt(1)?n[o].toString():parseFloat(n[o]):e})}function u(e){for(var t=arguments.length,n=Array(t>1?t-1:0),r=1;r<t;r++)n[r-1]=arguments[r];var a=0;return(e+"").replace(m,function(e,t,r){return o(t)?l.apply(window,[t].concat(r?r.split(",").map(function(e){return u(e)}):void 0)):void 0!==n[a]?n[a++]:e})}Object.defineProperty(n,"__esModule",{value:!0}),n.LOCALES=void 0,n.getLocales=r,n.suggestLocale=a,n.getLocale=i,n.setLocale=s,n.get=l,n.parse=u;var c=e("../storage"),f=function(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}(c),p=e("../output"),d=e("./dictionary"),v=function(e){return e&&e.__esModule?e:{default:e}}(d),y=n.LOCALES=[],_="terminal-localization",h="en",m=/%([a-zA-Z0-9]+)(?:\(([^)]*)\))?/g,g=a()},{"../output":356,"../storage":361,"./dictionary":348}],350:[function(e,t,n){"use strict";function r(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}function o(){var e=arguments.length>0&&void 0!==arguments[0]&&arguments[0];(0,l.get)("https://intersystems-community.github.io/webterminal/terminal.json",function(){var t=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{};t.error||void 0===t.motd||p.onAuth(function(){return a(t,e)})})}function a(e){var t=arguments.length>1&&void 0!==arguments[1]&&arguments[1];(m.get("updateCheck")||t)&&(c.clearPrompt(),e.motd&&m.get("initMessage")&&v.printLine(e.motd),e.versions instanceof Array&&i(e.versions),c.reprompt())}function i(e){var t=[],n="",r="";if(e.forEach(function(e){s(e.v,p.VERSION)&&((e.changes||[]).forEach(function(n,r){return t.push("\x1b[2m"+((0===r?e.v:"")+(0===r?":":"")+"                        ").substring(0,16)+"\x1b[0m"+("string"==typeof n?n:n.text||""))}),s(e.v,n)&&(n=e.v,r=e.url))}),t.length){
+         if(v.printLine(_.get("updReady",'javascript:window.updateTerminal("'+n+'","'+r+'")')),!r)return void v.printLine(_.get("noUpdUrl","https://intersystems-community.github.io/webterminal/#downloads"));v.printLine(t.join("\r\n"))}}function s(e,t){for(var n=e.split(/[\-\.]/g),r=t.split(/[\-\.]/g),o=0;o<n.length;o++)if(isNaN(+n[o])||isNaN(+r[o])){if(n[o]>r[o])return!0;if(n[o]<r[o])return!1}else{if(+n[o]>+r[o])return!0;if(+n[o]<+r[o])return!1}return r.length>n.length}Object.defineProperty(n,"__esModule",{value:!0}),n.checkUpdate=o;var l=e("../lib"),u=e("../input"),c=r(u),f=e("../index"),p=r(f),d=e("../output"),v=r(d),y=e("../localization"),_=r(y);e("./update");var h=e("../config"),m=r(h);m.get("updateCheck")&&o()},{"../config":337,"../index":340,"../input":345,"../lib":347,"../localization":349,"../output":356,"./update":351}],351:[function(e,t,n){"use strict";function r(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}var o=e("../index"),a=r(o),i=e("../output"),s=r(i),l=e("../input"),u=r(l),c=e("../localization"),f=r(c),p=e("../server"),d=r(p),v=!1;window.updateTerminal=function(e,t){v||(t=t.replace(/^http:/,"https:"),v=!0,u.hideInput(),s.printLine(f.get("updStart",a.VERSION,e)),s.printLine("URL: "+t),s.printLine(f.get("rSerUpd")),d.send("Update",t))}},{"../index":340,"../input":345,"../localization":349,"../output":356,"../server":360}],352:[function(e,t,n){"use strict";function r(e){this._lineElement=document.createElement("div"),this._lineElement.className="line",this.text="",this.INDEX=e,this.HTML_LINE=!1,this.HTMLRendered=!1,this.graphicProperties=[],this.setIndex(e),this._lineElement.style.height=s.SYMBOL_HEIGHT+"px",u.output.appendChild(this._lineElement)}function o(e,t){for(var n=["g"],r=[],o="span",a=[],i=0;i<e.length;i+=2){if(e[i+1].class&&n.push(e[i+1].class),e[i+1].style&&r.push(e[i+1].style),e[i+1].attrs)for(var s in e[i+1].attrs)a.push([s,e[i+1].attrs[s]]);e[i+1].tag&&(o=e[i+1].tag)}var l=document.createElement(o);l.className=n.join(" "),r.length&&l.setAttribute("style",r.join(";"));var u=!0,c=!1,f=void 0;try{for(var p,d=a[Symbol.iterator]();!(u=(p=d.next()).done);u=!0){var v=p.value;l.setAttribute(v[0],v[1])}}catch(e){c=!0,f=e}finally{try{!u&&d.return&&d.return()}finally{if(c)throw f}}return l.textContent=t,l}function a(e){for(var t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:0,n=arguments[2],r=arguments.length>3&&void 0!==arguments[3]?arguments[3]:[],o=arguments.length>4&&void 0!==arguments[4]&&arguments[4],a=r,i=t;i<n;i++)void 0!==e[i]&&(a=e[i],o&&(e[i]=void 0));return a}function i(e,t){if(e.length!==t.length)return!1;for(var n=0;n<e.length;n++)if(e[n]!==t[n])return!1;return!0}Object.defineProperty(n,"__esModule",{value:!0}),n.LINE_CLASS_NAME=void 0,n.Line=r;var s=e("./index"),l=e("../elements"),u=function(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}(l);n.LINE_CLASS_NAME="line";r.prototype.setIndex=function(e){this.INDEX=e,this._lineElement.setAttribute("index",e),this._lineElement.style.top=e*s.SYMBOL_HEIGHT+"px"},r.prototype.setHTML=function(e){this.HTML_LINE=!0,this.text=e,this._lineElement.className="html line",this.HTMLRendered=!1,this.render(),this._lineElement.style.maxHeight=Math.max(s.SYMBOL_HEIGHT,this._lineElement.offsetHeight)+"px"},r.prototype.getHeight=function(){return this._lineElement.offsetHeight},r.prototype.render=function(){if(this.HTML_LINE){if(this.HTMLRendered)return;return this._lineElement.innerHTML=this.text,void(this.HTMLRendered=!0)}var e=this._lineElement.style.display;this._lineElement.style.display="none",this._lineElement.innerHTML="";for(var t=0,n=0;n<this.text.length;n++)void 0!==this.graphicProperties[n]&&(t!==n&&this._lineElement.appendChild(o(this.graphicProperties[t]||[],this.text.substring(t,n))),t=n);this.text.length>0&&this._lineElement.appendChild(o(this.graphicProperties[t]||[],this.text.substr(t))),this._lineElement.style.display=e},r.prototype.print=function(e){var t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:this.text.length;this.HTML_LINE&&(this.HTML_LINE=!1,this._lineElement.className="line",this._lineElement.style.maxHeight="",this.text="");var n=e.substr(0,s.WIDTH-t),r=t+n.length,o=a(this.graphicProperties,0,t,[]),l=a(this.graphicProperties,t,r,o,!0);return i(o,s.GRAPHIC_PROPERTIES)||(this.graphicProperties[t]=s.GRAPHIC_PROPERTIES.slice()),(l.length||s.GRAPHIC_PROPERTIES.length)&&!i(l,s.GRAPHIC_PROPERTIES)&&r<this.text.length&&(this.graphicProperties[r]=a(this.graphicProperties,r,r+1,l),0===s.GRAPHIC_PROPERTIES.length&&0===this.graphicProperties[r].length&&(this.graphicProperties[r]=void 0)),this.text=t<this.text.length?this.text.substring(0,t)+n+this.text.substr(r):this.text+new Array(t-this.text.length+1).join(" ")+n,n.length===e.length?"":e.substr(n.length)},r.prototype.clear=function(){this.text="",this.graphicProperties={},this.render()},r.prototype.remove=function(){this._lineElement.parentNode&&this._lineElement.parentNode.removeChild(this._lineElement)}},{"../elements":338,"./index":356}],353:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0});n.COLOR_8BIT={0:"#000000",1:"#800000",2:"#008000",3:"#808000",4:"#000080",5:"#800080",6:"#008080",7:"#c0c0c0",8:"#808080",9:"#ff0000",10:"#00ff00",11:"#ffff00",12:"#0000ff",13:"#ff00ff",14:"#00ffff",15:"#ffffff",16:"#000000",17:"#00005f",18:"#000087",19:"#0000af",20:"#0000df",21:"#0000ff",22:"#005f00",23:"#005f5f",24:"#005f87",25:"#005faf",26:"#005fdf",27:"#005fff",28:"#008700",29:"#00875f",30:"#008787",31:"#0087af",32:"#0087df",33:"#0087ff",34:"#00af00",35:"#00af5f",36:"#00af87",37:"#00afaf",38:"#00afdf",39:"#00afff",40:"#00df00",41:"#00df5f",42:"#00df87",43:"#00dfaf",44:"#00dfdf",45:"#00dfff",46:"#00ff00",47:"#00ff5f",48:"#00ff87",49:"#00ffaf",50:"#00ffdf",51:"#00ffff",52:"#5f0000",53:"#5f005f",54:"#5f0087",55:"#5f00af",56:"#5f00df",57:"#5f00ff",58:"#5f5f00",59:"#5f5f5f",60:"#5f5f87",61:"#5f5faf",62:"#5f5fdf",63:"#5f5fff",64:"#5f8700",65:"#5f875f",66:"#5f8787",67:"#5f87af",68:"#5f87df",69:"#5f87ff",70:"#5faf00",71:"#5faf5f",72:"#5faf87",73:"#5fafaf",74:"#5fafdf",75:"#5fafff",76:"#5fdf00",77:"#5fdf5f",78:"#5fdf87",79:"#5fdfaf",80:"#5fdfdf",81:"#5fdfff",82:"#5fff00",83:"#5fff5f",84:"#5fff87",85:"#5fffaf",86:"#5fffdf",87:"#5fffff",88:"#870000",89:"#87005f",90:"#870087",91:"#8700af",92:"#8700df",93:"#8700ff",94:"#875f00",95:"#875f5f",96:"#875f87",97:"#875faf",98:"#875fdf",99:"#875fff",100:"#878700",101:"#87875f",102:"#878787",103:"#8787af",104:"#8787df",105:"#8787ff",106:"#87af00",107:"#87af5f",108:"#87af87",109:"#87afaf",110:"#87afdf",111:"#87afff",112:"#87df00",113:"#87df5f",114:"#87df87",115:"#87dfaf",116:"#87dfdf",117:"#87dfff",118:"#87ff00",119:"#87ff5f",120:"#87ff87",121:"#87ffaf",122:"#87ffdf",123:"#87ffff",124:"#af0000",125:"#af005f",126:"#af0087",127:"#af00af",128:"#af00df",129:"#af00ff",130:"#af5f00",131:"#af5f5f",132:"#af5f87",133:"#af5faf",134:"#af5fdf",135:"#af5fff",136:"#af8700",137:"#af875f",138:"#af8787",139:"#af87af",140:"#af87df",141:"#af87ff",142:"#afaf00",143:"#afaf5f",144:"#afaf87",145:"#afafaf",146:"#afafdf",147:"#afafff",148:"#afdf00",149:"#afdf5f",150:"#afdf87",151:"#afdfaf",152:"#afdfdf",153:"#afdfff",154:"#afff00",155:"#afff5f",156:"#afff87",157:"#afffaf",158:"#afffdf",159:"#afffff",160:"#df0000",161:"#df005f",162:"#df0087",163:"#df00af",164:"#df00df",165:"#df00ff",166:"#df5f00",167:"#df5f5f",168:"#df5f87",169:"#df5faf",170:"#df5fdf",171:"#df5fff",172:"#df8700",173:"#df875f",174:"#df8787",175:"#df87af",176:"#df87df",177:"#df87ff",178:"#dfaf00",179:"#dfaf5f",180:"#dfaf87",181:"#dfafaf",182:"#dfafdf",183:"#dfafff",184:"#dfdf00",185:"#dfdf5f",186:"#dfdf87",187:"#dfdfaf",188:"#dfdfdf",189:"#dfdfff",190:"#dfff00",191:"#dfff5f",192:"#dfff87",193:"#dfffaf",194:"#dfffdf",195:"#dfffff",196:"#ff0000",197:"#ff005f",198:"#ff0087",199:"#ff00af",200:"#ff00df",201:"#ff00ff",202:"#ff5f00",203:"#ff5f5f",204:"#ff5f87",205:"#ff5faf",206:"#ff5fdf",207:"#ff5fff",208:"#ff8700",209:"#ff875f",210:"#ff8787",211:"#ff87af",212:"#ff87df",213:"#ff87ff",214:"#ffaf00",215:"#ffaf5f",216:"#ffaf87",217:"#ffafaf",218:"#ffafdf",219:"#ffafff",220:"#ffdf00",221:"#ffdf5f",222:"#ffdf87",223:"#ffdfaf",224:"#ffdfdf",225:"#ffdfff",226:"#ffff00",227:"#ffff5f",228:"#ffff87",229:"#ffffaf",230:"#ffffdf",231:"#ffffff",232:"#080808",233:"#121212",234:"#1c1c1c",235:"#262626",236:"#303030",237:"#3a3a3a",238:"#444444",239:"#4e4e4e",240:"#585858",241:"#606060",242:"#666666",243:"#767676",244:"#808080",245:"#8a8a8a",246:"#949494",247:"#9e9e9e",248:"#a8a8a8",249:"#b2b2b2",250:"#bcbcbc",251:"#c6c6c6",252:"#d0d0d0",253:"#dadada",254:"#e4e4e4",255:"#eeeeee"}},{}],354:[function(e,t,n){"use strict";function r(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}Object.defineProperty(n,"__esModule",{value:!0});var o=function(){function e(e,t){var n=[],r=!0,o=!1,a=void 0;try{for(var i,s=e[Symbol.iterator]();!(r=(i=s.next()).done)&&(n.push(i.value),!t||n.length!==t);r=!0);}catch(e){o=!0,a=e}finally{try{!r&&s.return&&s.return()}finally{if(o)throw a}}return n}return function(t,n){if(Array.isArray(t))return t;if(Symbol.iterator in Object(t))return e(t,n);throw new TypeError("Invalid attempt to destructure non-iterable instance")}}(),a=e("./index"),i=r(a),s=e("./const"),l=e("../server"),u=r(l),c=e("../input/caret"),f=r(c),p=void 0,d=[],v={},y=void 0,_={"\f":function(){i.clear()},"\n":function(){i.scrollDisplay(1)},"\r":function(){i.setCursorX(1)},"\t":function(){for(var e=i.getCursorX(),t=i.getTabs(),n=0;n<t.length;n++)if(e<t[n])return void i.setCursorX(t[n])},"\x1bH":function(){i.setTabAt(i.getCursorX())},"\x1b[g":function(){i.clearTab(i.getCursorX())},"\x1b[3g":function(){i.clearTab()},"\x1b[r":function(){i.disableScrolling()},"\x1b[{\\d*}{;?}{\\d*}r":function(e){var t=e[0]||1,n=e[2]||i.HEIGHT;if(e[1]||(t=e[0]||e[2]),!t)return void i.disableScrolling();i.enableScrolling(t,n)},"\x1bD":function(){i.scrollDisplay(1)},"\x1bM":function(){i.scrollDisplay(-1)},"\x1b[c":function(){u.send("i","\x1b10c")},"\x1b[5n":function(){u.send("i","\x1b0n")},"\x1b[6n":function(){u.send("i","\x1b["+i.getCursorY()+";"+i.getCursorY()+"n")},"\x1bc":function(){i.LINE_WRAP_ENABLED=!0},"\x1b[7h":function(){i.LINE_WRAP_ENABLED=!0},"\x1b[7l":function(){i.LINE_WRAP_ENABLED=!1},"\x1b[?25h":function(){f.hide()},"\x1b[?25l":function(){f.update()},"\x1b(":function(){},"\x1b)":function(){},"\x1b[{\\d*}i":function(){window.print()},"\x1b[{\\d*}{;?}{\\d*}H":p=function(e){e[0]||e[2]?(e[0]&&i.setCursorY(+e[0]),e[2]&&i.setCursorX(+e[2])):(i.setCursorX(1),i.setCursorY(1))},"\x1b[{\\d*}{;?}{\\d*}f":p,"\x1b[{\\d*}A":function(e){i.setCursorY(Math.max(1,i.getCursorY()-(+e[0]||1)))},"\x1b[{\\d*}B":function(e){i.setCursorY(Math.min(i.HEIGHT,i.getCursorY()+(+e[0]||1)))},"\x1b[{\\d*}C":function(e){i.setCursorX(Math.min(i.WIDTH,i.getCursorX()+(+e[0]||1)))},"\x1b[{\\d*}D":function(e){i.setCursorX(Math.max(1,i.getCursorX()-(+e[0]||1)))},"\x1b[{\\d*}G":function(e){i.setCursorX(+e[0])},"\x1b[s":function(){d=[i.getCursorX(),i.getCursorY()]},"\x1b[u":function(){d.length&&(i.setCursorX(d[0]),i.setCursorY(d[1]))},"\x1b7":function(){d=[i.getCursorX(),i.getCursorY()],v=JSON.parse(JSON.stringify(i.GRAPHIC_PROPERTIES))},"\x1b8":function(){d.length&&(i.setCursorX(d[0]),i.setCursorY(d[1]),i.GRAPHIC_PROPERTIES=JSON.parse(JSON.stringify(v)))},"\x1b[K":y=function(){var e=i.getCursorX(),t=i.GRAPHIC_PROPERTIES;i.resetGraphicProperties(),i.getCurrentLine().print(new Array(i.WIDTH-e+2).join(" "),e-1),i.GRAPHIC_PROPERTIES=t},"\x1b[0K":y,"\x1b[1K":function(){var e=i.getCursorX(),t=i.GRAPHIC_PROPERTIES;i.resetGraphicProperties(),i.getCurrentLine().print(new Array(e+1).join(" "),0),i.GRAPHIC_PROPERTIES=t},"\x1b[2K":function(){i.getCurrentLine().clear()},"\x1b[J":y=function(){var e=i.getCursorY()+1;for(_["\x1b[K"]();e<i.HEIGHT+1;e++)i.getLineByCursorY(e).clear()},"\x1b[0J":y,"\x1b[1J":function(){var e=i.getCursorY()-1;for(_["\x1b[1K"]();e>0;e--)i.getLineByCursorY(e).clear()},"\x1b[2J":function(){for(var e=1;e<i.HEIGHT+1;e++)i.getLineByCursorY(e).clear();i.setCursorX(1),i.setCursorY(1)},'\x1b[{\\d*};"{[^"]}"p':function(e){console.log("todo: implement key assignment",e)},"\x1b[{\\d*(?:;\\d*)*}m":function(e){for(var t=e[0].split(";"),n=0;n<t.length;n++)"0"!==t[n]&&""!==t[n]?"22"!==t[n]?"38"!==t[n]&&"48"!==t[n]||"5"!==t[n+1]?i.setGraphicProperty(t[n],{class:"m"+t[n]}):(i.setGraphicProperty(+t[n],{class:"m"+t[n],style:("48"===t[n]?"background-":"")+"color:"+s.COLOR_8BIT[t[n+2]]}),n+=2):(i.clearGraphicProperty(1),i.clearGraphicProperty(2)):i.resetGraphicProperties()},"\x1b[({[\\w\\-]+})m":function(e){var t=e[0];t&&i.setGraphicProperty(9,{class:t})},"\x1b!URL={[^\\x20]*} ({[^\\)]+})":function(e){var t=o(e,2),n=t[0],r=void 0===n?"":n,a=t[1],s=void 0===a?"":a;i.setGraphicProperty(9,{tag:"a",attrs:{href:r,target:0===r.indexOf("javascript:")?"":"_blank"}}),i.immediatePlainPrint(s),i.clearGraphicProperty(9)},"\x1b!<HTML>{![^]*(?=<\\/HTML>)}</HTML>":function(e){var t=o(e,1),n=t[0],r=i.getCurrentLine();r.setHTML(n);var a=r.INDEX+Math.ceil(r.getHeight()/i.SYMBOL_HEIGHT);i.getLineByIndex(a),i.setCursorYToLineIndex(a),i.setCursorX(1)}};n.default=_},{"../input/caret":342,"../server":360,"./const":353,"./index":356}],355:[function(e,t,n){"use strict";function r(e,t){var n=arguments.length>2&&void 0!==arguments[2]?arguments[2]:[];if(!t)return 0;var o=void 0,a=-1,i=void 0,s=void 0;if(e[t[0]]){if("function"==typeof e[t[0]])return e[t[0]](n),1;if((a=r(e[t[0]],t.substr(1),n))>0)return 1+a}for(var l in e[""]){var u="!"===l[0]?l.slice(1):l;if(o=t.match("^"+u)){if((i=r(e[""][l],t.substr(s=o.join().length),n.concat(o)))>0)return i+s;a=i>a?i:a}else"!"===l[0]&&(a=0)}return a}function o(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"",t=r(s,e);return-1===t?e.substr(1):0===t?e:e.substr(t)}Object.defineProperty(n,"__esModule",{value:!0}),n.ESC_CHARS_MASK=void 0,n.applyEscapeSequence=o;var a=e("./esc"),i=function(e){return e&&e.__esModule?e:{default:e}}(a),s={};for(var l in i.default)!function(){for(var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"",t=arguments[1],n=0,r=void 0,o=void 0,a=s;n<e.length;)if("{"!==e[n]||-1===(r=e.indexOf("}",n)))a=a[e[n]]=n+1<e.length?a[e[n]]?a[e[n]]:{}:t,n++;else{try{o=new RegExp(e.substring(n+1,r))}catch(t){console.error('Malformed RegExp in "'+e+'" pattern.',t);continue}n=r+1,a=(a[""]=a[""]?a[""]:{})[o.source]=n<e.length?a[""][o.source]?a[""][o.source]:{}:t}}(l,i.default[l]);n.ESC_CHARS_MASK=/[\x00-\x1F]/;window.applyEscapeSequence=o},{"./esc":354}],356:[function(e,t,n){"use strict";function r(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}function o(){return re.x}function a(){return re.y}function i(){return ne.length}function s(){return P(re.y).INDEX}function l(){
+         return Math.max(ne.length-J,0)}function u(e){return h(e-l()+1,!1)}function c(e){Y.clearPrompt(),f(e),Y.reprompt()}function f(e){(0,q.onOutput)(e),ee+=e,$&&k()}function p(e){f(e+"\r\n")}function d(e){for(var t=0;t<oe.length;t++){if(e<oe[t])return void oe.splice(t,0,e);if(e===oe[t])return}oe.push(e)}function v(e){var t=void 0;e?-1!==(t=oe.indexOf(e))&&oe.splice(t,1):oe=[]}function y(){return oe}function _(e){return re.x=Math.max(1,Math.min(Q,e)),e===re.x}function h(e){var t=!(arguments.length>1&&void 0!==arguments[1])||arguments[1];return re.y=t?Math.max(1,Math.min(J,e)):e,P(re.y),e===re.y}function m(e,t){Z.enabled=!0,Z.lineStart=Math.max(e,1),Z.lineEnd=Math.min(t,J),_(1),h(1)}function g(){Z.enabled=!1,_(1),h(1)}function b(e){var t=a();if(!Z.enabled||!(Z.lineStart===t&&e<0||Z.lineEnd===t&&e>0))return t+e>J&&S(1),void h(t+e);var n=l(),r=Z.lineStart===t;O(n+Z.lineEnd);var o=ne.slice(n+Z.lineStart-1,n+Z.lineEnd);o[r?"pop":"shift"]().remove();var i=!0,s=!1,u=void 0;try{for(var c,f=o[Symbol.iterator]();!(i=(c=f.next()).done);i=!0){var p=c.value;p.setIndex(p.INDEX+(r?1:-1))}}catch(e){s=!0,u=e}finally{try{!i&&f.return&&f.return()}finally{if(s)throw u}}o[r?"unshift":"push"](new N.Line(n+(r?Z.lineStart:Z.lineEnd)-1)),ne.splice.apply(ne,[n+Z.lineStart-1,o.length].concat(o))}function x(e){var t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{};-1!==te.indexOf(+e)&&w(+e),te.push(+e,{class:t.class,style:t.style,tag:t.tag,attrs:t.attrs})}function w(e){var t=te.indexOf(+e);-1!==t&&te.splice(t,2)}function j(){n.GRAPHIC_PROPERTIES=te=[]}function A(){return O(l()+re.y-1)}function S(e){for(;e>0;e--)ne.push(new N.Line(ne.length))}function k(){if(ee){for(var e=void 0,t=void 0;-1!==(e=ee.search(G.ESC_CHARS_MASK));)if(C(ee.substring(0,e)),ee=(0,G.applyEscapeSequence)((t=ee).substr(e)),ee.length===t.length)return;C(ee),ee="",T()}}function E(e){return C(e)}function I(){W.default["\r"](),W.default["\n"]()}function C(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"";if(e.length){var t=void 0,n=void 0;do{t=A(),n=e.length,e=t.print(e,re.x-1),ae[t.INDEX]=!0,n-=e.length,e?(W.default["\r"](),W.default["\n"]()):_(re.x+n)||(W.default["\r"](),W.default["\n"]())}while(e);0===ie&&(ie=setTimeout(function(){for(var e in ae)ne[e]&&ne[e].render(),delete ae[e];ie=0,T()},X))}}function O(e){var t=Math.max(e-ne.length+1,0);return t>0&&S(t),ne[e]}function P(e){return O(l()+(e-1))}function L(){b(1);var e=l()+a()-1,t=ne.length,n=t-e-1,r=ne.length-l();S(Math.max(J-n,r)),_(1),h(1),T()}function M(){var e=!0,t=!1,n=void 0;try{for(var r,o=ne[Symbol.iterator]();!(e=(r=o.next()).done);e=!0){r.value.remove()}}catch(e){t=!0,n=e}finally{try{!e&&o.return&&o.return()}finally{if(t)throw n}}ne=[],Z.enabled=!1,_(1),h(1)}function T(){F.output.scrollTop=l()*V}function R(){var e=s(),t=document.createElement("span"),r=document.createElement("div"),o=F.output.style.overflowY,a=void 0,i=void 0,l=void 0;if(F.output.style.overflowY="scroll",r.className=N.LINE_CLASS_NAME,F.output.appendChild(r),a=F.output.offsetWidth-r.offsetWidth,F.output.style.overflowY=o,t.innerHTML="XXXXXXXXXX",r.appendChild(t),n.SYMBOL_WIDTH=K=t.offsetWidth/10||8.8,n.SYMBOL_HEIGHT=V=t.offsetHeight||19,n.WIDTH=Q=(i=Math.floor((F.terminal.offsetWidth-a)/K))||32*V,n.HEIGHT=J=(l=Math.floor(F.terminal.offsetHeight/V))||80*K,F.input.style.width=Q*K+"px",F.output.removeChild(r),u(e),!i||!l){setTimeout(R,25);try{console.warn("[WebTerminal] Size calculations delayed for 25s due to WebTerminal is not attached to the page. If this message doesn't stop appearing, check if WebTerminal's iFrame is visible and is attached to the DOM.")}catch(e){}}}Object.defineProperty(n,"__esModule",{value:!0}),n.GRAPHIC_PROPERTIES=n.LINE_WRAP_ENABLED=n.HEIGHT=n.WIDTH=n.SYMBOL_WIDTH=n.SYMBOL_HEIGHT=void 0,n.getCursorX=o,n.getCursorY=a,n.getLinesNumber=i,n.getCurrentLineIndex=s,n.getTopLineIndex=l,n.setCursorYToLineIndex=u,n.printAsync=c,n.print=f,n.printLine=p,n.setTabAt=d,n.clearTab=v,n.getTabs=y,n.setCursorX=_,n.setCursorY=h,n.enableScrolling=m,n.disableScrolling=g,n.scrollDisplay=b,n.setGraphicProperty=x,n.clearGraphicProperty=w,n.resetGraphicProperties=j,n.getCurrentLine=A,n.pushLines=S,n.immediatePlainPrint=E,n.newLine=I,n.getLineByIndex=O,n.getLineByCursorY=P,n.clear=L,n.reset=M,n.scrollDown=T;var N=e("./Line"),D=e("../elements"),F=r(D),H=e("../lib"),G=e("./escStateMachine"),U=e("./esc"),W=function(e){return e&&e.__esModule?e:{default:e}}(U),B=e("../input"),Y=r(B),z=e("../init"),q=e("../index"),X=10,V=n.SYMBOL_HEIGHT=12,K=n.SYMBOL_WIDTH=8,Q=n.WIDTH=0,J=n.HEIGHT=0,Z=(n.LINE_WRAP_ENABLED=!0,{enabled:!1,lineStart:1,lineEnd:1}),$=!1;(0,z.onInit)(function(){$=!0,k()});var ee="",te=n.GRAPHIC_PROPERTIES=[],ne=[],re={x:1,y:1},oe=[];(0,H.onWindowLoad)(function(){window.addEventListener("resize",R),R();for(var e=9;e<Q;e+=8)oe.push(e)});var ae={},ie=0},{"../elements":338,"../index":340,"../init":341,"../input":345,"../lib":347,"./Line":352,"./esc":354,"./escStateMachine":355}],357:[function(e,t,n){(function(t){"use strict";function r(){return f}function o(e){for(var t=void 0,n=[];null!==(t=l.exec(e));)for(var r=1;r<t.length;r++)if(t[r]){n.push({type:r,value:t[r],class:u[r-1]||""});break}return l.lastIndex=0,n}function t(e){for(var t=arguments.length>1&&void 0!==arguments[1]?arguments[1]:e.length,n=!(arguments.length>2&&void 0!==arguments[2])||arguments[2],r=arguments.length>3&&void 0!==arguments[3]?arguments[3]:"CWTInput",l=o(e),u=[],c=[],d=p[r]||1,v=0,y=d,_=0,h=0,m=0,g=!1,b=y,x=0,w=[],j=-1,A=-1,S=0,k=-1,E="";_<l.length&&S++<100;){void 0===f[y]&&(console.warn("No state",f[y]),y=d),_>h&&(h=_,S=0);for(var I=!1,C=y,O=void 0;m<(f[y]||[]).length;m++){var P=f[y][m],L=l[_];if(null===P[0])_--;else{if(!1===P[0])break;if(!0===P[0])L.type===s.TYPE_WHITESPACE&&(g=!0),"string"==typeof L.value&&(v+=L.value.length);else if(0===P[0])c.push([y,m,u.length,v,_,w.length]),_--;else if(P[0].type===s.TYPE_WHITESPACE){if(g)_--;else{if(P[0].type!==L.type)continue;"string"==typeof L.value&&(v+=L.value.length)}g=!0}else if(P[0].type===s.TYPE_ID){if(P[0].type!==L.type)continue;if(v<t&&t<=v+L.value.length&&(E=L.value.substr(0,t-v)[P[0].value.CI?"toLowerCase":"toString"]()),"string"==typeof P[0].value){if(L.value!==P[0].value)continue}else if("object"===a(P[0].value)&&void 0!==P[0].value.value&&L.value[P[0].value.CI?"toLowerCase":"toString"]()!==P[0].value.value)continue;"string"==typeof L.value&&(v+=L.value.length),O=L.value[P[0].value.CI?"toLowerCase":"toString"](),g=!1}else if(P[0].type===s.TYPE_STRING){if(P[0].type!==L.type)continue;"string"==typeof L.value&&(v+=L.value.length),g=!1}else if(P[0].type===s.TYPE_CONSTANT){if(P[0].type!==L.type)continue;"string"==typeof L.value&&(v+=L.value.length),g=!1}else if(P[0].type===s.TYPE_CHAR){if(P[0].type!==L.type)continue;if("string"==typeof P[0].value){if(L.value!==P[0].value)continue}else if("object"===a(P[0].value)&&void 0!==P[0].value.value&&L.value!==P[0].value.value)continue;"string"==typeof L.value&&(v+=L.value.length),g=!1}}if(P[0]&&"object"===a(P[0].value)&&(P[0].value.class&&(L.class=P[0].value.class),x&&k!==_||(P[0].value.type&&"*"!==P[0].value.type?w.push({type:P[0].value.type,value:-1===k?L.value:L.value.substring(0,t-(v-L.value.length))}):"*"===P[0].value.type||w[w.length-1]&&","===w[w.length-1].type||w.push({type:",",value:""}))),void 0!==P[2]&&u.push(P[2]),0===P[1]){for(;;)if(y=u.pop(),c.length&&c[c.length-1][2]===u.length&&c.pop(),0!==y)break;void 0===y&&(y=0)}else y=P[1];_++,I=!0;break}if(I){var M=l[_]?l[_].value.length:1;_>j&&(b=y),m=0,_>j&&v<=t&&t<v+M&&(k=_,x=l[_-1]&&l[_-1].type===s.TYPE_ID?C:b,O&&(E=O))}else if(function(){if(j<_&&(j=_),!c.length)return-1===A&&(A=Math.max(_,j)),!0;var e=c.pop();return y=e[0],m=e[1]+1,u.length>e[2]&&(u=u.slice(0,e[2])),v=e[3],_=e[4],!x&&w.length>e[5]&&(w=w.slice(0,e[5])),!1}()){m=0,y=0,g=!1,l[_]&&("string"==typeof l[_].value&&(v+=l[_].value.length),j<=_&&(l[_].class="error"),_++),u=[],c=[];var T=l[_]?l[_].value.length:1;!x&&v<=t&&t<v+T&&l[_-1]&&l[_-1].type===s.TYPE_ID&&A===_-1&&(x=b,E=l[_-1].value.toLowerCase())}}return S>=100&&console.error("Statement",l,"looped more than 100 times without a progress, exiting."),v!==e.length&&console.error("Oops, you've caught a rare exception! parsedStringLength != string.length ("+v+" != "+e.length+") for '"+e+"'. Please, report this issue."),{lexemes:l,suggestions:0!==x&&n?(0,i.suggest)(x,E):[],collector:w}}Object.defineProperty(n,"__esModule",{value:!0});var a="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e};n.getAutomaton=r,n.process=t;var i=e("../autocomplete"),s=e("./pushdownAutomaton"),l=/([\s\t]+)|([a-z]+[a-z0-9]*)|("(?:"(?=")"|[^"])*(?:"|$))|([0-9]*\.[0-9]+|[0-9]+)|([^])/gi,u=["","","string","constant",""],c=function(e){return e},f=c([[[!1,0]],[[{type:5,value:{value:"/",class:"special"}},2,0],[null,3]],[[{type:2,value:{value:"help",class:"special"}},0],[{type:2,value:{value:"clear",class:"special"}},0],[{type:2,value:{value:"config",class:"special"}},6],[{type:2,value:{value:"favorite",class:"special"}},12],[{type:2,value:{value:"info",class:"special"}},0],[{type:2,value:{value:"logout",class:"special"}},0],[{type:2,value:{value:"sql",class:"special"}},0],[{type:2,value:{value:"trace",class:"special"}},18],[{type:2,value:{value:"update",class:"special"}},0]],[[null,4,5]],[[{type:2,value:{CI:!0,value:"break",class:"keyword"}},22,23],[{type:2,value:{CI:!0,value:"b",class:"keyword"}},22,23],[{type:2,value:{CI:!0,value:"close",class:"keyword"}},22,25],[{type:2,value:{CI:!0,value:"c",class:"keyword"}},22,25],[{type:2,value:{CI:!0,value:"continue",class:"keyword"}},22,0],[{type:2,value:{CI:!0,value:"do",class:"keyword"}},22,29],[{type:2,value:{CI:!0,value:"d",class:"keyword"}},22,29],[{type:2,value:{CI:!0,value:"write",class:"keyword"}},22,35],[{type:2,value:{CI:!0,value:"w",class:"keyword"}},22,35],[{type:2,value:{CI:!0,value:"hang",class:"keyword"}},22,42],[{type:2,value:{CI:!0,value:"h",class:"keyword"}},22,42],[{type:2,value:{CI:!0,value:"halt",class:"keyword"}},22,0],[{type:2,value:{CI:!0,value:"job",class:"keyword"}},22,43],[{type:2,value:{CI:!0,value:"j",class:"keyword"}},22,43],[{type:2,value:{CI:!0,value:"merge",class:"keyword"}},22,48],[{type:2,value:{CI:!0,value:"m",class:"keyword"}},22,48],[{type:2,value:{CI:!0,value:"open",class:"keyword"}},22,54],[{type:2,value:{CI:!0,value:"o",class:"keyword"}},22,54],[{type:2,value:{CI:!0,value:"zwrite",class:"keyword"}},22,68],[{type:2,value:{CI:!0,value:"zw",class:"keyword"}},22,68],[{type:2,value:{CI:!0,value:"set",class:"keyword"}},22,73],[{type:2,value:{CI:!0,value:"s",class:"keyword"}},22,73],[{type:2,value:{CI:!0,value:"try",class:"keyword"}},79],[{type:2,value:{CI:!0,value:"kill",class:"keyword"}},22,97],[{type:2,value:{CI:!0,value:"k",class:"keyword"}},22,97],[{type:2,value:{CI:!0,value:"quit",class:"keyword"}},22,106],[{type:2,value:{CI:!0,value:"q",class:"keyword"}},22,106],[{type:2,value:{CI:!0,value:"return",class:"keyword"}},22,106],[{type:2,value:{CI:!0,value:"read",class:"keyword"}},22,108],[{type:2,value:{CI:!0,value:"r",class:"keyword"}},22,108],[{type:2,value:{CI:!0,value:"tstart",class:"keyword"}},22,0],[{type:2,value:{CI:!0,value:"ts",class:"keyword"}},22,0],[{type:2,value:{CI:!0,value:"tcommit",class:"keyword"}},22,0],[{type:2,value:{CI:!0,value:"tc",class:"keyword"}},22,0],[{type:2,value:{CI:!0,value:"trollback",class:"keyword"}},22,0],[{type:2,value:{CI:!0,value:"tro",class:"keyword"}},22,0],[{type:2,value:{CI:!0,value:"use",class:"keyword"}},22,116],[{type:2,value:{CI:!0,value:"u",class:"keyword"}},22,116],[{type:2,value:{CI:!0,value:"xecute",class:"keyword"}},22,126],[{type:2,value:{CI:!0,value:"x",class:"keyword"}},22,126],[{type:2,value:{CI:!0,value:"zload",class:"keyword"}},22,131],[{type:2,value:{CI:!0,value:"zl",class:"keyword"}},22,131],[{type:2,value:{CI:!0,value:"znspace",class:"keyword"}},22,133],[{type:2,value:{CI:!0,value:"zn",class:"keyword"}},22,133],[{type:2,value:{CI:!0,value:"if",class:"keyword"}},135],[{type:2,value:{CI:!0,value:"i",class:"keyword"}},135],[{type:2,value:{CI:!0,value:"for",class:"keyword"}},154],[{type:2,value:{CI:!0,value:"f",class:"keyword"}},154],[{type:2,value:{CI:!0,value:"while",class:"keyword"}},171]],[[{type:1},3]],[[{type:1},7]],[[{type:2,value:{value:"default",class:"global"}},0],[{type:2,value:{value:"defaultNamespace",class:"variable"}},8],[{type:2,value:{value:"initMessage",class:"variable"}},8],[{type:2,value:{value:"language",class:"variable"}},8],[{type:2,value:{value:"maxHistorySize",class:"variable"}},8],[{type:2,value:{value:"sqlMaxResults",class:"variable"}},8],[{type:2,value:{value:"suggestions",class:"variable"}},8],[{type:2,value:{value:"syntaxHighlight",class:"variable"}},8],[{type:2,value:{value:"serverName",class:"variable"}},8],[{type:2,value:{value:"updateCheck",class:"variable"}},8],[{type:2,value:{class:"variable"}},8]],[[{type:1},9],[null,9]],[[{type:5,value:{value:"="}},10]],[[{type:1},11],[null,11]],[[{type:2,value:{class:"constant"}},0],[{type:3,value:{class:"string"}},0],[{type:4,value:{class:"constant"}},0]],[[{type:1},13]],[[{type:2,value:{value:"delete",class:"wrong"}},14],[{type:2,value:{class:"constant",type:"favorites"}},16],[{type:4,value:{type:"favorites"}},16]],[[{type:1},15]],[[{type:2,value:{class:"constant",type:"favorites"}},0],[{type:4,value:{type:"favorites"}},0]],[[{type:1},17]],[[null,4,0]],[[{type:1},19]],[[{type:2,value:{value:"stop",class:"global"}},0],[{type:5,value:{value:"^",class:"global",type:"global"}},20,0],[{type:5,value:{type:"filename",class:"string"}},21],[{type:2,value:{type:"filename",class:"string"}},21]],[[{type:5,value:{value:"%",class:"global",type:"global"}},257],[null,257]],[[{type:5,value:{type:"filename",class:"string"}},21],[{type:2,value:{type:"filename",class:"string"}},21],[{type:1},21]],[[{type:5,value:{value:":"}},37,0],[null,0]],[[{type:1},24],[null,24]],[[{type:3},0],[{type:4},0],[null,0]],[[{type:1},26]],[[{type:3},27],[{type:4},27]],[[{type:5,value:{value:","}},28],[null,0]],[[{type:1},26],[null,26]],[[{type:1},30]],[[null,31,32]],[[{type:5,value:{value:"^",class:"global"}},194],[{type:2,value:{class:"variable",type:"variable"}},197],[null,206,0]],[[{type:1},33],[null,33]],[[{type:5,value:{value:","}},34],[null,0]],[[{type:1},30],[null,30]],[[{type:1},36]],[[{type:5,value:{value:"!",class:"special"}},39],[0,37,39],[0,38,39],[null,39]],[[{type:4},241],[{type:5,value:{value:"("}},229],[{type:5,value:{value:"[",class:"argument"}},232],[{type:5,value:{value:"{",class:"argument"}},236],[{type:5,value:{value:"-"}},37,241],[{type:5,value:{value:"'"}},37,241],[{type:3},241],[0,50,241],[0,206,241],[0,240,241]],[[{type:5,value:{value:"!",class:"special"}},193],[{type:5,value:{value:"#",class:"special"}},193],[{type:5,value:{value:"?",class:"special"}},37,0]],[[{type:1},40],[null,40]],[[{type:5,value:{value:","}},41],[null,0]],[[{type:1},36],[null,36]],[[{type:1},37,0]],[[{type:1
+         },44]],[[null,31,45]],[[{type:1},46],[null,46]],[[{type:5,value:{value:","}},47],[null,0]],[[{type:1},44],[null,44]],[[{type:1},49]],[[{type:5,value:{value:"^",class:"global",type:"global"}},20,49],[null,50,49],[{type:1},51],[null,51]],[[{type:5,value:{value:"^",class:"global",type:"global"}},20,0],[{type:5,value:{value:"@"}},248],[null,248]],[[{type:5,value:{value:"="}},52]],[[{type:1},53],[null,53]],[[{type:5,value:{value:"^",class:"global",type:"global"}},20,0],[null,50,0]],[[{type:1},55]],[[{type:3},56],[{type:4},56]],[[{type:5,value:{value:":"}},57],[null,66]],[[{type:5,value:{value:"("}},58,59],[{type:4},64],[{type:3},66]],[[{type:5,value:{value:"/",class:"special"}},189],[{type:3},192],[null,0]],[[{type:5,value:{value:")"}},60]],[[{type:5,value:{value:":"}},61],[null,66]],[[{type:4},62],[{type:3},66]],[[{type:5,value:{value:":"}},63],[null,66]],[[{type:3},66]],[[{type:5,value:{value:":"}},65],[null,66]],[[{type:3},66]],[[{type:5,value:{value:","}},67],[null,0]],[[{type:1},55],[null,55]],[[{type:1},69]],[[0,37,70],[null,70]],[[{type:1},71],[null,71]],[[{type:5,value:{value:","}},72],[null,0]],[[{type:1},69],[null,69]],[[{type:1},74]],[[null,75,76]],[[{type:5,value:{value:"("}},180],[null,50,183]],[[{type:1},77],[null,77]],[[{type:5,value:{value:","}},78],[null,0]],[[{type:1},74],[null,74]],[[{type:1},80],[null,80]],[[{type:5,value:{value:"{"}},81]],[[{type:1},82],[null,82]],[[{type:5,value:{value:"}"}},83],[null,4,96]],[[{type:1},84],[null,84]],[[{type:2,value:{CI:!0,value:"catch",class:"keyword"}},85]],[[{type:1},86],[null,86]],[[{type:5,value:{value:"("}},87],[{type:2,value:{class:"variable"}},91]],[[{type:1},88],[null,88]],[[{type:2,value:{class:"variable"}},89]],[[{type:1},90],[null,90]],[[{type:5,value:{value:")"}},91]],[[{type:1},92],[null,92]],[[{type:5,value:{value:"{"}},93]],[[{type:1},94],[null,94]],[[{type:5,value:{value:"}"}},0],[null,4,95]],[[{type:1},93]],[[{type:1},81]],[[{type:1},98]],[[{type:5,value:{value:"("}},99],[null,50,103]],[[{type:1},100,101],[null,100,101]],[[null,50,186]],[[{type:1},102],[null,102]],[[{type:5,value:{value:")"}},103]],[[{type:1},104],[null,104]],[[{type:5,value:{value:","}},105],[null,0]],[[{type:1},98],[null,98]],[[{type:1},107],[null,107]],[[0,37,0],[null,0]],[[{type:1},109]],[[{type:3},113],[{type:2,value:{class:"variable",type:"variable"}},110],[{type:5,value:{value:"*",class:"special"}},111],[null,38,113]],[[{type:5,value:{value:"#",class:"special"}},37,112],[null,112]],[[{type:2,value:{class:"variable",type:"variable"}},112]],[[{type:5,value:{value:":",class:"special"}},37,113],[null,113]],[[{type:1},114],[null,114]],[[{type:5,value:{value:","}},115],[null,0]],[[{type:1},109],[null,109]],[[{type:1},117]],[[{type:3},119],[{type:4},119],[{type:5,value:{value:"$",class:"keyword"}},118]],[[{type:2,value:{CI:!0,value:"io",class:"keyword"}},119],[{type:2,value:{CI:!0,value:"principal",class:"keyword"}},119]],[[{type:5,value:{value:":"}},120],[null,124]],[[{type:5,value:{value:"("}},58,121],[{type:3},124]],[[{type:5,value:{value:")"}},122]],[[{type:5,value:{value:":"}},123],[null,124]],[[{type:3},124]],[[{type:5,value:{value:","}},125],[null,0]],[[{type:1},117],[null,117]],[[{type:1},127]],[[{type:3},22,128]],[[{type:1},129],[null,129]],[[{type:5,value:{value:","}},130],[null,0]],[[{type:1},127],[null,127]],[[{type:1},132]],[[{type:2,value:{type:"routine",class:"global"}},0]],[[{type:1},134]],[[{type:3},0]],[[{type:1},37,136]],[[{type:1},137],[null,137]],[[{type:5,value:{value:"{"}},138],[null,4,0]],[[{type:1},139],[null,139]],[[null,4,140]],[[{type:1},141],[null,141]],[[{type:5,value:{value:"}"}},142],[null,139]],[[{type:1},143],[null,143]],[[{type:2,value:{CI:!0,value:"else",class:"keyword"}},144],[{type:2,value:{CI:!0,value:"elseif",class:"keyword"}},150]],[[{type:1},145],[null,145]],[[{type:5,value:{value:"{"}},146]],[[{type:1},147],[null,147]],[[null,4,148]],[[{type:1},149],[null,149]],[[{type:5,value:{value:"}"}},0],[null,147]],[[{type:1},37,151]],[[{type:1},152],[null,152]],[[{type:5,value:{value:"{"}},153]],[[{type:1},139],[null,139]],[[{type:1},155]],[[{type:2,value:{type:"variable",class:"variable"}},156]],[[{type:5,value:{value:"="}},37,157]],[[{type:1},158],[null,158]],[[{type:5,value:{value:":"}},159],[null,163]],[[{type:1},37,160],[null,37,160]],[[{type:1},161],[null,161]],[[{type:5,value:{value:":"}},162],[null,163]],[[{type:1},37,163],[null,37,163]],[[{type:1},164],[null,164]],[[{type:5,value:{value:","}},165],[null,166]],[[{type:1},155],[null,155]],[[{type:5,value:{value:"{"}},167]],[[{type:1},168],[null,168]],[[null,4,169]],[[{type:1},170],[null,170]],[[{type:5,value:{value:"}"}},0],[null,168]],[[{type:1},172]],[[null,37,173]],[[{type:1},174],[null,174]],[[{type:5,value:{value:","}},175],[{type:5,value:{value:"{"}},176]],[[{type:1},172],[null,172]],[[{type:1},177],[null,177]],[[null,4,178]],[[{type:1},179],[null,179]],[[{type:5,value:{value:"}"}},0],[null,177]],[[{type:1},100,181],[null,100,181]],[[{type:1},182],[null,182]],[[{type:5,value:{value:")"}},183]],[[{type:1},184],[null,184]],[[{type:5,value:{value:"="}},185]],[[{type:1},37,0],[null,37,0]],[[{type:1},187],[null,187]],[[{type:5,value:{value:","}},188],[null,0]],[[{type:1},100],[null,100]],[[{type:2,value:{class:"special"}},190]],[[{type:5,value:{value:"="}},37,191],[null,191]],[[{type:5,value:{value:":"}},58],[null,0]],[[{type:5,value:{value:":"}},58],[null,0]],[[{type:5,value:{value:"!",class:"special"}},193],[{type:5,value:{value:"#",class:"special"}},193],[{type:5,value:{value:"?",class:"special"}},37,0],[null,0]],[[{type:5,value:{value:"%",type:"routine",class:"global"}},195],[null,195]],[[{type:2,value:{type:"routine",class:"global"}},196]],[[{type:5,value:{value:".",type:"routine",class:"global"}},194],[null,22,0]],[[{type:5,value:{value:".",type:"*"}},198]],[[{type:5,value:{value:"%",type:"memberMethod"}},199],[null,199]],[[{type:2,value:{type:"memberMethod"}},200]],[[{type:5,value:{value:"("}},201],[{type:5,value:{value:".",type:"*"}},198]],[[{type:1},202,203],[null,202,203]],[[0,252,0],[null,0]],[[{type:1},204],[null,204]],[[{type:5,value:{value:")"}},205]],[[{type:5,value:{value:".",type:"*"}},198],[null,22,0]],[[{type:5,value:{value:"#",class:"special"}},268],[{type:5,value:{value:"$",class:"special"}},278]],[[{type:5,value:{value:"("}},208],[{type:5,value:{value:"{",class:"argument"}},211],[{type:5,value:{value:"[",class:"argument"}},216],[{type:3},0],[{type:4},0]],[[{type:1},37,209],[null,37,209]],[[{type:1},210],[null,210]],[[{type:5,value:{value:")"}},0]],[[{type:1},212],[null,212]],[[{type:5,value:{value:"}",class:"argument"}},0],[null,213,214]],[[{type:3},221]],[[{type:1},215],[null,215]],[[{type:5,value:{value:"}",class:"argument"}},0]],[[{type:1},217],[null,217]],[[{type:5,value:{value:"]",class:"argument"}},0],[null,218,219]],[[{type:1},207,227],[null,207,227]],[[{type:1},220],[null,220]],[[{type:5,value:{value:"]",class:"argument"}},0]],[[{type:1},222],[null,222]],[[{type:5,value:{value:":"}},223]],[[{type:1},207,224],[null,207,224]],[[{type:1},225],[null,225]],[[{type:5,value:{value:","}},226],[null,0]],[[{type:1},213],[null,213]],[[{type:1},228],[null,228]],[[{type:5,value:{value:","}},218],[null,0]],[[{type:1},37,230],[null,37,230]],[[{type:1},231],[null,231]],[[{type:5,value:{value:")"}},241]],[[{type:1},233],[null,233]],[[{type:5,value:{value:"]",class:"argument"}},241],[null,218,234]],[[{type:1},235],[null,235]],[[{type:5,value:{value:"]",class:"argument"}},241]],[[{type:1},237],[null,237]],[[{type:5,value:{value:"}",class:"argument"}},241],[null,213,238]],[[{type:1},239],[null,239]],[[{type:5,value:{value:"}",class:"argument"}},241]],[[{type:5,value:{value:"$",class:"keyword"}},288]],[[{type:1},242],[null,242]],[[{type:5,value:{value:"+",class:"special"}},247],[{type:5,value:{value:"-",class:"special"}},247],[{type:5,value:{value:"*",class:"special"}},247],[{type:5,value:{value:"/",class:"special"}},247],[{type:5,value:{value:"_",class:"special"}},247],[{type:5,value:{value:"=",class:"special"}},247],[{type:5,value:{value:"'",class:"special"}},243],[{type:5,value:{value:"<",class:"special"}},244],[{type:5,value:{value:">",class:"special"}},244],[{type:5,value:{value:"&",class:"special"}},245],[{type:5,value:{value:"|",class:"special"}},246],[{type:5,value:{value:"[",class:"special"}},247],[{type:5,value:{value:"]",class:"special"}},247],[{type:5,value:{value:"#",class:"special"}},247],[null,0]],[[{type:5,value:{value:"=",class:"special"}},247],[{type:5,value:{value:">",class:"special"}},247],[{type:5,value:{value:"<",class:"special"}},247]],[[{type:5,value:{value:"=",class:"special"}},247],[null,247]],[[{type:5,value:{value:"&",class:"special"}},247],[null,247]],[[{type:5,value:{value:"|",class:"special"}},247]],[[{type:1},37,0],[null,37,0]],[[{type:2,value:{class:"variable",type:"variable"}},250],[{type:5,value:{value:"%",class:"variable",type:"variable"}},249]],[[{type:2,value:{class:"variable",type:"variable"}},250]],[[{type:5,value:{value:"("}},251],[null,255]],[[{type:1},252,253],[null,252,253]],[[{type:5,value:{value:".",class:"argument"}},294],[{type:5,value:{value:","}},295],[null,37,296]],[[{type:1},254],[null,254]],[[{type:5,value:{value:")"}},255]],[[{type:5,value:{value:".",type:"*"}},256,255],[null,0]],[[{type:5,value:{value:"%",type:"member"}},263],[{type:5,value:{value:"#",type:"member"}},263],[null,263]],[[{type:2,value:{class:"global",type:"global"}},258]],[[{type:5,value:{value:".",class:"global",type:"global"}},257],[null,259]],[[{type:5,value:{value:"("}},260],[null,0]],[[{type:1},202,261],[null,202,261]],[[{type:1},262],[null,262]],[[{type:5,value:{value:")"}},0]],[[{type:2,value:{type:"member"}},264]],[[{type:5,value:{value:"("}},265],[null,0]],[[{type:1},202,266],[null,202,266]],[[{type:1},267],[null,267]],[[{type:5,value:{value:")"}},0]],[[{type:5,value:{value:"#",class:"special"}},269]],[[{type:2,value:{CI:!0,value:"class",class:"special"}},270],[{type:2,value:{CI:!0,value:"super",class:"special"}},276]],[[{type:5,value:{value:"(",class:"special"}},271]],[[{type:5,value:{value:"%",type:"classname",class:"classname"}},272],[null,272]],[[{type:2,value:{type:"classname",class:"classname"}},273]],[[{type:5,value:{value:".",type:"classname",class:"classname"}},272],[{type:5,value:{value:")",class:"special",type:"*"}},274]],[[{type:5,value:{value:".",type:"*"}},275,0]],[[{type:5,value:{value:"#",type:"parameter",class:"keyword"}},282],[{type:5,value:{value:"%",type:"publicClassMember",class:"keyword"}},283],[null,283]],[[{type:5,value:{value:"(",class:"special"}},202,277]],[[{type:5,value:{value:")",class:"special"}},0]],[[{type:2,value:{CI:!0,value:"system",class:"special"}},279]],[[{type:5,value:{value:".",type:"classname",class:"classname"}},280]],[[{type:2,value:{type:"classname",class:"classname"}},281]],[[{type:5,value:{value:".",type:"*"}},275,0]],[[{type:2,value:{type:"parameter",class:"keyword"}},0]],[[{type:2,value:{type:"publicClassMember",class:"keyword"}},284]],[[{type:5,value:{value:"("}},285]],[[{type:1},202,286],[null,202,286]],[[{type:1},287],[null,287]],[[{type:5,value:{value:")"}},0]],[[{type:2,value:{CI:!0,class:"keyword",value:"ascii"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"bit"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"bitcount"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"bitfind"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"bitlogic"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"char"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"classmethod"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"classname"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"compile"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"data"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"decimal"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"double"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"extract"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"factor"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"find"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"fnumber"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"get"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"increment"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"inumber"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"isobject"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"isvaliddouble"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"isvalidnum"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"justify"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"length"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"lb"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listbuild"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listdata"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listfind"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listfromstring"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listget"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listlength"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listnext"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listsame"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listtostring"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listupdate"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listvalid"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"list"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"locate"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"match"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"method"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"name"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"nconvert"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"next"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"normalize"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"now"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"number"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"order"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"parameter"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"piece"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"prefetchoff"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"prefetchon"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"property"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"qlength"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"qsubscript"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"query"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"random"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"replace"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"reverse"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"sconvert"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"sequence"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"sortbegin"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"sortend"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"stack"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"text"}
+         },290],[{type:2,value:{CI:!0,class:"keyword",value:"translate"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"view"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"wascii"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"wchar"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"wextract"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"wfind"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"wiswide"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"wlength"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"wreverse"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"xecute"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"xecute"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zabs"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zarccos"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zarcsin"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zarctan"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zcos"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zcot"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zcsc"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zdate"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zdateh"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zdatetime"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zdatetimeh"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zexp"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zhex"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zln"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zlog"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zpower"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zsec"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zsin"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zsqr"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"ztan"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"ztime"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"ztimeh"}},290],[{type:2,value:{CI:!0,class:"keyword"}},290],[{type:5,value:{value:"$",class:"keyword"}},289],[null,290]],[[{type:2,value:{class:"keyword"}},290]],[[{type:5,value:{value:"("}},291],[null,0]],[[{type:1},202,292],[null,202,292]],[[{type:1},293],[null,293]],[[{type:5,value:{value:")"}},0]],[[{type:2,value:{class:"argument"}},296]],[[{type:1},252],[null,252]],[[{type:5,value:{value:","}},297],[null,0]],[[{type:1},252],[null,252]],[[{type:5,value:{value:"/",class:"special"}},2,0],[{type:2,value:{CI:!0,value:"delete",class:"keyword"}},299],[{type:2,value:{CI:!0,value:"update",class:"keyword"}},301],[{type:2,value:{CI:!0,value:"select",class:"keyword"}},303],[{type:2,value:{CI:!0,value:"call",class:"keyword"}},305]],[[{type:1},300,0]],[[null,338,374]],[[{type:1},302,0]],[[null,316,360]],[[{type:1},304,0]],[[{type:2,value:{CI:!0,value:"top",class:"keyword"}},323],[null,326]],[[{type:1},306,0]],[[null,316,317]],[[{type:2,value:{class:"variable",type:"sqlFieldName"}},308]],[[{type:5,value:{value:"."}},309],[null,310]],[[{type:2,value:{class:"variable",type:"sqlFieldName"}},310]],[[{type:1},311],[null,311]],[[{type:5,value:{value:"-"}},312],[null,0]],[[{type:5,value:{value:">"}},313]],[[{type:1},314],[null,314]],[[{type:2,value:{class:"variable",type:"sqlFieldName"}},315]],[[{type:1},311],[null,311]],[[{type:5,value:{value:"%",type:"sqlClassname",class:"classname"}},378],[null,378]],[[{type:5,value:{value:"_",type:"sqlClassname",class:"classname"}},317],[{type:2,value:{CI:!0,type:"sqlClassname",class:"classname"}},317],[null,318]],[[{type:5,value:{value:"("}},319]],[[{type:1},320,321],[null,320,321]],[[{type:5,value:{value:"("}},383],[{type:4},387],[{type:5,value:{value:"'",class:"string"}},386],[null,387]],[[{type:1},322],[null,322]],[[{type:5,value:{value:")"}},0]],[[{type:1},324]],[[{type:4},325]],[[{type:1},326]],[[{type:5,value:{value:"*",class:"special"}},337],[{type:2,value:{CI:!0,value:"avg",class:"keyword"}},327],[{type:2,value:{CI:!0,value:"count",class:"keyword"}},327],[{type:2,value:{CI:!0,value:"max",class:"keyword"}},327],[{type:2,value:{CI:!0,value:"min",class:"keyword"}},327],[null,307,331]],[[{type:5,value:{value:"("}},328]],[[{type:1},307,329],[null,307,329]],[[{type:1},330],[null,330]],[[{type:5,value:{value:")"}},337]],[[{type:2,value:{CI:!0,value:"as",class:"keyword"}},332],[null,335]],[[{type:1},333]],[[{type:2,value:{class:"variable"}},334]],[[{type:1},335],[null,335]],[[{type:5,value:{value:","}},336],[null,337]],[[{type:1},326],[null,326]],[[{type:1},338,339]],[[{type:2,value:{CI:!0,value:"from",class:"keyword"}},377]],[[{type:1},340],[null,340]],[[{type:2,value:{CI:!0,value:"order",class:"keyword"}},341,0],[{type:2,value:{CI:!0,value:"where",class:"keyword"}},342],[{type:2,value:{class:"variable"}},346],[null,0]],[[{type:1},351]],[[{type:1},343,344]],[[{type:4},409],[{type:2,value:{CI:!0,value:"null",class:"constant"}},409],[{type:5,value:{value:"("}},390],[{type:2,value:{CI:!0,value:"not",class:"keyword"}},400],[{type:5,value:{value:"'",class:"string"}},401],[{type:2,value:{CI:!0,value:"char",class:"keyword",type:"sqlFunc"}},402],[{type:2,value:{CI:!0,value:"ascii",class:"keyword",type:"sqlFunc"}},402],[{type:2,value:{class:"variable",type:"sqlFieldName"}},406]],[[{type:1},345],[null,345]],[[{type:2,value:{CI:!0,value:"order",class:"keyword"}},341,0],[null,0]],[[{type:1},347]],[[{type:2,value:{CI:!0,value:"order",class:"keyword"}},341,0],[{type:2,value:{CI:!0,value:"where",class:"keyword"}},348],[null,0]],[[{type:1},343,349]],[[{type:1},350],[null,350]],[[{type:2,value:{CI:!0,value:"order",class:"keyword"}},341,0],[null,0]],[[{type:2,value:{CI:!0,value:"by",class:"keyword"}},352]],[[{type:1},353]],[[{type:2,value:{class:"variable",type:"sqlFieldName"}},354]],[[{type:1},355],[null,355]],[[{type:2,value:{CI:!0,value:"desc",class:"keyword"}},356],[{type:2,value:{CI:!0,value:"asc",class:"keyword"}},357],[null,358]],[[{type:1},358],[null,358]],[[{type:1},358],[null,358]],[[{type:5,value:{value:","}},359],[null,0]],[[{type:1},353],[null,353]],[[{type:1},361]],[[{type:2,value:{CI:!0,value:"set",class:"keyword"}},364],[{type:2,value:{class:"variable"}},362]],[[{type:1},363]],[[{type:2,value:{CI:!0,value:"set",class:"keyword"}},364]],[[{type:1},365]],[[{type:2,value:{type:"sqlFieldName",class:"variable"}},366]],[[{type:1},367],[null,367]],[[{type:5,value:{value:"="}},368]],[[{type:1},343,369],[null,343,369]],[[{type:1},370],[null,370]],[[{type:5,value:{value:","}},371],[null,372]],[[{type:1},365],[null,365]],[[{type:2,value:{CI:!0,value:"where",class:"keyword"}},373]],[[{type:1},343,0]],[[{type:1},375]],[[{type:2,value:{CI:!0,value:"where",class:"keyword"}},376]],[[{type:1},343,0]],[[{type:1},316,0]],[[{type:2,value:{type:"sqlClassname",class:"classname"}},379]],[[{type:5,value:{value:"_",type:"sqlClassname",class:"classname"}},378],[{type:5,value:{value:".",type:"sqlClassname",class:"classname"}},380]],[[{type:2,value:{CI:!0,type:"sqlClassname",class:"classname"}},381]],[[{type:5,value:{value:"_",type:"sqlClassname",class:"classname"}},382],[null,0]],[[{type:2,value:{CI:!0,type:"sqlClassname",class:"classname"}},0]],[[{type:1},320,384],[null,320,384]],[[{type:1},385],[null,385]],[[{type:5,value:{value:")"}},387]],[[{type:5,value:{value:"'",class:"string"}},387],[{type:4,value:{class:"string"}},386],[{type:2,value:{class:"string"}},386],[{type:3,value:{class:"string"}},386],[{type:5,value:{class:"string"}},386],[{type:1},386]],[[{type:1},388],[null,388]],[[{type:5,value:{value:","}},389],[null,0]],[[{type:1},320],[null,320]],[[{type:1},391],[null,391]],[[{type:2,value:{CI:!0,value:"delete",class:"keyword"}},392],[{type:2,value:{CI:!0,value:"update",class:"keyword"}},394],[{type:2,value:{CI:!0,value:"select",class:"keyword"}},396],[null,343,398]],[[{type:1},300,393]],[[{type:1},399],[null,399]],[[{type:1},302,395]],[[{type:1},399],[null,399]],[[{type:1},304,397]],[[{type:1},399],[null,399]],[[{type:1},399],[null,399]],[[{type:5,value:{value:")"}},409]],[[{type:1},343,409],[null,343,409]],[[{type:5,value:{value:"'",class:"string"}},409],[{type:4,value:{class:"string"}},401],[{type:2,value:{class:"string"}},401],[{type:3,value:{class:"string"}},401],[{type:5,value:{class:"string"}},401],[{type:1},401]],[[{type:5,value:{value:"("}},403]],[[{type:1},343,404],[null,343,404]],[[{type:1},405],[null,405]],[[{type:5,value:{value:")"}},409]],[[{type:5,value:{value:"_",class:"variable",type:"sqlFieldName"}},407],[{type:5,value:{value:".",class:"variable",type:"sqlFieldName"}},408],[null,409]],[[{type:2,value:{class:"variable",type:"sqlFieldName"}},409]],[[{type:2,value:{class:"variable",type:"sqlFieldName"}},406]],[[{type:1},410],[null,410]],[[{type:5,value:{value:"+"}},412],[{type:5,value:{value:"-"}},412],[{type:5,value:{value:"*"}},412],[{type:5,value:{value:"/"}},412],[{type:5,value:{value:"="}},412],[{type:5,value:"<"},411],[{type:5,value:">"},411],[{type:2,value:{CI:!0,value:"and",class:"keyword"}},412],[{type:2,value:{CI:!0,value:"like",class:"keyword"}},412],[{type:2,value:{CI:!0,value:"or",class:"keyword"}},412],[{type:2,value:{CI:!0,value:"is",class:"keyword"}},412],[null,0]],[[{type:5,value:{value:"="}},412],[null,412]],[[{type:1},343,0],[null,343,0]]]),p=c({CWTInput:1,CWTSpecial:2,OSCommand:4,globalBody:20,postCondition:22,doArgument:31,expression:37,termSpecial:38,variable:50,deviceParameters:58,setExpression:75,variableListExpression:100,argumentList:202,class:206,jsonValue:207,jsonObjectBody:213,jsonArrayBody:218,function:240,nonEmptyArgumentList:252,member:256,classStatic:275,SQLMode:298,SQLDelete:300,SQLUpdate:302,SQLSelect:304,SQLCall:306,SQLVar:307,SQLClassName:316,SQLCallArgList:320,SQLFrom:338,SQLOrder:341,SQLExpression:343})}).call(this,e("_process"))},{"../autocomplete":335,"./pushdownAutomaton":358,_process:332}],358:[function(e,t,n){"use strict";function r(e){var t=e.slice();for(var n in t)if(t[n]){t[n]=t[n].slice();for(var r in t[n])t[n][r]=t[n][r].slice()}t[0]=[[!1,0]];for(var o=1;o<t.length;o++)if(!t[o]){for(var a in t)if(t[a])for(var i in t[a])parseInt(t[a][i][1])>o&&(t[a][i][1]-=1),parseInt(t[a][i][2])>o&&(t[a][i][2]-=1);if(!P)for(var s in L)L[s]>o&&(L[s]-=1);t.splice(o,1),o--}return P=!0,t}function o(){return{automaton:r(O),ruleMappings:L}}function a(e){return e instanceof s?e:new s(!0)}function i(e){var t=new s;return t.ruleName=e,t}function s(e){this.built=e||!1,this.ruleName="",this.chain=[]}function l(e){return function(t){var n=a(this);return n.chain.push({type:e,value:e!==g&&e!==_||"object"===(void 0===t?"undefined":v(t))?t:void 0===t?{}:{value:t}}),n}}function u(){return++M}function c(e){return L.hasOwnProperty(e)||(L[e]=u()),L[e]}function f(e,t){var n=d(t,[],c(e));if(n[0].length||n[1].length)throw console.error("Not completed state. Stack",n[0],", BackStack:",n[1]),new Error("There is a mistake in grammar definition. Please, make sure all chains are exited or looped.")}function p(e){return void 0===O[e]&&(O[e]=[]),O[e]}function d(e,t,n){function r(e){i.length&&(a=u(),i.forEach(function(t){return t[1]=void 0===e?a:e}),i=[])}function o(e){s.length&&(s.forEach(function(t){return t[2]=void 0===e?a:e}),s=[])}var a=void 0===n?u():n,i=[],s=[];for(var l in e){var f=e[l];switch(f.type){case g:case _:case m:case y:case h:r(),o();var v=p(a);if(f.value instanceof Array){var O=!0,P=!1,L=void 0;try{for(var M,T=f.value[Symbol.iterator]();!(O=(M=T.next()).done);O=!0){var R=M.value,N=[{type:f.type,value:R}];v.push(N),i.push(N)}}catch(e){P=!0,L=e}finally{try{!O&&T.return&&T.return()}finally{if(P)throw L}}}else{var D=[f];v.push(D),i.push(D)}break;case S:r(),o();var F=[{type:y,value:void 0}],H=[null];p(a).push(F,H),i.push(F,H);break;case w:r(),o();var G=[null];p(a).push(G),i.push(G);break;case E:case I:r(),o();var U=[f.type===E];p(a).push(U),i.push(U);break;case A:r(),o(),t=t.concat(a);break;case x:var W=t.pop();if(void 0===a)throw new Error("Unmatched 'merge()': no matching 'branch()' in the chain.");r(W),o(W);break;case C:r(),o();var B=!0,Y=!1,z=void 0;try{for(var q,X=f.value[Symbol.iterator]();!(B=(q=X.next()).done);B=!0){var V=q.value,K=d(V,t.slice(),a);i=i.concat(K[0]),s=s.concat(K[1])}}catch(e){Y=!0,z=e}finally{try{!B&&X.return&&X.return()}finally{if(Y)throw z}}break;case j:if(i.length)s=s.concat(i),r(c(f.value));else{var Q=[null,c(f.value)];p(a).push(Q),s.push(Q),a=u()}break;case k:i.length&&(r(),o());var J=[0,c(f.value)];p(a).push(J),s.push(J),a=u();break;case b:r(0),o(0)}}return[i,s]}Object.defineProperty(n,"__esModule",{value:!0});var v="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e};n.getAutomaton=o,n.rule=i;var y=n.TYPE_WHITESPACE=1,_=n.TYPE_ID=2,h=n.TYPE_STRING=3,m=n.TYPE_CONSTANT=4,g=n.TYPE_CHAR=5,b=n.TYPE_EXIT=6,x=n.TYPE_MERGE=7,w=n.TYPE_ANY=8,j=n.TYPE_CALL=9,A=n.TYPE_BRANCH=10,S=n.TYPE_OPT_WHITESPACE=11,k=n.TYPE_TRY_CALL=12,E=n.TYPE_ALL=13,I=n.TYPE_NONE=14,C=n.TYPE_SPLIT=15,O=[],P=!1,L={};n.branch=s.prototype.branch=l(A),n.call=s.prototype.call=l(j),n.char=s.prototype.char=l(g),n.string=s.prototype.string=l(h),n.id=s.prototype.id=l(_),n.any=s.prototype.any=l(w),n.all=s.prototype.all=l(E),n.none=s.prototype.none=l(I),n.whitespace=s.prototype.whitespace=l(y),n.optWhitespace=s.prototype.optWhitespace=l(S),n.constant=s.prototype.constant=l(m),n.tryCall=l(k);s.prototype.end=function(){this.built||this.buildTable()};n.merge=s.prototype.merge=function(){var e=a(this);return e.chain.push({type:x}),e.built||e.buildTable(),e},n.exit=s.prototype.exit=function(){var e=a(this);return e.chain.push({type:b}),e.built||e.buildTable(),e},n.split=s.prototype.split=function(){for(var e=a(this),t=[],n=0;n<arguments.length;n++)t.push(arguments[n].chain);return e.chain.push({type:C,value:t}),e};s.prototype.buildTable=function(){this.built=!0,f(this.ruleName,this.chain)};var M=0},{}],359:[function(e,t,n){"use strict";function r(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}function o(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{};k.get("initMessage")&&!e.cleanStart&&(_.printLine("CWTv"+w.VERSION+" "+e.system+":\x1b[(keyword)m"+e.username+"\x1b[0m"+(e.name?" ("+e.name+")":"")),e.firstLaunch&&_.printLine(A.get("firstLaunchMessage"))),e.cleanStart&&k.setTemp("updateCheck","false"),I.collect(e),k.set("serverName",e.name,!0),document.title=(e.name||e.system)+" - WebTerminal",w.authDone()}function a(e){w.NAMESPACE=e,m.prompt(e+" > ",{},function(e){b.send("Execute",e)})}function i(e){w.promptCallback(e)}function s(e){var t=e.replace(/(\w+(?:\+[0-9]+)?\^(?:\w\.?)+)/,"\x1b[(special)m$1\x1b[0m").replace(/^(<.*>)/,"\x1b[31m$1\x1b[0m"),n=t.replace(/z\w+\+[0-9]+\^WebTerminal\.\w+\.[0-9]+/,"");return{string:n,internal:n.length!==t.length}}function l(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"",t=[""];if("object"===(void 0===e?"undefined":v(e))){var n=s(e.zerror||"?")
+         ;if(t.push(n.string),!n.internal)for(var r=e.source.split(/\n/g),o=0;o<r.length;o++){var a=o===e.line;t.push("\x1b["+(a?"(wrong)":"(special)")+"m"+(a?"\u2560":"\u2551")+"\x1b[0m"+(a?"\x1b[(wrong)m":"")+r[o]+(a?"\x1b[0m":""))}}else t.push(s(e).string);_.printAsync(t.join("\r\n")+"\r\n")}function u(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"";_.print("\x1b[31m"+A.parse(e)+"\x1b[0m")}function c(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{};m.prompt("",e,function(e){b.send("i",e)},!1)}function f(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{};m.getKey(e,function(e){b.send("i",e)})}function p(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"";_.print(e)}function d(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:"";_.print(A.parse(e))}Object.defineProperty(n,"__esModule",{value:!0});var v="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e};n.init=o,n.prompt=a,n.promptCallback=i,n.execError=l,n.error=u,n.readString=c,n.readChar=f,n.o=p,n.oLocalized=d;var y=e("../output"),_=r(y),h=e("../input"),m=r(h),g=e("./index"),b=r(g),x=e("../index"),w=r(x),j=e("../localization"),A=r(j),S=e("../config"),k=r(S),E=e("../analytics"),I=r(E)},{"../analytics":333,"../config":337,"../index":340,"../input":345,"../localization":349,"../output":356,"./index":360}],360:[function(e,t,n){"use strict";function r(e){clearTimeout(x),x=0,g=o(),e&&(S=e),g.addEventListener("open",a),g.addEventListener("close",l),g.addEventListener("error",i),g.addEventListener("message",function(e){if("o"===e.data[0])return void u({h:"o",d:e.data.slice(1)});var t=void 0;try{t=JSON.parse(e.data)}catch(t){return void(0,p.printLine)((0,d.get)("serParseErr",e.data))}u(t)})}function o(){return new WebSocket(("https:"===location.protocol?"wss:":"ws:")+"//"+location.hostname+":"+(location.port||("https:"===location.protocol?"443":"80"))+"/terminalsocket/"+encodeURIComponent(_))}function a(){m=!0,f("Auth",S),c()}function i(e){(0,p.printLine)((0,d.get)("wsErr",e.data||e))}function s(){(0,p.printLine)((0,d.get)("plRefPageSes")),b.unshift(w),r()}function l(e){m=!1,1e3!==e.code&&1005!==e.code?((0,p.printLine)("\r\n"+(0,d.get)("wsConnLost",e.code,e.reason?" "+e.reason:"")),(0,p.printLine)((0,d.get)("reConn",h/1e3)),x=setTimeout(s,h)):(0,p.printLine)((0,d.get)("seeYou"))}function u(){var e=arguments.length>0&&void 0!==arguments[0]?arguments[0]:{};if(e._cb){if(!A[e._cb])return void(0,p.printLine)("\r\n"+(0,d.get)("eInt","E.server.index.3 ("+e._cb+")"));A[e._cb](e.d),delete A[e._cb]}else e.h?"function"==typeof y[e.h]?y[e.h](e.d):(0,p.printLine)("\r\n"+(0,d.get)("eInt","E.server.index.1 ("+e.h+")")):(0,p.printLine)("\r\n"+(0,d.get)("eInt","E.server.index.2 ("+JSON.stringify(e)+")"))}function c(){m&&(b=b.filter(function(e){try{g.send(JSON.stringify(e))}catch(e){return x||(x=setTimeout(s,h)),!0}return!1}))}function f(e,t,n){var r={d:t||null,h:e};"function"==typeof n&&(r._cb=j,A[j++]=n),w||(w=r),b.push(r),c()}Object.defineProperty(n,"__esModule",{value:!0}),n.connect=r,n.send=f;var p=e("../output"),d=e("../localization"),v=e("./handlers"),y=function(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}(v),_="WebTerminal.Engine.cls",h=1e4,m=!1,g=void 0,b=[],x=0,w=void 0,j=1,A={},S={}},{"../localization":349,"../output":356,"./handlers":359}],361:[function(e,t,n){"use strict";function r(){localStorage.clear()}function o(e,t){localStorage.setItem(e,t)}function a(e){localStorage.removeItem(e)}function i(e){return localStorage.getItem(e)}Object.defineProperty(n,"__esModule",{value:!0}),n.clear=r,n.set=o,n.remove=a,n.get=i;var s=e("./output"),l=e("./localization"),u=function(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}(l);"undefined"!=typeof JSON&&"undefined"!=typeof localStorage||(0,s.printLine)(u.get("storageErr"))},{"./localization":349,"./output":356}],362:[function(e,t,n){"use strict";function r(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}function o(){return d.map(function(e){return"\x1b[("+("^"===e[0]?"global":"string")+")m"+e+"\x1b[0m"}).join(", ")}function a(e){-1===d.indexOf(e)&&(d.push(e),0===v&&(v=setTimeout(s,p)))}function i(e){if(!e)return d=[],void(v&&clearTimeout(v));d=d.filter(function(t){return t!==e}),d.length>0||v&&(clearTimeout(v),v=0)}function s(){if(0===d.length)return void(v=0);u.send("TracingStatus",{},function(e){e.changes&&f.printAsync(e.changes);for(var t in e.stop)i(t);v=setTimeout(s,p)})}Object.defineProperty(n,"__esModule",{value:!0}),n.getList=o,n.start=a,n.stop=i;var l=e("../server"),u=r(l),c=e("../output"),f=r(c),p=1e3,d=[],v=0},{"../output":356,"../server":360}]},{},[340]);]]]]><![CDATA[>
+</data>
+]]></Data>
+</XData>
+</Class>
+
+
+<Class name="WebTerminal.Trace">
+<Super>Common</Super>
+<TimeChanged>65316,65786.17866</TimeChanged>
+<TimeCreated>65316,65786.17866</TimeCreated>
+
+<Property name="Watches">
+<Description>
+Property is used to store watching files/globals. </Description>
+<Type>%List</Type>
+</Property>
+
+<Property name="WatchesCaret">
+<Description>
+Watch position in file or global</Description>
+<Type>%Numeric</Type>
+<MultiDimensional>1</MultiDimensional>
+</Property>
+
+<Method name="Trace">
+<Description>
+Checks for correct watch source and sets watch target to ..Watches
+Returns status of this operation</Description>
+<FormalSpec>name</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set s = $CHAR(0)
+    set watches = s _ $LISTTOSTRING(..Watches, s) _ s
+    if ($FIND(watches, s_name_s) '= 0) return 0 // if watch already defined
+
+    if ($EXTRACT(name,1,1) = "^") { // watching global
+        set g = 0
+        try {
+            if (($data(@name)) '= 0) set g = 1
+        } catch {  }
+        set $ZERROR = ""
+        if (g = 1) {
+            set ..Watches = ..Watches _ $LISTBUILD(name)
+            set ..WatchesCaret(name, 0) = $QUERY(@name@(""), -1) // last
+            set ..WatchesCaret(name, 1) = "?"
+            return 1
+        }
+    } else { // watch file
+        if (##class(%File).Exists(name)) {
+            set ..Watches = ..Watches _ $LISTBUILD(name)
+            set file = ##class(%File).%New(name)
+            set ..WatchesCaret(name,0) = file.Size // current watch cursor position
+            set ..WatchesCaret(name,1) = file.DateModified
+            return 1
+        }
+    }
+
+    return 0
+]]></Implementation>
+</Method>
+
+<Method name="StopTracing">
+<Description>
+Removes watch from watches list
+Returns success status</Description>
+<FormalSpec>name</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set s = $CHAR(0)
+    set watches = s _ $LISTTOSTRING(..Watches,s) _ s
+    set newWatches = $REPLACE(watches, s_name_s, s)
+    set ..Watches = $LISTFROMSTRING($EXTRACT(newWatches, 2, *-1), s)
+    if (watches '= newWatches) {
+        kill ..WatchesCaret(name)
+    }
+    return watches '= newWatches
+]]></Implementation>
+</Method>
+
+<Method name="ListWatches">
+<Description>
+Returns a list current watches</Description>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    set no = 0
+    set s = "Watching: " _ $CHAR(10)
+    while $LISTNEXT(..Watches, no, value) {
+        set s = s_"(pos: "_..WatchesCaret(value,0)_
+            "; mod: "_..WatchesCaret(value,1)_") "_value_$CHAR(10)
+    }
+    return s
+]]></Implementation>
+</Method>
+
+<Method name="GetTraceGlobalModified">
+<Description>
+Return null string if global hadn't been updated
+This method watches only for tail of global and detects if global still alive</Description>
+<FormalSpec>watch</FormalSpec>
+<ReturnType>%List</ReturnType>
+<Implementation><![CDATA[
+    set data = ""
+    if ($data(@watch)=0) {
+        do ..StopTracing(watch)
+        return $lb($C(27)_"[(wrong)m[D]"_$C(27)_"[0m", $C(13, 10))
+    }
+    for {
+        set query = $QUERY(@..WatchesCaret(watch,0))
+        quit:query=""
+        set ..WatchesCaret(watch,0) = query
+        set data = data _ $case(data = "", 1: "", :$CHAR(13, 10)) _ @query
+    }
+    return $lb($C(27)_"[(special)m[M]"_$C(27)_"[0m", data)
+]]></Implementation>
+</Method>
+
+<Method name="GetTraceFileModified">
+<FormalSpec>watch</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    set file=##class(%File).%New(watch)
+    set size = file.Size
+    set modDate = file.DateModified
+    set output = ""
+    if (size < 0) { // file had been deleted
+        do ..StopTracing(watch)
+        return $lb($C(27)_"[(wrong)m[D]"_$C(27)_"[0m", $C(13, 10))
+    }
+
+    if (size > ..WatchesCaret(watch, 0)) {
+
+        set stream = ##class(%Stream.FileCharacter).%New()
+        set sc = stream.LinkToFile(watch)
+        do stream.MoveTo(..WatchesCaret(watch, 0) + 1)
+        set read = stream.Read(size - ..WatchesCaret(watch, 0))
+        set output = output _ read
+        set ..WatchesCaret(watch, 0) = size
+        set ..WatchesCaret(watch, 1) = file.DateModified
+        return $lb($C(27)_"[(constant)m[A]"_$C(27)_"[0m", output)
+
+    } elseif ((size < ..WatchesCaret(watch, 0)) || (file.DateModified '= ..WatchesCaret(watch, 1))) {
+
+        set output = output _ "Size change: " _ (size - ..WatchesCaret(watch, 0))
+        set ..WatchesCaret(watch, 0) = size
+        set ..WatchesCaret(watch, 1) = file.DateModified
+        return $lb($C(27)_"[(special)m[M]"_$C(27)_"[0m", output)
+
+    } // else file not changed
+
+    return $lb("", "")
+]]></Implementation>
+</Method>
+
+<Method name="CheckTracing">
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    set no = 0
+    set data = ""
+    set overall = ""
+    set watchList = ..Watches // do not remove or simplify: ..Watches can be modified
+    while $LISTNEXT(watchList, no, value) {
+        set global = $EXTRACT(value, 1, 1) = "^"
+        if global {
+            set data = ..GetTraceGlobalModified(value)
+        } else {
+            set data = ..GetTraceFileModified(value)
+        }
+        if ($LISTGET(data, 2) '= "") {
+            set overall = $LISTGET(data, 1) _ " " _ $C(27) _ "[2m" _ $ZDATETIME($NOW(),1,1)
+            _ $C(27) _ "[0m " _ $C(27) _ "[(" _ $case(global, 1: "global", :"string") _ ")m"
+            _ value _ $C(27) _ "[0m" _ $CHAR(13, 10) _ $LISTGET(data, 2) _ $CHAR(13, 10)
+        }
+        set data = ""
+    }
+    return overall
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.Updater">
+<Description>
+Web Terminal version 4.9.1 update module class.
+This class represents update mechanism for WebTerminal. Internet connection is required to
+update WebTerminal.</Description>
+<TimeChanged>65316,65786.18367</TimeChanged>
+<TimeCreated>65316,65786.18367</TimeCreated>
+
+<Parameter name="SSLConfigName">
+<Description>
+SSL configuration name used for HTTPS requests.</Description>
+<Default>WebTerminalSSL</Default>
+</Parameter>
+
+<Method name="GetSSLConfigurationName">
+<ClassMethod>1</ClassMethod>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    new $namespace
+    zn "%SYS"
+    if ('##class(Security.SSLConfigs).Exists(..#SSLConfigName)) {
+        set st = ##class(Security.SSLConfigs).Create(..#SSLConfigName)
+        return:(st '= 1) "UnableToCreateSSLConfig:"_$System.Status.GetErrorText(st)
+    }
+    return ..#SSLConfigName
+]]></Implementation>
+</Method>
+
+<Method name="WriteAndDelete">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,file:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    if ##class(%File).Exists(file) {
+        set stream = ##class(%Stream.FileCharacter).%New()
+        set sc = stream.LinkToFile(file)
+        while 'stream.AtEnd {
+            do client.Send("o", stream.Read()_$CHAR(13, 10))
+        }
+        do client.Send("oLocalized", "%sUpdCleanLog("_file_")"_$CHAR(13, 10))
+        do ##class(%File).Delete(file)
+    } else {
+        do client.Send("oLocalized", "%sUpdNoFile")
+    }
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="Stop">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,status:%Status</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    if ($$$ISERR(status)) {
+        do client.Send("oLocalized", "%sUpdErr("_$System.Status.GetErrorText(status)_")"_$C(13, 10))
+    }
+    return status
+]]></Implementation>
+</Method>
+
+<Method name="Update">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,URL:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do client.Send("oLocalized", "%sUpdSt"_$CHAR(13, 10))
+    set request = ##class(%Net.HttpRequest).%New()
+    set request.Server = $PIECE(URL, "/", 3)
+    set request.Location = $PIECE(URL, "/", 4, *)
+    set request.Https = 1
+    set request.SSLConfiguration = ..GetSSLConfigurationName()
+    do client.Send("oLocalized", "%sUpdRURL(https://"_request.Server_"/"_request.Location_")"_$CHAR(13, 10))
+    set status = request.Get()
+    do client.Send("oLocalized", "%sUpdGetOK"_$CHAR(13, 10))
+    return:(status '= $$$OK) status
+
+    if (request.HttpResponse.StatusCode '= 200) {
+        do client.Send("oLocalized", "%sUpdSCode("_request.HttpResponse.StatusCode_")"_$CHAR(13, 10))
+        return $$$ERROR($$$GeneralError, "HTTP "_request.HttpResponse.StatusCode)
+    }
+
+    do client.Send("oLocalized", "%sUpdWTF"_$CHAR(13, 10))
+    set tempFile = ##class(%File).TempFilename("xml")
+    set file = ##class(%File).%New(tempFile)
+    do file.Open("NW")
+    set data = request.HttpResponse.Data
+    if (($IsObject(data)) && (data.%IsA("%Stream.Object"))) {
+        while 'data.AtEnd {
+            set chunk = data.Read(data.Size)
+            do file.Write(chunk)
+        }
+    } else {
+        do file.Write(data)
+    }
+    do file.Close()
+
+    set backupFile = ##class(%File).TempFilename("xml")
+    do client.Send("oLocalized", "%sUpdBack("_backupFile_")"_$CHAR(13, 10))
+
+    set logFile = ##class(%File).TempFilename("txt")
+    set io = $IO
+
+    open logFile:("NW")
+    use logFile
+    set exportStatus = $System.OBJ.Export("WebTerminal.*.CLS", backupFile)
+    close logFile
+    use io
+
+    do ..WriteAndDelete(client, logFile)
+    if ($$$ISERR(exportStatus)) {
+        do ##class(WebTerminal.Analytics).ReportInstallStatus(exportStatus, "Update")
+        return ..Stop(client, exportStatus)
+    }
+    do client.Send("oLocalized", "%sUpdRemLoad"_$CHAR(13, 10))
+
+    open logFile:("NW")
+    use logFile
+    write $C(27)_"[2m"
+    do $System.OBJ.DeletePackage("WebTerminal")
+    write $C(27)_"[0m", !
+    set loadStatus = $SYSTEM.OBJ.Load(tempFile, "c")
+
+    // At this moment WebTerminal's code can be broken, totally changed or deleted. Do not call
+    // WebTerminal's methods until terminal is restored / fully updated
+
+    if '$$$ISOK(loadStatus) { // roll back
+        write !, $C(27)_"[(wrong)m==FAILED=="_$C(27)_"[0m", !,
+            $System.Status.GetErrorText(loadStatus), !, !,
+            $C(27)_"[(special)m==RESTORING=="_$C(27)_"[0m", !
+        do $SYSTEM.OBJ.Load(backupFile, "c")
+    }
+
+    // end
+
+    close logFile
+    use io
+    do ..WriteAndDelete(client, logFile)
+
+    do client.Send("oLocalized", "%sUpdClean("_tempFile_")"_$CHAR(13, 10))
+    do ##class(%File).Delete(tempFile)
+    do client.Send("oLocalized", "%sUpdClean("_backupFile_")"_$CHAR(13, 10, 13, 10))
+    do ##class(%File).Delete(backupFile)
+    if '$$$ISOK(loadStatus) {
+        do ..Stop(client, loadStatus)
+        do client.Send("oLocalized", $CHAR(13, 10)_"%sUpdRes"_$CHAR(13, 10))
+    }
+    do client.Send("oLocalized", "%sUpdDone"_$CHAR(13, 10))
+
+    do ##class(WebTerminal.Analytics).ReportInstallStatus(loadStatus, "Update")
+
+    return $$$OK
+]]></Implementation>
+</Method>
+</Class>
+</Export>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1530,7 +1530,7 @@ localization/dictionary.js</a></code></td>
                 <h2>The Latest Versions:</h2>
                 <ul class="downloadLinks">
                     <li>
-                        <a href="files/WebTerminal-v4.9.0.xml">WebTerminal-v4.9.0</a>
+                        <a href="files/WebTerminal-v4.9.1.xml">WebTerminal-v4.9.1</a>
                         - Better <code>/sql</code> (CALL support), name changes
                     </li>
                     <li>

--- a/docs/terminal.json
+++ b/docs/terminal.json
@@ -466,6 +466,13 @@
         "call support in /sql mode",
         "Minor copywriting fixes"
       ]
+    },
+    {
+      "v": "4.9.1",
+      "url": "https://intersystems-community.github.io/webterminal/files/WebTerminal-v4.9.1.xml",
+      "changes": [
+        "Improve input copy/paste when multiple lines are copied"
+      ]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "name": "Nikita Savchenko",
     "url": "https://nikita.tk"
   },
-  "version": "4.9.0",
+  "version": "4.9.1",
   "gaID": "UA-83005064-2",
   "releaseNumber": 26,
   "scripts": {

--- a/src/client/js/input/index.js
+++ b/src/client/js/input/index.js
@@ -39,6 +39,9 @@ window.addEventListener(`keydown`, (e) => {
 }, true);
 window.addEventListener(`click`, focusInput, true);
 elements.input.addEventListener(`input`, () => {
+    if (/\r?\n/.test(elements.input.value)) {
+        elements.input.value = elements.input.value.replace(/(?:\r?\n)+/g, ` `);
+    }
     history.setLast(elements.input.value);
     update();
     inputUpdated();


### PR DESCRIPTION
Upon pasting to the terminal, all newline symbols are replaced with a single space to avoid crashing the input