### PR TITLE
Support /terminal being hosted deeper than the web server root level

### DIFF
--- a/docs/files/WebTerminal-v4.9.4.xml
+++ b/docs/files/WebTerminal-v4.9.4.xml
@@ -1,0 +1,2343 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Export generator="Cache" version="25" zv="Cache for Windows (x86-64) 2018.1.7 (Build 721)" ts="2022-06-29 21:44:49">
+<Class name="WebTerminal.Analytics">
+<Description>
+This class includes methods which collect WebTerminal's analytics such as error and installation reports.</Description>
+<TimeChanged>66289,77576.241129</TimeChanged>
+<TimeCreated>66289,77576.241129</TimeCreated>
+
+<Method name="ReportInstallStatus">
+<Description>
+This method sends a report about installation status, including error message if any errors happened.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>status:%Status=1,type:%String="Install"</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set req = ##class(%Net.HttpRequest).%New()
+    set req.Server = "www.google-analytics.com"
+    do req.EntityBody.Write("v=1&tid=UA-83005064-2&cid="_##class(%SYS.System).InstanceGUID()
+        _"&ds=web&an=WebTerminal&av="_##class(WebTerminal.Installer).#VERSION
+        _"&t=event&aiid="_$ZCONVERT($zv, "O", "URL")_"&ec="_$ZCONVERT(type, "O", "URL")_"&ea="
+        _$case($$$ISOK(status), 1: "Success", : "Failure")_"&el="
+        _$ZCONVERT($System.Status.GetErrorText(status), "O", "URL"))
+    try {
+        return req.Post("/collect")
+    } catch e {
+        write "Unable to send analytics to " _ req.Server _ ", skipping analytics collection."
+        return $$$OK
+    }
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.Autocomplete">
+<Super>Common</Super>
+<TimeChanged>66289,77576.244661</TimeChanged>
+<TimeCreated>66289,77576.244661</TimeCreated>
+
+<Method name="GetGlobals">
+<Description>
+Returns a comma-delimited string of globals names in the namespace, which begin from "beginning".</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>namespace:%String="%SYS",beginning:%String=""</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    set result = ""
+    set pattern = beginning _ "*"
+    new $Namespace
+    set $Namespace = namespace
+    set rset = ##class(%ResultSet).%New("%SYS.GlobalQuery:NameSpaceList")
+    do rset.Execute($Namespace, pattern, 1)
+    while (rset.Next()) {
+        set result = result _ $case(result = "", 1:"", :",") _ rset.GetData(1)
+    }
+    return result
+]]></Implementation>
+</Method>
+
+<Method name="GetClass">
+<Description>
+Returns a comma-delimited string of class names in the namespace, which begin from "beginning".</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>namespace:%String="%SYS",beginning:%String=""</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    new $Namespace
+    set $Namespace = namespace
+    set pattern = $REPLACE(beginning, "%", "!%") _ "%"
+    &sql(select LIST(ID) into :ids from %Dictionary.CompiledClass where ID like :pattern ESCAPE '!' and deployed <> 2)
+    return ids
+]]></Implementation>
+</Method>
+
+<Method name="GetPublicClassMembers">
+<Description>
+Returns a comma-delimited string of public class members (accessible through ##class() construction) in the class of namespace.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>namespace:%String="%SYS",className:%String="",beginning:%String=""</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    new $Namespace
+    set $Namespace = namespace
+    set pattern = $REPLACE(beginning, "%", "!%") _ "%"
+    &sql(select LIST(Name) into :names from %Dictionary.CompiledMethod WHERE parent=:className AND ClassMethod=1 AND Name like :pattern ESCAPE '!')
+    return names
+]]></Implementation>
+</Method>
+
+<Method name="GetClassMembers">
+<Description>
+Returns a comma-delimited string of class members in the class of namespace.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>namespace:%String="%SYS",className:%String="",beginning:%String="",methodsOnly=""</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    new $Namespace
+    set $Namespace = namespace
+    if $EXTRACT(beginning, 1) = "#" {
+        set ps = ..GetParameters(namespace, className, $EXTRACT(beginning, 2, $LENGTH(beginning)))
+        return:(ps = "") ps
+        return "#"_$REPLACE(ps, ",", ",#")
+    }
+    set pattern = $REPLACE(beginning, "%", "!%") _ "%"
+    set props = ""
+    &sql(select LIST(Name) into :methods from %Dictionary.CompiledMethod WHERE parent=:className AND Private = 0 AND Name like :pattern ESCAPE '!')
+    if (methodsOnly = "") {
+        &sql(select LIST(Name) into :props from %Dictionary.CompiledProperty WHERE parent=:className AND Name like :pattern ESCAPE '!')
+    }
+    return $case((methods '= "") && (props '= ""), 1: methods _ "," _ props, : methods _ props)
+]]></Implementation>
+</Method>
+
+<Method name="GetParameters">
+<Description>
+Returns a comma-delimited string of class members in the class of namespace.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>namespace:%String="%SYS",className:%String="",beginning:%String=""</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    new $Namespace
+    set $Namespace = namespace
+    set pattern = $REPLACE(beginning, "%", "!%") _ "%"
+    &sql(select LIST(Name) into :names from %Dictionary.CompiledParameter WHERE parent=:className AND Name like :pattern ESCAPE '!')
+    return names
+]]></Implementation>
+</Method>
+
+<Method name="GetRoutines">
+<Description>
+Returns a comma-delimited string of routine names in the namespace, which begin from "beginning".</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>namespace:%String="%SYS",beginning:%String=""</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    set result = ""
+    set pattern = beginning _ "*.*"
+    new $Namespace
+    set $Namespace = namespace
+    set rset = ##class(%ResultSet).%New("%Library.Routine:RoutineList")
+    do rset.Execute(pattern, , , $Namespace)
+    while (rset.Next()) {
+        set result = result _ $case(result = "", 1:"", :",") _ $PIECE(rset.GetData(1), ".", 1, *-1)
+    }
+    return result
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.Common">
+<IncludeCode>%sySystem</IncludeCode>
+<TimeChanged>66289,77576.30877</TimeChanged>
+<TimeCreated>66289,77576.30877</TimeCreated>
+
+<Parameter name="ChunkSize">
+<Description>
+Interprocess communication cannot handle big messages at once, so they need to be split.</Description>
+<Default>45</Default>
+</Parameter>
+
+<Method name="SendChunk">
+<Description>
+Send the chunk of data to another process. The process need to receive the chunk with the
+appropriate function ReceiveChunk. Consider event length less than 44 characters long.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>pid:%Numeric,flag:%String,data:%String=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set pos = 1
+    set len = $LENGTH(data) + 1 // send the last empty message if the data size = ChunkSize
+    for {
+        try {
+            set st = $system.Event.Signal(
+                pid,
+                $LB(flag, $EXTRACT(data, pos, pos + ..#ChunkSize - 1))
+            )
+        } catch (e) { return $$$NOTOK }
+        if (st '= 1) { return $$$NOTOK }
+        set pos = pos + ..#ChunkSize
+        if (pos > len) { quit }
+    }
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="ReceiveChunk">
+<Description>
+Receives the chunk of data from another process. Returns the $LISTBUILD string which contains
+flag at the first position and string at the second. This method also terminates the process
+if the parent process is gone.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>timeout:%Numeric=-1,masterProcess=0</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    set flag = ""
+    set str = ""
+    set status = -1
+    for {
+        set message = $system.Event.WaitMsg("", $Case(timeout = -1, 1: 1, :timeout))
+        set status = $LISTGET(message, 1)
+        set data = $LISTGET(message, 2)
+        if (status <= 0) {
+            if ($ZPARENT '= 0) && ('$data(^$Job($ZPARENT))) {
+                do $system.Process.Terminate($JOB, 0)
+                return $LISTBUILD("e", $LISTBUILD("", "Parent process "_$JOB_" is gone"), -1)
+            }
+            if masterProcess && ($ZCHILD '= 0) && ('$data(^$Job($ZCHILD))) {
+                return $LISTBUILD("e", $LISTBUILD("", "Child process "_$ZCHILD_" is gone"), -1)
+            }
+        }
+        if (data = "") && (timeout = 0) quit
+        if (status <= 0) {
+            set:(timeout = 0) timeout = 1
+            continue
+        }
+        set flag = $LISTGET(data, 1)
+        set m = $LISTGET(data, 2)
+        set str = str _ m
+        if (timeout = 0) set timeout = 1
+        quit:($LENGTH(m) '= ..#ChunkSize)
+    }
+    return $LISTBUILD(flag, str, status)
+]]></Implementation>
+</Method>
+
+<Method name="GetJSONString">
+<Description><![CDATA[
+Returns the contents of the proxy object to the current device in JSON format.<br/>
+This method is called when a proxy object is used in conjunction with
+the <class>%ZEN.Auxiliary.jsonProvider</class> component.<br/>
+<var>format</var> is a flags string to control output formatting options.<br/>
+The following character option codes are supported:<br/>
+1-9 : indent with this number of spaces (4 is the default with the 'i' format specifier)<br/>
+a - output null arrays/objects<br/>
+b - line break before opening { of objects<br/>
+c - output the Cach&eacute;-specific "_class" and "_id" properties (if a child property is an instance of a concrete object class)<br/>
+e - output empty object properties<br/>
+i - indent with 4 spaces unless 't' or 1-9<br/>
+l - output empty lists<br/>
+n - newline (lf)<br/>
+o - output empty arrays/objects<br/>
+q - output numeric values unquoted even when they come from a non-numeric property<br/>
+s - use strict JSON output - <strong>NOTE:</strong> special care should be taken when sending data to a browser, as using this flag
+may expose you to cross site scripting (XSS) vulnerabilities if the data is sent inside <code>&lt;script&gt;</code> tags. Zen uses
+this technique extensively, so this flag should <strong>NOT</strong> be specified for jsonProviders in Zen pages.<br/>
+t - indent with tab character<br/>
+u - output pre-converted to UTF-8 instead of in native internal format<br/>
+w - Windows-style cr/lf newline<br/>]]></Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>obj:%ZEN.proxyObject,format:%String="aeos"</FormalSpec>
+<ProcedureBlock>0</ProcedureBlock>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    set tOldIORedirected = ##class(%Device).ReDirectIO()
+    set tOldMnemonic = ##class(%Device).GetMnemonicRoutine()
+    set tOldIO = $io
+    try {
+        set str = ""
+        use $io::("^" _ $ZNAME)
+        do ##class(%Device).ReDirectIO(1)
+        do ##class(%ZEN.Auxiliary.jsonProvider).%ObjectToJSON(obj,,,format)
+    } catch ex {
+        set str = ""
+    }
+    if (tOldMnemonic '= "") {
+        use tOldIO::("^" _ tOldMnemonic)
+    } else {
+        use tOldIO
+    }
+    do ##class(%Device).ReDirectIO(tOldIORedirected)
+    return str
+
+rchr(c)
+    quit
+rstr(sz,to)
+    quit
+wchr(s)
+    do output($char(s))
+    quit
+wff()
+    do output($char(12))
+    quit
+wnl()
+    do output($char(13,10))
+    quit
+wstr(s)
+    do output(s)
+    quit
+wtab(s)
+    do output($char(9))
+    quit
+output(s)
+    set str = str _ s
+    quit
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.Core">
+<Description>
+Web Terminal version 4.9.4 core.
+The core class which handles client requests and executes ObjectScript code.
+All writes used here are used for $X and $Y compatibility, but they actually do not
+write any code to the screen.</Description>
+<ProcedureBlock>0</ProcedureBlock>
+<Super>Common</Super>
+<TimeChanged>66289,77576.323929</TimeChanged>
+<TimeCreated>66289,77576.323929</TimeCreated>
+
+<Method name="redirects">
+<Description>
+Write and read redirects used when redirecting i/o.
+Each of the redirects signals to $ZPARENT process the $LISTBUILD string.
+There is several actions defined in the WebTerminal.Engine handler class for received list.
+"o" is for output. Resulting with $lb("o", {string})
+"r" is for reading string. Resulting with $lb("r", {length}, {timeout})
+"rc" is for reading char. Resulting with $lb("rc", {timeout})
+"end" symbolizes that execution end is reached. Resulting with $lb("end", {error message})</Description>
+<Private>1</Private>
+<ProcedureBlock>0</ProcedureBlock>
+<Implementation><![CDATA[
+wstr(str)
+	do ##class(%Device).ReDirectIO($$$NO)
+	write str
+	do ##class(%Device).ReDirectIO($$$YES)
+    quit ##class(WebTerminal.Common).SendChunk($ZPARENT, "o", str)
+
+wchr(c)
+	do ##class(%Device).ReDirectIO($$$NO)
+	write $CHAR(c)
+	do ##class(%Device).ReDirectIO($$$YES)
+    quit ##class(WebTerminal.Common).SendChunk($ZPARENT, "o", $CHAR(c))
+
+wnl
+	do ##class(%Device).ReDirectIO($$$NO)
+	write !
+	do ##class(%Device).ReDirectIO($$$YES)
+    quit ##class(WebTerminal.Common).SendChunk($ZPARENT, "o", $CHAR(13, 10))
+
+wff
+	do ##class(%Device).ReDirectIO($$$NO)
+	set $X = 0
+	set $Y = 0
+	do ##class(%Device).ReDirectIO($$$YES)
+    quit ##class(WebTerminal.Common).SendChunk($ZPARENT, "o", $CHAR(12))
+
+wtab(s)
+	do ##class(%Device).ReDirectIO($$$NO)
+	set $x = s
+	do ##class(%Device).ReDirectIO($$$YES)
+    quit ##class(WebTerminal.Common).SendChunk($ZPARENT, "o", $CHAR(27) _ "[" _ (s + 1) _ "G")
+
+rstr(length = 32656, timeout = 86400)
+    do ##class(WebTerminal.Common).SendChunk($ZPARENT, "r", $lb(length, timeout))
+    quit $LISTGET(##class(WebTerminal.Common).ReceiveChunk(), 2)
+
+rchr(timeout = 86400)
+    do ##class(WebTerminal.Common).SendChunk($ZPARENT, "c", timeout)
+    quit $LISTGET(##class(WebTerminal.Common).ReceiveChunk(), 2)
+
+erdx s $x=0 q
+erdy s $y=0 q
+APC ; Application program command
+ w $c(27)_"_"
+ q
+BEL ; Ring the bell
+ w $c(7)
+ q
+CBT(%1) ; Cursor backward tabulation %1 tab stops
+ s %1=+$g(%1,1) w $c(27,91)_%1_"Z" s $zt="erdx",$x=$x+7\8-%1*8
+ q
+CCH ; Cancel character
+ w $c(27)_"T"
+ q
+CHA(%1) ; Cursor horizontal absolute (move to column %1)
+ s %1=+$g(%1,1) w $c(27,91)_%1_"G" s $zt="erdx",$x=%1-1
+ q
+CHT(%1) ; Cursor horizontal tabulation (forward %1 tab stops)
+ s %1=+$g(%1,1) w $c(27,91)_%1_"I" s $zt="erdx",$x=$x\8+%1*8
+ q
+CNL(%1) ; Cursor next line (cursor down %1 lines)
+ s %1=+$g(%1,1) w $c(27,91)_%1_"E" s $zt="erdy",$y=$y+%1
+ q
+CPL(%1) ; Cursor preceding line (cursor up %1 lines)
+ s %1=+$g(%1,1) w $c(27,91)_%1_"F" s $zt="erdy",$y=$y-%1
+ q
+CPR ; Cursor position report (return in $KEY)
+ n %1 w $c(27,91)_"6n" r %1
+ q
+CTC(%1,%2,%3,%4,%5,%6,%7,%8,%9) ; Cursor tabulation control
+ n %i,%p s %p=""
+ f %i=1:1:9 i $d(@("%"_%i)) s %p=%p_$e(";",%p'="")_@("%"_%i)
+ w $c(27,91)_%p_"W"
+ q
+CUB(%1) ; Cursor backward %1 columns
+ s %1=+$g(%1,1) w $c(27,91)_%1_"D" s $zt="erdx",$x=$x-%1
+ q
+CUD(%1) ; Cursor down %1 lines
+ s %1=+$g(%1,1) w $c(27,91)_%1_"B" s $zt="erdy",$y=$y+%1
+ q
+CUF(%1) ; Cursor forward %1 columns
+ s %1=+$g(%1,1) w $c(27,91)_%1_"C" s $zt="erdx",$x=$x+%1
+ q
+CUP(%2,%1) ; Cursor position (column %1, line %2)
+ s %1=+$g(%1,1),%2=+$g(%2,1) w $c(27,91)_%2_";"_%1_"H"
+ s $zt="ecup",$x=%1-1,$zt="erdy",$y=%2-1 q
+ecup s $x=0,$zt="erdy",$y=%2-1
+ q
+CUU(%1) ; Cursor up %1 lines
+ s %1=+$g(%1,1) w $c(27,91)_%1_"A" s $zt="erdy",$y=$y-%1
+ q
+CVT(%1) ; Cursor vertical tabulation
+ w $c(27,91)_+$g(%1,1)_"Y"
+ q
+DA ; Device attributes - return in $KEY
+ n %1,%2,%3 s %3="" u $i:("":"+S")
+ w $c(27,91)_"c" r %1 s %2=$k f  r *%1 s %3=%3_$c(%1) q:%1=99
+ s $k=%2_%3 u $i:("":"-S")
+ q
+DAQ(%1,%2,%3,%4,%5,%6,%7,%8,%9) ; Define area qualification
+ n %i,%p s %p=""
+ f %i=1:1:9 i $d(@("%"_%i)) s %p=%p_$e(";",%p'="")_@("%"_i)
+ w $c(27,91)_%p_"o"
+ q
+DCH(%1) ; Delete %1 characters
+ w $c(27,91)_+$g(%1,1)_"P"
+ q
+DCS ; Device control string
+ w $c(27)_"P"
+ q
+DL(%1) ; Delete %1 lines
+ w $c(27,91)_+$g(%1,1)_"M"
+ q
+DMI ; Disable manual input
+ q
+DSR(%1) ; Device status report - type %1 - return in $KEY
+ n %2 w $c(27,91)_+$g(%1,5)_"n" r %2
+ q
+EA(%1) ; Erase in area
+ w $c(27,91)_+$g(%1,1)_"O"
+ q
+ECH(%1) ; Erase %1 characters
+ w $c(27,91)_+$g(%1,1)_"X"
+ q
+ED(%1) ; Erase in display (%1=0 cursor-to-end,1 begin-to-cursor,2 entire scr)
+ w $c(27,91)_+$g(%1)_"J"
+ q
+EF(%1) ; Erase in field
+ w $c(27,91)_+$g(%1,1)_"N"
+ q
+EL(%1) ; Erase in line (%1=0 cursor-to-end, 1 begin-to-cursor, 2 entire line)
+ w $c(27,91)_+$g(%1)_"K"
+ q
+EMI ; Enable manual input
+ q
+EPA ; End of protected area
+ w $c(27)_"W"
+ q
+ESA ; End of selected area
+ w $c(27)_"G"
+ q
+FNT ; Font selection
+ q
+GSM ; Graphic size modification
+ q
+GSS ; Graphic size selection
+ q
+HPA(%1) ; Horizontal position attribute (cursor to column %1)
+ s %1=+$g(%1,1) w $c(27,91)_%1_"`" s $zt="erdx",$x=%1-1
+ q
+HPR(%1) ; Horizontal position relative (cursor forward %1 columns)
+ s %1=+$g(%1,1) w $c(27,91)_%1_"a" s $zt="erdx",$x=$x+%1
+ q
+HTJ ; Horizontal tab with justify
+ w $c(27)_"I"
+ q
+HTS ; Horizontal tabulation set
+ w $c(27)_"H"
+ q
+HVP(%1,%2) ; Horizontal and vertical position (column %1, line %2)
+ s %1=+$g(%1,1),%2=+$g(%2,1) w $c(27,91)_%2_";"_%1_"f"
+ s $zt="ehvp",$x=%1-1,$zt="erdy",$y=%2-1 q
+ehvp s $x=0,$zt="erdy",$y=%2-1
+ q
+ICH(%1) ; Insert %1 characters
+ w $c(27,91)_+$g(%1,1)_"@"
+ q
+IL(%1) ; Insert %1 lines
+ w $c(27,91)_+$g(%1,1),"L"
+ q
+IND ; Index
+ w $c(27)_"D" s $y=$y+1
+ q
+INT ; Interrupt
+ w $c(27,91)_"a"
+ q
+JFY ; Justify
+ q
+MC ; Media copy
+ w $c(27,91)_"i"
+ q
+MW ; Message waiting
+ w $c(27)_"U"
+ q
+NEL ; Next line
+ w $c(27)_"E" s $x=0,$y=$y+1
+ q
+NP(%1) ; Next page (advance %1 pages of terminal display memory)
+ w $c(27,91)_+$g(%1,1)_"U"
+ q
+OSC ; Operating system command
+ w $c(27)_"]"
+ q
+PLD ; Partial line down
+ w $c(27)_"K"
+ q
+PLU ; Partial line up
+ w $c(27)_"L"
+ q
+PM ; Privacy message
+ w $c(27)_"^"
+ q
+PP(%1) ; Preceding page (backup %1 pages of terminal display memory)
+ w $c(27,91)_+$g(%1,1)_"V"
+ q
+PU1 ; Private use one
+ w $c(27)_"Q"
+ q
+PU2 ; Private use two
+ w $c(27)_"R"
+ q
+QUAD ; QUAD
+ q
+REP ; Repeat
+ w $c(27,91)_"b"
+ q
+RI ; Reverse index
+ w $c(27)_"M" s $zt="erdy",$y=$y-1
+ q
+RIS ; Reset to initial state
+ w $c(27)_"c" s $x=0,$y=0
+ q
+RM(%1,%2,%3,%4,%5,%6,%7,%8,%9) ; Reset mode
+ n %i,%p s %p=""
+ f %i=1:1:9 i $d(@("%"_%i)) s %p=%p_$e(";",%p'="")_@("%"_%i)
+ w $c(27,91)_%p_"l"
+ q
+SEM ; Select editing extent mode
+ w $c(27,91)_"Q"
+ q
+SGR(%1,%2,%3,%4,%5,%6,%7,%8,%9)  ; Select graphic rendition %1 thru %9
+ n %i,%p s %p=""
+ f %i=1:1:9 i $d(@("%"_%i)) s %p=%p_$e(";",%p'="")_@("%"_%i)
+ w $c(27,91)_%p_"m"
+ q
+SL ; Scroll left
+ q
+SM(%1,%2,%3,%4,%5,%6,%7,%8,%9) ; Set mode
+ n %i,%p s %p=""
+ f %i=1:1:9 i $d(@("%"_%i)) s %p=%p_$e(";",%p'="")_@("%"_%i)
+ w $c(27,91)_%p_"h"
+ q
+SPA ; Start of protected area
+ w $c(27)_"V"
+ q
+SPI ; Spacing increment
+ q
+SR ; Scroll right
+ q
+SS2 ; Single shift two
+ w $c(27)_"N"
+ q
+SS3 ; Single shift three
+ w $c(27)_"O"
+ q
+SSA ; Start of selected area
+ w $c(27)_"F"
+ q
+ST ; String terminator
+ w $c(27)_"\"
+ q
+STS ; Set transmit state
+ w $c(27)_"S"
+ q
+SU ; Scroll up
+ w $c(27,91)_"S"
+ q
+TBC ; Tabulation clear
+ w $c(27,91)_"g"
+ q
+TSS ; Thin space specification
+ q
+VPA(%1) ; Vertical position attribute (move to row %1 at same column)
+ s %1=+$g(%1,1) w $c(27,91)_%1_"d" s $zt="erdy",$y=%1-1
+ q
+VPR(%1) ; Vertical position relative (move down %1 lines at same column)
+ s %1=+$g(%1,1) w $c(27,91)_%1_"e" s $zt="erdy",$y=$y+%1
+ q
+VTS ; Vertical tabulation sets
+ w $c(27)_"J"
+ q
+]]></Implementation>
+</Method>
+
+<Method name="VarList">
+<ClassMethod>1</ClassMethod>
+<ProcedureBlock>1</ProcedureBlock>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    if $data(%)
+    new % set %=$select($test:$LISTBUILD("%"),1:"")
+    set:$data(%0) %=%_$LISTBUILD("%0")
+    new %0 set %0="%0"
+    for {
+        set %0=$ORDER(@%0)
+        quit:%0=""
+        set %=%_$LISTBUILD(%0, $IsObject(@%0), @%0)
+    }
+    return %
+]]></Implementation>
+</Method>
+
+<Method name="WaitCommand">
+<Description>
+Retrieves a command text from the parent process.
+Terminates itself if the parent process is dead.</Description>
+<ClassMethod>1</ClassMethod>
+<ProcedureBlock>1</ProcedureBlock>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    for {
+        set data = ..ReceiveChunk()
+        set flag = $LISTGET(data, 1)
+        if (flag = "m") { // message
+            return $LISTGET(data, 2)
+        } elseif (flag = "a") { // autocomplete
+            do ##class(WebTerminal.Common).SendChunk($ZPARENT, "a", ..VarList())
+        } else { // end or unexpected
+            do $system.Process.Terminate($JOB, 2)
+            return ""
+        }
+    }
+]]></Implementation>
+</Method>
+
+<Method name="Loop">
+<Description>
+Starts new terminal loop. Must be called with JOB command.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>startupRoutine:%String=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+	if ($ZPARENT = 0) {
+        write "This method is for JOB use only."
+        return 0
+    }
+    open "terminal"::"^%X364"
+    use $io::"^" _ $ZName
+    if (startupRoutine '= "") {
+        return ..StartupRoutine(startupRoutine)
+    }
+    kill // Kill any temporary variables ProcedureBlock may have.
+    // Procedure block will hold only user-defined variables, so any declarations here may
+    // potentially influence user experience. Do not add any set expressions in this procedure block
+    for {
+        do ..StartExecMode()
+        try {
+            xecute ..WaitCommand()
+        } catch {
+            do ..EndExecMode($ZERROR)
+            continue
+        }
+        do ..EndExecMode()
+    }
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="StartupRoutine">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>routineName=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do ..StartExecMode()
+    try {
+        do @routineName
+    } catch {
+        do ..EndExecMode($ZERROR)
+        return $$$OK
+    }
+    do ..EndExecMode()
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="StartExecMode">
+<ClassMethod>1</ClassMethod>
+<Implementation><![CDATA[
+    write ! // Y pos shift
+    do ##class(%Device).ReDirectIO($$$YES)
+    do $System.Util.SetInterruptEnable($$$YES)
+]]></Implementation>
+</Method>
+
+<Method name="EndExecMode">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>error=""</FormalSpec>
+<Implementation><![CDATA[
+    use $io::"^" _ $ZName
+    do $System.Util.SetInterruptEnable($$$NO)
+    do ##class(%Device).ReDirectIO($$$NO)
+    write ! // Y pos shift
+    do ..SendChunk($ZPARENT, "e", $LISTBUILD($NAMESPACE, error))
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.Engine">
+<Description>
+Web Terminal version 4.9.4 WebSocket client.
+This class represents a connected client via WebSocket.</Description>
+<Super>%CSP.WebSocket,Common,Trace,Autocomplete</Super>
+<TimeChanged>66289,77576.341087</TimeChanged>
+<TimeCreated>66289,77576.341087</TimeCreated>
+
+<Parameter name="WSKEYEXPIRES">
+<Description>
+Timeout in minutes when connection key expires.</Description>
+<Default>3600</Default>
+</Parameter>
+
+<Parameter name="AuthorizationTimeout">
+<Description>
+How long to wait for authorization key when connection established</Description>
+<Default>5</Default>
+</Parameter>
+
+<Property name="CurrentNamespace">
+<Type>%String</Type>
+</Property>
+
+<Property name="InitialZName">
+<Type>%String</Type>
+</Property>
+
+<Property name="InitialZNamespace">
+<Type>%String</Type>
+</Property>
+
+<Property name="corePID">
+<Description>
+The process ID of the terminal core.</Description>
+<Type>%Numeric</Type>
+<InitialExpression>0</InitialExpression>
+</Property>
+
+<Property name="childNamespace">
+<Description>
+The last known namespace in child process.</Description>
+<Type>%String</Type>
+</Property>
+
+<Property name="StartupRoutine">
+<Type>%String</Type>
+</Property>
+
+<Property name="echo">
+<Description>
+Output flag</Description>
+<Type>%Boolean</Type>
+<InitialExpression>1</InitialExpression>
+</Property>
+
+<Property name="bufferOutput">
+<Description>
+flag which enables output buffering</Description>
+<Type>%Boolean</Type>
+<InitialExpression>0</InitialExpression>
+</Property>
+
+<Property name="outputBuffer">
+<Description>
+Used to buffer the output ("o" flag) when bufferOutput flag is set</Description>
+<Type>%Stream.TmpCharacter</Type>
+<InitialExpression>##class(%Stream.TmpCharacter).%New()</InitialExpression>
+</Property>
+
+<Property name="handler">
+<Description>
+Output flag</Description>
+<Type>%Boolean</Type>
+<InitialExpression>0</InitialExpression>
+<Private>1</Private>
+</Property>
+
+<Method name="GetMessage">
+<FormalSpec>timeout:%Integer=86400</FormalSpec>
+<ReturnType>%ZEN.proxyObject</ReturnType>
+<Implementation><![CDATA[
+    #define err(%e, %s) if (%e '= $$$OK) { set obj = ##class(%ZEN.proxyObject).%New() set obj.error = %s return obj }
+    set data = ..Read(, .st, timeout)
+    return:((st = $$$CSPWebSocketTimeout) || (st = $$$CSPWebSocketClosed)) ""
+    $$$err(st, "%wsReadErr: "_$System.Status.GetErrorText(st))
+    set st = ##class(%ZEN.Auxiliary.jsonProvider).%ConvertJSONToObject(data, , .obj, 1)
+    $$$err(st, "%wsParseErr: "_$System.Status.GetErrorText(st))
+    return obj
+]]></Implementation>
+</Method>
+
+<Method name="Send">
+<Description>
+Do not remove this method in future versions of WebTerminal, it is used by update.</Description>
+<FormalSpec>handler:%String="",data=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    if (handler = "o") && (..bufferOutput = 1) {
+        do ..outputBuffer.Write(data)
+        return $$$OK
+    }
+    return:((handler = "o") && (..echo = 0)) $$$OK
+    return:(handler = "o") ..Write("o"_data) // Enables 2013.2 support (no JSON)
+    set obj = ##class(%ZEN.proxyObject).%New()
+    set obj.h = handler
+    if (..handler '= 0) {
+        set obj."_cb" = ..handler
+    }
+    set obj.d = data
+    return ..Write(..GetJSONString(obj))
+]]></Implementation>
+</Method>
+
+<Method name="OnPreServer">
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set ..InitialZName = $zname
+    set ..InitialZNamespace = $znspace
+    quit $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="OnPostServer">
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    if (..corePID '= 0) {
+        do ..SendChunk(..corePID, "e")
+    }
+    quit $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="WriteToFile">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>filename:%String,data:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set file=##class(%File).%New(filename)
+    do file.Open("WSN")
+    do file.WriteLine(data)
+    do file.Close()
+]]></Implementation>
+</Method>
+
+<Method name="ExecuteSQL">
+<FormalSpec>query:%String=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set tStatement = ##class(%SQL.Statement).%New()
+    set qStatus = tStatement.%Prepare(query)
+    if qStatus'=1 {
+        write $System.Status.DisplayError(qStatus)
+    } else {
+        set rset = tStatement.%Execute()
+        do rset.%Display()
+    }
+    quit $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="RequireAuthorization">
+<Description>
+This method performs the authorization and login to WebTerminal.
+It returns a list with data (see Router.Auth method), which is used then to set up the
+initial values for the client.</Description>
+<ReturnType>%List</ReturnType>
+<Implementation><![CDATA[
+    set data = ..GetMessage(..#AuthorizationTimeout)
+    return:(data = "") $LB("%wsReadErr")
+    return:('$IsObject(data.d)) $LB($case(data.error = "", 1: "Unresolved WS message format", :data.error))
+    return:(data.d.key = "") $LB("Missing key")
+
+    set authKey = data.d.key
+    set key = $ORDER(^WebTerminal("AuthUser", ""))
+    set list = ""
+    while (key '= "") {
+        set lb = $GET(^WebTerminal("AuthUser", key))
+        if ((lb '= "") && (key = authKey)) {
+            set list = lb
+        }
+        set time = $LISTGET(lb, 2)
+        if (time '= "") && ($System.SQL.DATEDIFF("s", time, $h) > ..#WSKEYEXPIRES) {
+            kill ^WebTerminal("AuthUser", key)
+        }
+        set key = $ORDER(^WebTerminal("AuthUser", key))
+    }
+
+    if (list = "") { // not found
+        return $LB("Invalid key")
+    }
+
+    set username = $LISTGET(list, 1)
+    set namespace = $LISTGET(list, 3)
+    set ns = $Namespace
+
+    znspace "%SYS"
+    do ##class(Security.Users).Get(username, .userProps)
+    znspace ns
+
+    set namespace = $case(namespace, "":userProps("NameSpace"), :namespace)
+
+    if ($get(userProps("Routine")) '= "") {
+        set ..StartupRoutine = userProps("Routine")
+    }
+
+    if $get(userProps("Enabled")) '= 1 {
+        return $LB("User " _ username _ " is not enabled in the system")
+    }
+
+    set $LIST(list, 3) = namespace
+    set loginStatus = $System.Security.Login(username)
+
+    if (loginStatus '= 1) {
+        return $LB($System.Status.GetErrorText(loginStatus))
+    }
+
+    return $LB("", list)
+]]></Implementation>
+</Method>
+
+<Method name="ProcessRequest">
+<Description>
+See WebTerminal.Handlers</Description>
+<FormalSpec>handler:%String,data</FormalSpec>
+<Private>1</Private>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    try {
+        return $CLASSMETHOD("WebTerminal.Handlers", handler, $this, data)
+    } catch (e) {
+        set ..echo = 1
+        return e.AsSystemError()
+    }
+]]></Implementation>
+</Method>
+
+<Method name="ClientLoop">
+<Description>
+Main method for every new client.</Description>
+<Private>1</Private>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    job ##class(WebTerminal.Core).Loop(..StartupRoutine):($NAMESPACE):5
+    if ($TEST '= 1) { // $TEST=0 for JOB only when timeouted
+        do ..Send("error", "%noJob")
+        return $$$NOTOK
+    }
+    set ..corePID = $ZCHILD
+    set ..childNamespace = $NAMESPACE
+    if (..StartupRoutine = "") {
+        do ..Send("prompt", ..childNamespace)
+    } else {
+        set message = ##class(%ZEN.proxyObject).%New()
+        set status = $CLASSMETHOD("WebTerminal.Handlers", "Execute", $this, "", 1)
+        goto loopEnd
+    }
+    //try { // temp
+    for {
+        set message = ..GetMessage()
+        quit:(message = "") // if client is gone, finish looping
+        if (message.error) {
+            set st = ..Send("error", message.error)
+            quit
+        }
+        if (message."_cb" '= "") { set ..handler = message."_cb" }
+        set status = ..ProcessRequest(message.h, message.d)
+        set ..handler = 0
+        set ..echo = 1
+        if (status '= "") && (status '= $$$OK) {
+            set eType = $EXTRACT(status, 1, 1)
+            do ..Send("oLocalized", $C(13,10) _ $case(eType = 0, 1: $System.Status.GetErrorText(status), :status))
+            continue
+        }
+    }
+loopEnd
+    //} catch (e) {  do ..Send("o", $System.Status.GetErrorText(e)) } // temp
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="SendLoginInfo">
+<Description><![CDATA[
+This method sends basic login info to the user. Use this method to set client variables
+during the WebTerminal initialization.
+<parameter>authList</parameter> See Router.Auth method.]]></Description>
+<FormalSpec>authList:%List</FormalSpec>
+<Implementation><![CDATA[
+    set obj = ##class(%ZEN.proxyObject).%New()
+    set obj.username = $USERNAME
+    set obj.name = $get(^WebTerminal("Name"))
+    set obj.cleanStart = $ListGet(authList, 4)
+    set obj.system = $SYSTEM
+    set obj.firstLaunch = ($get(^WebTerminal("FirstLaunch"), 1) '= 0)
+    set obj.InstanceGUID = ##class(%SYS.System).InstanceGUID()
+    set obj.zv = $ZVersion
+    set ^WebTerminal("FirstLaunch") = 0
+    do ..Send("init", obj)
+]]></Implementation>
+</Method>
+
+<Method name="Server">
+<Description>
+Triggered when new connection established.</Description>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set authRes = ..RequireAuthorization()
+    set authMessage = $ListGet(authRes, 1)
+    if (authMessage = "") {
+        set authList = $ListGet(authRes, 2) // see Router.Auth method
+        set namespace = $ListGet(authList, 3)
+        if (namespace '= "") && (namespace '= $Namespace) {
+            try {
+                znspace namespace
+            } catch (e) {
+                do ..Send("oLocalized",
+                    $Char(27) _ "[31m%unNS(" _ namespace _ ")"_ $Char(27) _ "[0m" _ $Char(13,10)
+                )
+            }
+        }
+        set ..CurrentNamespace = $Namespace
+        do ..SendLoginInfo(authList)
+        do ..ClientLoop()
+        do ..Send("oLocalized", "%wsNormalClose"_$C(13,10))
+    } else {
+        do ..Send("oLocalized", "%wsRefuse(" _ authMessage _ ")")
+    }
+    do ..EndServer()
+    quit $$$OK
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.ErrorDecomposer">
+<TimeChanged>66289,77576.351378</TimeChanged>
+<TimeCreated>66289,77576.351378</TimeCreated>
+
+<Parameter name="LINES">
+<Type>%Numeric</Type>
+<Default>5</Default>
+</Parameter>
+
+<Method name="DecomposeError">
+<Description>
+Takes $ZERROR function result.
+Returns either simple string or %ZEN.proxyObject representing the error details.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>err:%String="",ns:%String=""</FormalSpec>
+<Implementation><![CDATA[
+    new $namespace
+    if (ns '= "") {
+        try {
+            set $namespace = ns
+        } catch (e) {
+            return err
+        }
+    }
+    return:($FIND(err, "<") '= 2) err
+    set startPos = $FIND(err, ">")
+    return:(startPos = 0) err
+    set spacePos = $FIND(err, " ") - 1
+    return:(spacePos = startPos) err
+    set label = $EXTRACT(err, startPos, $case(spacePos = -1, 1:999, :spacePos-1))
+    return:(label = "") err
+    try {
+        set obj = ##class(%ZEN.proxyObject).%New()
+        set obj.zerror = err
+        set plusPos = $FIND(label, "+")
+        set cPos = $FIND(label, "^")
+        if (plusPos = 0) || (cPos = 0) {
+            set obj.source = $TEXT(@label)
+            set obj.line = 0
+            return obj
+        }
+        set line = +$EXTRACT(label, plusPos, cPos - 2)
+        set part1 = $EXTRACT(label, 1, plusPos - 1)
+        set part2 = $EXTRACT(label, cPos - 1, *)
+        set range = ..#LINES \ 2
+        set obj.source = ""
+        set obj.line = 0
+        for i=line-range:1:line+range {
+            continue:(i < 1)
+            set label = part1 _ i _ part2
+            set text = $TEXT(@label)
+            set:(text '= "") obj.source = obj.source _ $case(obj.source = "", 1: "", :$C(10)) _ text
+            set:((text '= "") && (i < line)) obj.line = obj.line + 1
+        }
+        return obj
+    } catch (e) {
+        return err
+    }
+    return err
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.Handlers">
+<Description>
+Web Terminal version 4.9.4 WebSocket handlers class.
+This class describes handlers for WebSocket client. Each handler method takes WS client instance
+as a first argument, and a given data as second. For example, handler for "execute"
+command will be names as "HandleExecute". Note that all the processing is synchronous and it
+blocks the WebSocket input while processing.
+This class is inherited by WebTerminal.Engine class.
+Methods must return positive status or an error if one happened.
+Method must take two arguments, the first is the WebTerminal.Engine instance, and data as second</Description>
+<TimeChanged>66289,77576.345304</TimeChanged>
+<TimeCreated>66289,77576.345304</TimeCreated>
+
+<Method name="Execute">
+<Description>
+data can be either string or %ZEN.proxyObject. In case of proxyObject, the command is hold in
+data.command property, and it may have some other control properties.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data,bareStart:%Boolean=0</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    if (bareStart) goto loop
+    if $IsObject(data) {
+        set command = data.command
+        if (data.echo = 0) {
+            set client.echo = 0
+        }
+        if (data.bufferOutput = 1) {
+            set client.bufferOutput = 1
+        }
+    } else {
+        set command = data
+    }
+    do client.Send("o", $CHAR(13, 10))
+    do client.SendChunk(client.corePID, "m", command)
+loop
+    for {
+        set message = client.ReceiveChunk(0, 1) // read from WebSocket as well: timeout = 0
+        if ($LISTGET(message, 3) < 0) {
+            return $$$ERROR($$$GeneralError, "%cpTerm")
+        }
+        set flag = $LISTGET(message, 1)
+        if (flag = "") { // if there is no messages from the child process executing the task,
+            set mes = client.GetMessage(0) // look at the incoming WebSocket messages
+            if (mes '= "") && (mes.h = "Interrupt") { // and if the interrupt has been sent
+                do $System.Util.SendInterrupt(client.corePID) // interrupt the child process
+            } else { // else hang for a while to prevent "waiting" process from loading CPU
+                hang 0.05
+            }
+            continue
+        }
+        set chunk = $LISTGET(message, 2)
+        if (flag = "o") {
+            do client.Send("o", chunk)
+        } elseif (flag = "r") {
+            set obj = ##class(%ZEN.proxyObject).%New()
+            set obj.length = $LISTGET(chunk, 1)
+            set obj.timeout = $LISTGET(chunk, 2)
+            do client.Send("readString", obj)
+            set mes = client.GetMessage()
+            if (mes.h = "Interrupt") {
+                do $System.Util.SendInterrupt(client.corePID)
+            } else {
+                do client.SendChunk(client.corePID, "m", mes.d)
+            }
+        } elseif (flag = "c") {
+            set obj = ##class(%ZEN.proxyObject).%New()
+            set obj.timeout = chunk
+            do client.Send("readChar", obj)
+            set mes = client.GetMessage()
+            if (mes.h = "Interrupt") {
+                do $System.Util.SendInterrupt(client.corePID)
+            } else {
+                do client.SendChunk(client.corePID, "m", mes.d)
+            }
+        } elseif (flag = "e") {
+            set err = ""
+            if $ListValid(chunk) {
+                if ($LISTGET(chunk, 1) '= "") {
+                    set client.childNamespace = $LISTGET(chunk, 1)
+                }
+                if ($LISTGET(chunk, 2) '= "") {
+                    set err = $LISTGET(chunk, 2)
+                }
+            }
+            if $IsObject(data) && (data.bufferOutput = 1) {
+                do client.outputBuffer.Write(err)
+                quit // break for loop
+            }
+            if (err '= "") {
+                do client.Send(
+                    "execError",
+                    ##class(ErrorDecomposer).DecomposeError(err, client.childNamespace)
+                )
+            }
+            quit // break for loop
+        } else { // unknown response - just send it to the client
+            do client.Send("o", chunk)
+        }
+    }
+    do client.Send("o", $CHAR(13, 10))
+    if $IsObject(data) {
+        if (data.echo = 0) {
+            set client.echo = 1
+        }
+        if (data.bufferOutput = 1) {
+            set client.bufferOutput = 0
+            set str = ""
+            while ('client.outputBuffer.AtEnd) {
+                set str = str _ client.outputBuffer.Read()
+            }
+            do client.Send("promptCallback", str)
+            do client.outputBuffer.Clear()
+        }
+    }
+    do:('($IsObject(data) && (data.prompt = 0)) && '(bareStart = 1)) client.Send("prompt", client.childNamespace)
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="Update">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,URL:%String</FormalSpec>
+<Implementation><![CDATA[
+    set st = ##class(WebTerminal.Updater).Update(client, URL)
+    do:($$$ISERR(st)) ##class(WebTerminal.Analytics).ReportInstallStatus(st)
+    return st
+]]></Implementation>
+</Method>
+
+<Method name="LocalAutocomplete">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data</FormalSpec>
+<Implementation><![CDATA[
+	do client.SendChunk(client.corePID, "a")
+	set list = $LISTGET(client.ReceiveChunk(, 1), 2)
+	set obj = ##class(%ZEN.proxyObject).%New()
+	for i=3:3:$LISTLENGTH(list) {
+		set obj2 = ##class(%ZEN.proxyObject).%New()
+		set obj2.isOref = $LISTGET(list, i - 1)
+		set obj2.value = $LISTGET(list, i)
+		set $PROPERTY(obj, $LISTGET(list, i - 2)) = obj2
+	}
+    do client.Send("ac", obj)
+	return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="GlobalAutocomplete">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,part:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do client.Send(, ##class(WebTerminal.Autocomplete).GetGlobals(client.childNamespace, part))
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="ClassAutocomplete">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,part:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do client.Send(, ##class(WebTerminal.Autocomplete).GetClass(client.childNamespace, part))
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="RoutineAutocomplete">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,part:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do client.Send(, ##class(WebTerminal.Autocomplete).GetRoutines(client.childNamespace, part))
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="ClassMemberAutocomplete">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do client.Send(, ##class(WebTerminal.Autocomplete).GetPublicClassMembers(client.childNamespace, data.className, data.part))
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="MemberAutocomplete">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do client.SendChunk(client.corePID, "a")
+    set list = $LISTGET(client.ReceiveChunk(, 1), 2)
+    set isOref = 0
+    set value = ""
+    for i=3:3:$LISTLENGTH(list) {
+        if $LISTGET(list, i - 2) = data.variable {
+            set isOref = $LISTGET(list, i - 1)
+            set value = $LISTGET(list, i)
+            quit
+        }
+    }
+    if isOref {
+        do client.Send(, ##class(WebTerminal.Autocomplete).GetClassMembers(
+            client.childNamespace, $PIECE(value, "@", 2), data.part, data.methodsOnly
+        ))
+    } else {
+        do client.Send(, 0)
+    }
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="ParameterAutocomplete">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do client.Send(, ##class(WebTerminal.Autocomplete).GetParameters(client.childNamespace, data.className, data.part))
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="serverNameConfigSet">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,value:%String=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set ^WebTerminal("Name") = value
+    do client.Send(, 1)
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="SQL">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    new $Namespace
+    set $Namespace = client.childNamespace
+    set sql = data.sql
+    set max = $case(data.max = "", 1: 777, :data.max)
+    set obj = ##class(%ZEN.proxyObject).%New()
+    
+    SET tStatement = ##class(%SQL.Statement).%New()
+    SET st = tStatement.%Prepare(sql)
+    if (st '= $$$OK) {
+        set obj.error = "%badSQL("_$System.Status.GetErrorText(st)_")"
+        return client.Send(, obj)
+    }
+    SET rset = tStatement.%Execute()
+    if (rset.%SQLCODE '= 0) {
+    	set obj.error = "%sqlErr(SQLCODE="_rset.%SQLCODE_"; "_rset.%Message_")"
+    	return client.Send(, obj)
+    }
+
+	set headers = ##class(%ListOfDataTypes).%New()
+	for i=1:1:tStatement.%Metadata.columns.Count() {
+		do headers.Insert(tStatement.%Metadata.columns.GetAt(i).colName)
+	}
+
+	set dt = ##class(%ListOfDataTypes).%New()
+	while rset.%Next() {
+		if (rset.%ROWCOUNT > max) quit
+		set line = ##class(%ListOfDataTypes).%New()
+		for i=1:1:headers.Count() {
+			do line.Insert(rset.%GetData(i))
+		}
+		do dt.Insert(line)
+	}
+
+	set:(dt.Count() > 0) obj.data = dt
+	set:(headers.Count() > 0) obj.headers = headers
+	
+    do client.Send(, obj)
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="Trace">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set obj = ##class(%ZEN.proxyObject).%New()
+    set obj.OK = 1
+    set obj.started = client.Trace(data)
+    if (obj.started '= 1) {
+        set obj.stopped = client.StopTracing(data)
+        if (obj.stopped '= 1) {
+            set obj.OK = 0
+        }
+    }
+    do client.Send(, obj)
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="StopTracing">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set obj = ##class(%ZEN.proxyObject).%New()
+    set obj.OK = $LISTLENGTH(client.Watches) > 0
+    while ($LISTLENGTH(client.Watches) > 0) {
+        set stopped = client.StopTracing($LIST(client.Watches, 1))
+    }
+    do client.Send(, obj)
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="TracingStatus">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set obj = ##class(%ZEN.proxyObject).%New()
+    set oldWatch = client.Watches
+    set obj.changes = client.CheckTracing()
+    set obj.stop = ##class(%ZEN.proxyObject).%New()
+    if ($LENGTH(oldWatch) > $LENGTH(client.Watches)) {
+        for i=1:1:$LISTLENGTH(oldWatch) {
+            if ($LISTFIND(client.Watches, $LISTGET(oldWatch, i)) = 0) {
+                set $PROPERTY(obj.stop, $LISTGET(oldWatch, i)) = 1
+            }
+        }
+    }
+    do client.Send(, obj)
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="Auth">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    // This method is implemented in Engine class. In case of auth is off, this method handles
+    // the auth request and never respond (like when you send something to /dev/null).
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="Interrupt">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,data:%ZEN.proxyObject=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    // The interrupt behavior is implemented in Execute class method. When the user presses Ctrl+C
+    // in normal mode, we will do *nothing*.
+    return $$$OK
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.Installer">
+<Description>
+Importing this class will install Cache WEB Terminal properly.</Description>
+<Super>%Projection.AbstractProjection</Super>
+<TimeChanged>66289,77576.362759</TimeChanged>
+<TimeCreated>66289,77576.362759</TimeCreated>
+<DependsOn>Router</DependsOn>
+
+<Parameter name="DispatchClass">
+<Default>WebTerminal.Router</Default>
+</Parameter>
+
+<Parameter name="ResourceName">
+<Default>%WebTerminal</Default>
+</Parameter>
+
+<Parameter name="RoleName">
+<Default>WebTerminal</Default>
+</Parameter>
+
+<Projection name="Reference">
+<Type>Installer</Type>
+</Projection>
+
+<Parameter name="VERSION">
+<Default>4.9.4</Default>
+</Parameter>
+
+<Parameter name="iscProductVersion">
+<Description>
+In older Cache versions, method "GetISCProduct" does not exists</Description>
+<Expression>$case(
+        ##class(%Dictionary.CompiledMethod).IDKEYExists("%SYSTEM.Version", "GetISCProduct"),
+        1: $CLASSMETHOD("%SYSTEM.Version", "GetISCProduct"),
+        : 2
+    )</Expression>
+</Parameter>
+
+<Method name="RegisterWebApplication">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>name:%String,spec</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    new $Namespace
+    set $Namespace = "%SYS"
+    set st = $$$OK
+    if ('##class(Security.Applications).Exists(name)) {
+        write !,"Creating WEB application """_name_"""..."
+        set st = ##class(Security.Applications).Create(name, .spec)
+        write !, "WEB application """_name_""" is created."
+    } else { // ensure configuration matches in case of updating from old terminal versions
+        write !, "Updating web application """_name_"""..."
+        set st = ##class(Security.Applications).Modify(name, .spec)
+        write !, "WEB application """_name_""" is updated."
+    }
+    return st
+]]></Implementation>
+</Method>
+
+<Method name="RemoveWebApplication">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>name:%String</FormalSpec>
+<Implementation><![CDATA[
+    new $Namespace
+    set $Namespace = "%SYS"
+    set st = $$$OK
+    if (##class(Security.Applications).Exists(name)) {
+        do ##class(Security.Applications).Get(name, .props)
+        if (props("DispatchClass") '= ..#DispatchClass) && (name = "/terminal") {
+            write !, "Won't delete WEB-application """_name_""" because it does not refer to dispatch class anymore."
+        } else {
+            write !, "Deleting WEB application """_name_"""..."
+            set st = ##class(Security.Applications).Delete(name)
+            write !, "WEB application """_name_""" was successfully deleted."
+        }
+    }
+    return st
+]]></Implementation>
+</Method>
+
+<Method name="ReportInstallStatus">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>st,ns=^WebTerminal("HomeNamespace")</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set $Namespace = ns
+    if (st '= 1) {
+        do $System.Status.DisplayError(st)
+    }
+    set status = ##class(WebTerminal.Analytics).ReportInstallStatus(st)
+    set $Namespace = "%SYS"
+    return status
+]]></Implementation>
+</Method>
+
+<Method name="CreateProjection">
+<Description>
+This method is invoked when a class is compiled.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec><![CDATA[cls:%String,&params]]></FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+	new $Namespace
+	set ns = $Namespace // ought to be package home namespace!
+    set ^WebTerminal("HomeNamespace") = ns
+    set ^WebTerminal("FirstLaunch") = 1
+    write !, "Installing WebTerminal application to " _ ns
+    set dbdir = $$$defdir
+    try {
+        set $Namespace = "%SYS"
+    } catch (e) {
+        set mes = "<PROTECT> The user " _ $Username _ " has no privileges"
+            _ " to enter the %SYS namespace. Please, log in as a privileged user"
+            _ " to set up the WebTerminal application."
+        set err = $$$ERROR($$$GeneralError, mes)
+        do ..ReportInstallStatus(err, ns)
+        return err
+    }
+    
+    set cspProperties("AutheEnabled") = $$$AutheCache
+    set cspProperties("NameSpace") = ns
+    set cspProperties("Description") = "A WEB application for Cache WEB Terminal."
+    set cspProperties("IsNameSpaceDefault") = $$$NO
+    set cspProperties("DispatchClass") = ..#DispatchClass
+    set st = ..RegisterWebApplication("/terminal", .cspProperties)
+    do:($$$ISERR(st)) ..ReportInstallStatus(st, ns)
+    return:$$$ISERR(st) st
+    
+    set cspProperties("AutheEnabled") = $$$AutheUnauthenticated
+    set cspProperties("Description") = "An application representing the open socket for /terminal application."
+    set cspProperties("DispatchClass") = ""
+
+    set requiredRole = $case(..#iscProductVersion >= 4, 1: "%DB_IRISSYS", : "%DB_CACHESYS")
+    set roles = ..GetDBRole(dbdir)
+    set extractedRoles = $case($get(roles) '= "", 1: ":" _ roles, : "")
+    set cspProperties("MatchRoles") = ":" _ $case(
+        $find(extractedRoles, requiredRole) = 0,
+        1: requiredRole _ extractedRoles,
+        : requiredRole
+    )
+    write !, "Assigning role " _ requiredRole _ " to a web application; resulting roles: " _ cspProperties("MatchRoles")
+
+    set st = ..RegisterWebApplication("/terminalsocket", .cspProperties)
+    do:($$$ISERR(st)) ..ReportInstallStatus(st, ns)
+    return:$$$ISERR(st) st
+    
+    do ..CreateAllNamespace()
+    
+    write !, "Mapping %WebTerminal package into all namespaces:"
+    set st = ..Map(ns)
+    if ($$$ISERR(st)) {
+        do ..ReportInstallStatus(st, ns)
+    } else {
+	    write !, "WebTerminal package successfully mapped into all namespaces."
+	    do ..ReportInstallStatus(1, ns)
+    }
+
+    if (##class(Security.Resources).Exists(..#ResourceName) = 0) {
+        set st = ##class(Security.Resources).Create(..#ResourceName,
+            "Grants access to WebTerminal if set up.", "")
+    }
+
+    if (##class(Security.Roles).Exists(..#RoleName) = 0) {
+        set st = ##class(Security.Roles).Create(..#RoleName,
+            "WebTerminal user role which may grant access to WebTerminal application if set up.",
+            "%WebTerminal:RWU")
+    }
+    
+    return st
+]]></Implementation>
+</Method>
+
+<Method name="RemoveProjection">
+<Description>
+This method is invoked when a class is 'uncompiled'.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec><![CDATA[cls:%String,&params,recompile:%Boolean]]></FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+	new $Namespace
+
+	write:(recompile) !, "Recompiling WebTerminal, skipping the deletion..."
+    return:(recompile) $$$OK
+
+	set ns = $get(^WebTerminal("HomeNamespace"), $Namespace)
+    write !, "Uninstalling WebTerminal application from ", ns
+    zn "%SYS"
+    set st = ..RemoveWebApplication("/terminal")
+    do:($$$ISERR(st)) ..ReportInstallStatus(st, ns)
+    return:($$$ISERR(st)) st
+    set st = ..RemoveWebApplication("/terminalsocket")
+    do:($$$ISERR(st)) ..ReportInstallStatus(st, ns)
+    return:($$$ISERR(st)) st
+    if (##class(Security.Resources).Exists(..#ResourceName) = 1) {
+        set st = ##class(Security.Resources).Delete(..#ResourceName)
+        do:($$$ISERR(st)) ..ReportInstallStatus(st, ns)
+        return:($$$ISERR(st)) st
+    }
+    if (##class(Security.Roles).Exists(..#RoleName) = 1) {
+        set st = ##class(Security.Roles).Delete(..#RoleName)
+        do:($$$ISERR(st)) ..ReportInstallStatus(st, ns)
+        return:($$$ISERR(st)) st
+    }
+
+    kill:st ^WebTerminal
+    write !, "Global ^WebTerminal removed."
+
+    write !, "Unmapping %WebTerminal package from all namespaces:"
+	set st = ..UnMap(ns)
+    if ($$$ISERR(st)) {
+        do ..ReportInstallStatus(st, ns)
+    } else {
+	    write !, "Unmapping complete."
+    }
+
+    return st
+]]></Implementation>
+</Method>
+
+<Method name="GetDBRole">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>directory:%String</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+	return:'$d(directory) ""
+	new $Namespace
+	set $Namespace = "%SYS"
+	#dim db As SYS.Database
+	set db = ##class(SYS.Database).%OpenId(directory)
+	if $Isobject(db) {
+		set resource = db.ResourceName
+		set role = resource // I'm assuming that default role exists (@eduard93)
+	} else {
+		set role = ""
+	}
+	return role
+]]></Implementation>
+</Method>
+
+<Method name="CreateAllNamespace">
+<ClassMethod>1</ClassMethod>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+
+	new $Namespace
+    set $Namespace = "%SYS"
+	set ns = "%All"
+    set st = $$$OK
+
+	if ('##Class(Config.Namespaces).Exists(ns)) {
+
+        set dbPrefix = $case(..#iscProductVersion >= 4, 1: "IRIS", : "CACHE")
+        set Properties("Globals") = dbPrefix _ "TEMP"
+        set Properties("Library") = dbPrefix _ "LIB"
+        set Properties("Routines") = dbPrefix _ "TEMP"
+        set Properties("SysGlobals") = dbPrefix _ "SYS"
+        set Properties("SysRoutines") = dbPrefix _ "SYS"
+        set Properties("TempGlobals") = dbPrefix _ "TEMP"
+		
+		set st = ##Class(Config.Namespaces).Create(ns, .Properties)
+		if ($$$ISERR(st)) {
+        	do $System.Status.DisplayError(st)
+    	} else {
+        	write !, "%All namespace is created."
+        }
+
+    }
+
+    return st
+]]></Implementation>
+</Method>
+
+<Method name="Map">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>fromNS=""</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+	new $Namespace
+    set $Namespace = "%SYS"
+    set st = $$$OK
+
+    set mapTo = $LISTBUILD("%All", "SAMPLES", "DOCBOOK")
+    do ##Class(Config.Namespaces).Get(fromNS, .InstallNSProps)
+    set Properties("Database") = $get(InstallNSProps("Routines"))
+    set ptr = 0
+    while $LISTNEXT(mapTo, ptr, namespace) {
+        continue:(fromNS = namespace)
+        continue:('##Class(Config.Namespaces).Exists(namespace))
+        write " ", namespace
+        if ('##Class(Config.MapPackages).Exists(namespace, "WebTerminal")) {
+        	set st1 = ##Class(Config.MapPackages).Create(namespace, "WebTerminal", .Properties)
+        }
+        if ('##Class(Config.MapGlobals).Exists(namespace, "WebTerminal")) {
+	        set st2 = ##Class(Config.MapGlobals).Create(namespace, "WebTerminal", .Properties)
+        }
+        set st = $$$ADDSC(st,$$$ADDSC($get(st1,$$$OK),$get(st2,$$$OK)))
+    }
+    return st
+]]></Implementation>
+</Method>
+
+<Method name="UnMap">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>fromNS:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+	new $Namespace
+    set $Namespace = "%SYS"
+    set st = $$$OK
+    
+	set mapTo = $LISTBUILD("%All", "SAMPLES", "DOCBOOK")
+    set ptr = 0
+    while $LISTNEXT(mapTo, ptr, namespace) {
+	    continue:(fromNS = namespace)
+	    continue:('##Class(Config.Namespaces).Exists(namespace))
+        write " ", namespace
+        if (##Class(Config.MapPackages).Exists(namespace, "WebTerminal")) {
+        	set st1 = ##Class(Config.MapPackages).Delete(namespace, "WebTerminal", .Properties)
+        }
+        if (##Class(Config.MapGlobals).Exists(namespace, "WebTerminal")) {
+	        set st2 = ##Class(Config.MapGlobals).Delete(namespace, "WebTerminal", .Properties)
+        }
+        set st = $$$ADDSC(st,$$$ADDSC($get(st1,$$$OK),$get(st2,$$$OK)))
+    }
+    return st
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.Router">
+<Description>
+The REST interface: class that routes HTTP requests</Description>
+<CompileAfter>StaticContent</CompileAfter>
+<Super>%CSP.REST</Super>
+<TimeChanged>66289,77576.373655</TimeChanged>
+<TimeCreated>66289,77576.373655</TimeCreated>
+
+<XData name="UrlMap">
+<Data><![CDATA[
+<Routes>
+   <Route Url="/" Method="GET" Call="Index"/>
+   <Route Url="/index" Method="GET" Call="Index"/>
+   <Route Url="/auth" Method="GET" Call="Auth"/>
+   <Route Url="/css/index.css" Method="GET" Call="GetCss"/>
+   <Route Url="/css/themes/:theme" Method="GET" Call="GetTheme"/>
+   <Route Url="/js/index.js" Method="GET" Call="GetJs"/>
+</Routes>
+]]></Data>
+</XData>
+
+<Method name="WriteStatic">
+<Description>
+Calls StaticContent.Write method or sends not modified header. Type have to be "css" or "js"</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>type:%String,ContentType:%String=""</FormalSpec>
+<Private>1</Private>
+<Implementation><![CDATA[
+    #define CompileTime ##Expression("""" _ $zd($h, 11) _ ", "_ $zdt($NOW(0), 2,1) _ " GMT""")
+    set %response.CharSet = "utf-8"
+    set %response.ContentType = $case(type,
+        "css": "text/css",
+        "js": "text/javascript",
+        "html": "text/html",
+        : $case(ContentType="", 1:"text/plain", :ContentType)
+    )
+    do %response.SetHeader("Last-Modified", $$$CompileTime)
+
+    if (%request.GetCgiEnv("HTTP_IF_MODIFIED_SINCE")=$$$CompileTime) {
+        set %response.Status = "304 Not Modified"
+    } else {
+        do ##class(StaticContent).Write(type)
+    }
+]]></Implementation>
+</Method>
+
+<Method name="Auth">
+<ClassMethod>1</ClassMethod>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set cookie = $System.Encryption.Base64Encode(%session.Key)
+    set ^WebTerminal("AuthUser", cookie) = $LB( // authList
+        $Username, // username
+        $Horolog, // granting ticket date
+        $Get(%request.Data("ns", 1), $Get(%request.Data("NS", 1))),
+        $Get(%request.Data("clean", 1), 0) '= 0
+    )
+    write "{""key"":""" _ cookie _ """}"
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="GetCss">
+<Description>
+Method writes application CSS.</Description>
+<ClassMethod>1</ClassMethod>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do ..WriteStatic("css")
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="GetTheme">
+<Description>
+Method writes application theme.</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>Theme:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do ..WriteStatic("Theme"_$REPLACE(Theme, ".css", ""),"text/css")
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="GetJs">
+<Description>
+Method writes application JavaScript.</Description>
+<ClassMethod>1</ClassMethod>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do ..WriteStatic("js")
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="Index">
+<Description>
+Method writes application HTML.</Description>
+<ClassMethod>1</ClassMethod>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do ..WriteStatic("html")
+    return $$$OK
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.StaticContent">
+<Description>
+This class holds whole application static content like scripts and styles.
+Do not edit this file - use external tool to generate it.</Description>
+<TimeChanged>66289,77576.406244</TimeChanged>
+<TimeCreated>66289,77576.406244</TimeCreated>
+
+<Method name="Write">
+<Description>
+Write the contents of xData tag</Description>
+<ClassMethod>1</ClassMethod>
+<FormalSpec>Const:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set obj = ##class(%Dictionary.CompiledXData).%OpenId("WebTerminal.StaticContent||"_Const)
+    return:(obj = "") $$$OK
+    set xdata = obj.Data
+    set status = ##class(%XML.TextReader).ParseStream(xdata, .textreader)
+    while textreader.Read() { if (textreader.NodeType="chars") {
+        write textreader.Value
+    } }
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<XData name="Themecache">
+<Data><![CDATA[
+<data>
+<![CDATA[body,html{color:#000;background:#fff;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.terminal .hint{text-shadow:1px 1px 4px #fff}.g.m31{color:#c80000}.g.m32{color:#00c800}.g.m33{color:#c8c800}.g.m34{color:#0000c8}.g.m35{color:#c800c8}.g.m36{color:#00c8c8}.g.m41{background-color:#c80000}.g.m42{background-color:#00c800}.g.m43{background-color:#c8c800}.g.m44{background-color:#0000c8}.g.m45{background-color:#c800c8}.g.m46{background-color:#00c8c8}]]]]><![CDATA[>
+</data>
+]]></Data>
+</XData>
+
+<XData name="html">
+<Data><![CDATA[
+<data>
+<![CDATA[<!DOCTYPE html>
+         <html>
+         <head lang="en">
+             <meta charset="UTF-8"/>
+             <title>Cach&eacute; WEB Terminal</title>
+             <meta name="author" content="ZitRo"/>
+             <meta name="description" content="Web-based terminal emulator for Caché administering."/>
+             <meta name="keywords" content="Cache,Caché,terminal,web,remote,control,Caché WebTerminal"/>
+             <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, maximum-scale=1.0"/>
+             <meta name="MobileOptimized" content="320"/>
+             <meta name="HandheldFriendly" content="true"/>
+             <meta name="mobile-web-app-capable" content="yes"/>
+             <meta name="apple-mobile-web-app-capable" content="yes"/>
+             <link rel="stylesheet" href="css/index.css"/>
+             <script async src="https://www.google-analytics.com/analytics.js"></script>
+             <script type="text/javascript" src="js/index.js"></script>
+         </head>
+         <body>
+         <!-- @see js/index.js -->
+         </body>
+         </html>]]]]><![CDATA[>
+</data>
+]]></Data>
+</XData>
+
+<XData name="css">
+<Data><![CDATA[
+<data>
+<![CDATA[body,html{padding:0;margin:0;background:#000;color:#fff}.terminal,body,html{position:relative;width:100%;height:100%;overflow:hidden}.terminal{font-family:FreeMono,monospace;font-size:16px;background:inherit;-webkit-font-smoothing:subpixel-antialiased;-moz-osx-font-smoothing:auto}.terminal .output{position:absolute;white-space:pre;word-wrap:break-word;word-break:break-all;overflow-x:hidden;overflow-y:scroll;background:inherit;width:100%;height:100%;z-index:0}.terminal .output .input{position:absolute;width:100%;border:0;text-decoration:none;outline:none;margin:0;padding:0;opacity:0;font-family:inherit;font-size:inherit;z-index:3;background:transparent;color:transparent;overflow:hidden}.terminal .output .line{position:absolute;z-index:1;min-width:100%;background:inherit}.terminal .output .line .g{background:inherit}.terminal .output .line.html{z-index:2;white-space:normal;height:auto!important;word-break:normal;overflow-x:auto;width:100%}.terminal .output .caret{position:absolute;left:0;top:0;z-index:2;animation:a infinite 1s}.terminal .output .caret:after{position:relative;top:-1px;content:"_"}.terminal>.indicator{position:fixed;right:13px;top:7px;border:3px solid #fff;border-radius:30px;height:30px;margin:-15px 0 0 -15px;opacity:0;width:30px;animation:b infinite 1s}.terminal table{border-collapse:collapse;border:1px solid #666}.terminal table td,.terminal table th{padding:2px;border:1px solid #666}.terminal table td:nth-child(2n-1),.terminal table th:nth-child(2n-1){background:#222}.terminal table th{font-weight:700}a{color:#00ce00}.terminal .output .line .g.m1{font-weight:900}.terminal .output .line .g.m2{opacity:.7}.terminal .output .line .g.m3{font-style:italic}.terminal .output .line .g.m4{text-decoration:underline}.terminal .output .line .g.m5{animation:a infinite 1s}.terminal .output .line .g.m7{-khtml-filter:invert(100%);-moz-filter:invert(100%);-o-filter:invert(100%);-ms-filter:invert(100%);filter:invert(100%)}.terminal .output .line .g.m8{opacity:0}.terminal .output .line .g.hint{opacity:.5}.terminal .output .line .g.m30{color:#000}.terminal .output .line .g.m31{color:red}.terminal .output .line .g.m32{color:green}.terminal .output .line .g.m33{color:#ff0}.terminal .output .line .g.m34{color:#00f}.terminal .output .line .g.m35{color:#f0f}.terminal .output .line .g.m36{color:cyan}.terminal .output .line .g.m37{color:#fff}.terminal .output .line .g.m40{background-color:#000}.terminal .output .line .g.m41{background-color:red}.terminal .output .line .g.m42{background-color:green}.terminal .output .line .g.m43{background-color:#ff0}.terminal .output .line .g.m44{background-color:#00f}.terminal .output .line .g.m45{background-color:#f0f}.terminal .output .line .g.m46{background-color:cyan}.terminal .output .line .g.m47{background-color:#fff}.terminal .output .line .g.keyword{color:#4898ff}.terminal .output .line .g.string{color:#00c700}.terminal .output .line .g.constant{color:cyan}.terminal .output .line .g.special{color:#ff0}.terminal .output .line .g.variable{color:#ffa07a}.terminal .output .line .g.selected{color:#fff;background-color:#4169e1}.terminal .output .line .g.argument{color:#da7cff}.terminal .output .line .g.error{display:inline-block;position:relative}.terminal .output .line .g.error:after{content:"";position:absolute;display:block;bottom:0;left:0;width:100%;height:0;border-top:1px dashed red}.terminal .output .line .g.wrong{color:red}.terminal .output .line .g.global{color:#ef6913}.terminal .output .line .g.classname{color:cyan}@keyframes a{0%{-khtml-filter:invert(0);-moz-filter:invert(0);-o-filter:invert(0);-ms-filter:invert(0);filter:invert(0)}50%{-khtml-filter:invert(100%);-moz-filter:invert(100%);-o-filter:invert(100%);-ms-filter:invert(100%);filter:invert(100%)}to{-khtml-filter:invert(0);-moz-filter:invert(0);-o-filter:invert(0);-ms-filter:invert(0);filter:invert(0)}}@keyframes b{0%{transform:scale(.1);-o-transform:scale(.1);-ms-transform:scale(.1);-moz-transform:scale(.1);-webkit-transform:scale(.1);opacity:0}50%{opacity:1}to{transform:scale(.5);-o-transform:scale(.5);-ms-transform:scale(.5);-moz-transform:scale(.5);-webkit-transform:scale(.5);opacity:0}}.terminal .hintBox{position:absolute;left:0;top:0;width:300px;max-width:75%;height:0;overflow:visible;z-index:100}.terminal .hintBox>div{position:absolute;transition:all .3s ease;color:gray;border-radius:10px}]]]]><![CDATA[>
+</data>
+]]></Data>
+</XData>
+
+<XData name="js">
+<Data><![CDATA[
+<data>
+<![CDATA[!function r(o,a,i){function s(t,e){if(!a[t]){if(!o[t]){var n="function"==typeof require&&require;if(!e&&n)return n(t,!0);if(l)return l(t,!0);throw(e=new Error("Cannot find module '"+t+"'")).code="MODULE_NOT_FOUND",e}n=a[t]={exports:{}},o[t][0].call(n.exports,function(e){return s(o[t][1][e]||e)},n,n.exports,r,o,a,i)}return a[t].exports}for(var l="function"==typeof require&&require,e=0;e<i.length;e++)s(i[e]);return s}({1:[function(n,e,t){!function(e){!function(){"use strict";if(n("core-js/shim"),n("regenerator-runtime/runtime"),n("core-js/fn/regexp/escape"),e._babelPolyfill)throw new Error("only one instance of babel-polyfill is allowed");e._babelPolyfill=!0;function t(e,t,n){e[t]||Object.defineProperty(e,t,{writable:!0,configurable:!0,value:n})}t(String.prototype,"padLeft","".padStart),t(String.prototype,"padRight","".padEnd),"pop,reverse,shift,keys,values,entries,indexOf,every,some,forEach,map,filter,find,findIndex,includes,join,slice,concat,push,splice,unshift,sort,lastIndexOf,reduce,reduceRight,copyWithin,fill".split(",").forEach(function(e){[][e]&&t(Array,e,Function.call.bind([][e]))})}.call(this)}.call(this,"undefined"!=typeof global?global:"undefined"!=typeof self?self:"undefined"!=typeof window?window:{})},{"core-js/fn/regexp/escape":2,"core-js/shim":330,"regenerator-runtime/runtime":332}],2:[function(e,t,n){e("../../modules/core.regexp.escape"),t.exports=e("../../modules/_core").RegExp.escape},{"../../modules/_core":24,"../../modules/core.regexp.escape":132}],3:[function(e,t,n){t.exports=function(e){if("function"!=typeof e)throw TypeError(e+" is not a function!");return e}},{}],4:[function(e,t,n){var r=e("./_cof");t.exports=function(e,t){if("number"!=typeof e&&"Number"!=r(e))throw TypeError(t);return+e}},{"./_cof":19}],5:[function(e,t,n){var r=e("./_wks")("unscopables"),o=Array.prototype;null==o[r]&&e("./_hide")(o,r,{}),t.exports=function(e){o[r][e]=!0}},{"./_hide":44,"./_wks":130}],6:[function(e,t,n){"use strict";var r=e("./_string-at")(!0);t.exports=function(e,t,n){return t+(n?r(e,t).length:1)}},{"./_string-at":107}],7:[function(e,t,n){t.exports=function(e,t,n,r){if(!(e instanceof t)||void 0!==r&&r in e)throw TypeError(n+": incorrect invocation!");return e}},{}],8:[function(e,t,n){var r=e("./_is-object");t.exports=function(e){if(r(e))return e;throw TypeError(e+" is not an object!")}},{"./_is-object":53}],9:[function(e,t,n){"use strict";var l=e("./_to-object"),u=e("./_to-absolute-index"),c=e("./_to-length");t.exports=[].copyWithin||function(e,t){var n=l(this),r=c(n.length),o=u(e,r),a=u(t,r),e=2<arguments.length?arguments[2]:void 0,i=Math.min((void 0===e?r:u(e,r))-a,r-o),s=1;for(a<o&&o<a+i&&(s=-1,a+=i-1,o+=i-1);0<i--;)a in n?n[o]=n[a]:delete n[o],o+=s,a+=s;return n}},{"./_to-absolute-index":115,"./_to-length":119,"./_to-object":120}],10:[function(e,t,n){"use strict";var i=e("./_to-object"),s=e("./_to-absolute-index"),l=e("./_to-length");t.exports=function(e){for(var t=i(this),n=l(t.length),r=arguments.length,o=s(1<r?arguments[1]:void 0,n),r=2<r?arguments[2]:void 0,a=void 0===r?n:s(r,n);o<a;)t[o++]=e;return t}},{"./_to-absolute-index":115,"./_to-length":119,"./_to-object":120}],11:[function(e,t,n){var r=e("./_for-of");t.exports=function(e,t){var n=[];return r(e,!1,n.push,n,t),n}},{"./_for-of":40}],12:[function(e,t,n){var l=e("./_to-iobject"),u=e("./_to-length"),c=e("./_to-absolute-index");t.exports=function(s){return function(e,t,n){var r,o=l(e),a=u(o.length),i=c(n,a);if(s&&t!=t){for(;i<a;)if((r=o[i++])!=r)return!0}else for(;i<a;i++)if((s||i in o)&&o[i]===t)return s||i||0;return!s&&-1}}},{"./_to-absolute-index":115,"./_to-iobject":118,"./_to-length":119}],13:[function(e,t,n){var g=e("./_ctx"),b=e("./_iobject"),x=e("./_to-object"),w=e("./_to-length"),r=e("./_array-species-create");t.exports=function(f,e){var p=1==f,d=2==f,v=3==f,y=4==f,_=6==f,h=5==f||_,m=e||r;return function(e,t,n){for(var r,o,a=x(e),i=b(a),s=g(t,n,3),l=w(i.length),u=0,c=p?m(e,l):d?m(e,0):void 0;u<l;u++)if((h||u in i)&&(o=s(r=i[u],u,a),f))if(p)c[u]=o;else if(o)switch(f){case 3:return!0;case 5:return r;case 6:return u;case 2:c.push(r)}else if(y)return!1;return _?-1:v||y?y:c}}},{"./_array-species-create":16,"./_ctx":26,"./_iobject":49,"./_to-length":119,"./_to-object":120}],14:[function(e,t,n){var c=e("./_a-function"),f=e("./_to-object"),p=e("./_iobject"),d=e("./_to-length");t.exports=function(e,t,n,r,o){c(t);var a=f(e),i=p(a),s=d(a.length),l=o?s-1:0,u=o?-1:1;if(n<2)for(;;){if(l in i){r=i[l],l+=u;break}if(l+=u,o?l<0:s<=l)throw TypeError("Reduce of empty array with no initial value")}for(;o?0<=l:l<s;l+=u)l in i&&(r=t(r,i[l],l,a));return r}},{"./_a-function":3,"./_iobject":49,"./_to-length":119,"./_to-object":120}],15:[function(e,t,n){var r=e("./_is-object"),o=e("./_is-array"),a=e("./_wks")("species");t.exports=function(e){var t;return o(e)&&("function"!=typeof(t=e.constructor)||t!==Array&&!o(t.prototype)||(t=void 0),r(t)&&null===(t=t[a])&&(t=void 0)),void 0===t?Array:t}},{"./_is-array":51,"./_is-object":53,"./_wks":130}],16:[function(e,t,n){var r=e("./_array-species-constructor");t.exports=function(e,t){return new(r(e))(t)}},{"./_array-species-constructor":15}],17:[function(e,t,n){"use strict";var r=e("./_a-function"),o=e("./_is-object"),c=e("./_invoke"),f=[].slice,p={};t.exports=Function.bind||function(i){var s=r(this),l=f.call(arguments,1),u=function(){var e=l.concat(f.call(arguments));if(this instanceof u){var t=s,n=e.length,r=e;if(!(n in p)){for(var o=[],a=0;a<n;a++)o[a]="a["+a+"]";p[n]=Function("F,a","return new F("+o.join(",")+")")}return p[n](t,r)}return c(s,e,i)};return o(s.prototype)&&(u.prototype=s.prototype),u}},{"./_a-function":3,"./_invoke":48,"./_is-object":53}],18:[function(e,t,n){var r=e("./_cof"),o=e("./_wks")("toStringTag"),a="Arguments"==r(function(){return arguments}());t.exports=function(e){var t;return void 0===e?"Undefined":null===e?"Null":"string"==typeof(t=function(e,t){try{return e[t]}catch(e){}}(e=Object(e),o))?t:a?r(e):"Object"==(t=r(e))&&"function"==typeof e.callee?"Arguments":t}},{"./_cof":19,"./_wks":130}],19:[function(e,t,n){var r={}.toString;t.exports=function(e){return r.call(e).slice(8,-1)}},{}],20:[function(e,t,n){"use strict";function i(e,t){var n,r=v(t);if("F"!==r)return e._i[r];for(n=e._f;n;n=n.n)if(n.k==t)return n}var s=e("./_object-dp").f,l=e("./_object-create"),u=e("./_redefine-all"),c=e("./_ctx"),f=e("./_an-instance"),p=e("./_for-of"),r=e("./_iter-define"),o=e("./_iter-step"),a=e("./_set-species"),d=e("./_descriptors"),v=e("./_meta").fastKey,y=e("./_validate-collection"),_=d?"_s":"size";t.exports={getConstructor:function(e,o,n,r){var a=e(function(e,t){f(e,a,o,"_i"),e._t=o,e._i=l(null),e._f=void 0,e._l=void 0,e[_]=0,null!=t&&p(t,n,e[r],e)});return u(a.prototype,{clear:function(){for(var e=y(this,o),t=e._i,n=e._f;n;n=n.n)n.r=!0,n.p&&(n.p=n.p.n=void 0),delete t[n.i];e._f=e._l=void 0,e[_]=0},delete:function(e){var t,n,r=y(this,o),e=i(r,e);return e&&(t=e.n,n=e.p,delete r._i[e.i],e.r=!0,n&&(n.n=t),t&&(t.p=n),r._f==e&&(r._f=t),r._l==e&&(r._l=n),r[_]--),!!e},forEach:function(e){y(this,o);for(var t,n=c(e,1<arguments.length?arguments[1]:void 0,3);t=t?t.n:this._f;)for(n(t.v,t.k,this);t&&t.r;)t=t.p},has:function(e){return!!i(y(this,o),e)}}),d&&s(a.prototype,"size",{get:function(){return y(this,o)[_]}}),a},def:function(e,t,n){var r,o=i(e,t);return o?o.v=n:(e._l=o={i:r=v(t,!0),k:t,v:n,p:t=e._l,n:void 0,r:!1},e._f||(e._f=o),t&&(t.n=o),e[_]++,"F"!==r&&(e._i[r]=o)),e},getEntry:i,setStrong:function(e,n,t){r(e,n,function(e,t){this._t=y(e,n),this._k=t,this._l=void 0},function(){for(var e=this,t=e._k,n=e._l;n&&n.r;)n=n.p;return e._t&&(e._l=n=n?n.n:e._t._f)?o(0,"keys"==t?n.k:"values"==t?n.v:[n.k,n.v]):(e._t=void 0,o(1))},t?"entries":"values",!t,!0),a(n)}}},{"./_an-instance":7,"./_ctx":26,"./_descriptors":30,"./_for-of":40,"./_iter-define":57,"./_iter-step":59,"./_meta":67,"./_object-create":72,"./_object-dp":73,"./_redefine-all":92,"./_set-species":101,"./_validate-collection":127}],21:[function(e,t,n){var r=e("./_classof"),o=e("./_array-from-iterable");t.exports=function(e){return function(){if(r(this)!=e)throw TypeError(e+"#toJSON isn't generic");return o(this)}}},{"./_array-from-iterable":11,"./_classof":18}],22:[function(e,t,n){"use strict";function i(e){return e._l||(e._l=new r)}function r(){this.a=[]}function o(e,t){return y(e.a,function(e){return e[0]===t})}var s=e("./_redefine-all"),l=e("./_meta").getWeak,a=e("./_an-object"),u=e("./_is-object"),c=e("./_an-instance"),f=e("./_for-of"),p=e("./_array-methods"),d=e("./_has"),v=e("./_validate-collection"),y=p(5),_=p(6),h=0;r.prototype={get:function(e){e=o(this,e);if(e)return e[1]},has:function(e){return!!o(this,e)},set:function(e,t){var n=o(this,e);n?n[1]=t:this.a.push([e,t])},delete:function(t){var e=_(this.a,function(e){return e[0]===t});return~e&&this.a.splice(e,1),!!~e}},t.exports={getConstructor:function(e,n,r,o){var a=e(function(e,t){c(e,a,n,"_i"),e._t=n,e._i=h++,e._l=void 0,null!=t&&f(t,r,e[o],e)});return s(a.prototype,{delete:function(e){if(!u(e))return!1;var t=l(e);return!0===t?i(v(this,n)).delete(e):t&&d(t,this._i)&&delete t[this._i]},has:function(e){if(!u(e))return!1;var t=l(e);return!0===t?i(v(this,n)).has(e):t&&d(t,this._i)}}),a},def:function(e,t,n){var r=l(a(t),!0);return!0===r?i(e).set(t,n):r[e._i]=n,e},ufstore:i}},{"./_an-instance":7,"./_an-object":8,"./_array-methods":13,"./_for-of":40,"./_has":43,"./_is-object":53,"./_meta":67,"./_redefine-all":92,"./_validate-collection":127}],23:[function(e,t,n){"use strict";var h=e("./_global"),m=e("./_export"),g=e("./_redefine"),b=e("./_redefine-all"),x=e("./_meta"),w=e("./_for-of"),j=e("./_an-instance"),A=e("./_is-object"),S=e("./_fails"),k=e("./_iter-detect"),E=e("./_set-to-string-tag"),I=e("./_inherit-if-required");t.exports=function(n,e,t,r,o,a){function i(e){var n=y[e];g(y,e,"delete"==e?function(e){return!(a&&!A(e))&&n.call(this,0===e?0:e)}:"has"==e?function(e){return!(a&&!A(e))&&n.call(this,0===e?0:e)}:"get"==e?function(e){return a&&!A(e)?void 0:n.call(this,0===e?0:e)}:"add"==e?function(e){return n.call(this,0===e?0:e),this}:function(e,t){return n.call(this,0===e?0:e,t),this})}var s,l,u,c,f,p=h[n],d=p,v=o?"set":"add",y=d&&d.prototype,_={};return"function"==typeof d&&(a||y.forEach&&!S(function(){(new d).entries().next()}))?(l=(s=new d)[v](a?{}:-0,1)!=s,u=S(function(){s.has(1)}),c=k(function(e){new d(e)}),f=!a&&S(function(){for(var e=new d,t=5;t--;)e[v](t,t);return!e.has(-0)}),c||(((d=e(function(e,t){j(e,d,n);e=I(new p,e,d);return null!=t&&w(t,o,e[v],e),e})).prototype=y).constructor=d),(u||f)&&(i("delete"),i("has"),o&&i("get")),(f||l)&&i(v),a&&y.clear&&delete y.clear):(d=r.getConstructor(e,n,o,v),b(d.prototype,t),x.NEED=!0),E(d,n),_[n]=d,m(m.G+m.W+m.F*(d!=p),_),a||r.setStrong(d,n,o),d}},{"./_an-instance":7,"./_export":34,"./_fails":36,"./_for-of":40,"./_global":42,"./_inherit-if-required":47,"./_is-object":53,"./_iter-detect":58,"./_meta":67,"./_redefine":93,"./_redefine-all":92,"./_set-to-string-tag":102}],24:[function(e,t,n){t=t.exports={version:"2.6.12"};"number"==typeof __e&&(__e=t)},{}],25:[function(e,t,n){"use strict";var r=e("./_object-dp"),o=e("./_property-desc");t.exports=function(e,t,n){t in e?r.f(e,t,o(0,n)):e[t]=n}},{"./_object-dp":73,"./_property-desc":91}],26:[function(e,t,n){var a=e("./_a-function");t.exports=function(r,o,e){if(a(r),void 0===o)return r;switch(e){case 1:return function(e){return r.call(o,e)};case 2:return function(e,t){return r.call(o,e,t)};case 3:return function(e,t,n){return r.call(o,e,t,n)}}return function(){return r.apply(o,arguments)}}},{"./_a-function":3}],27:[function(e,t,n){"use strict";function o(e){return 9<e?e:"0"+e}var e=e("./_fails"),a=Date.prototype.getTime,r=Date.prototype.toISOString;t.exports=e(function(){return"0385-07-25T07:06:39.999Z"!=r.call(new Date(-5e13-1))})||!e(function(){r.call(new Date(NaN))})?function(){if(!isFinite(a.call(this)))throw RangeError("Invalid time value");var e=this,t=e.getUTCFullYear(),n=e.getUTCMilliseconds(),r=t<0?"-":9999<t?"+":"";return r+("00000"+Math.abs(t)).slice(r?-6:-4)+"-"+o(e.getUTCMonth()+1)+"-"+o(e.getUTCDate())+"T"+o(e.getUTCHours())+":"+o(e.getUTCMinutes())+":"+o(e.getUTCSeconds())+"."+(99<n?n:"0"+o(n))+"Z"}:r},{"./_fails":36}],28:[function(e,t,n){"use strict";var r=e("./_an-object"),o=e("./_to-primitive");t.exports=function(e){if("string"!==e&&"number"!==e&&"default"!==e)throw TypeError("Incorrect hint");return o(r(this),"number"!=e)}},{"./_an-object":8,"./_to-primitive":121}],29:[function(e,t,n){t.exports=function(e){if(null==e)throw TypeError("Can't call method on  "+e);return e}},{}],30:[function(e,t,n){t.exports=!e("./_fails")(function(){return 7!=Object.defineProperty({},"a",{get:function(){return 7}}).a})},{"./_fails":36}],31:[function(e,t,n){var r=e("./_is-object"),o=e("./_global").document,a=r(o)&&r(o.createElement);t.exports=function(e){return a?o.createElement(e):{}}},{"./_global":42,"./_is-object":53}],32:[function(e,t,n){t.exports="constructor,hasOwnProperty,isPrototypeOf,propertyIsEnumerable,toLocaleString,toString,valueOf".split(",")},{}],33:[function(e,t,n){var s=e("./_object-keys"),l=e("./_object-gops"),u=e("./_object-pie");t.exports=function(e){var t=s(e),n=l.f;if(n)for(var r,o=n(e),a=u.f,i=0;o.length>i;)a.call(e,r=o[i++])&&t.push(r);return t}},{"./_object-gops":79,"./_object-keys":82,"./_object-pie":83}],34:[function(e,t,n){function d(e,t,n){var r,o,a,i=e&d.F,s=e&d.G,l=e&d.P,u=e&d.B,c=s?v:e&d.S?v[t]||(v[t]={}):(v[t]||{})[g],f=s?y:y[t]||(y[t]={}),p=f[g]||(f[g]={});for(r in n=s?t:n)o=((a=!i&&c&&void 0!==c[r])?c:n)[r],a=u&&a?m(o,v):l&&"function"==typeof o?m(Function.call,o):o,c&&h(c,r,o,e&d.U),f[r]!=o&&_(f,r,a),l&&p[r]!=o&&(p[r]=o)}var v=e("./_global"),y=e("./_core"),_=e("./_hide"),h=e("./_redefine"),m=e("./_ctx"),g="prototype";v.core=y,d.F=1,d.G=2,d.S=4,d.P=8,d.B=16,d.W=32,d.U=64,d.R=128,t.exports=d},{"./_core":24,"./_ctx":26,"./_global":42,"./_hide":44,"./_redefine":93}],35:[function(e,t,n){var r=e("./_wks")("match");t.exports=function(t){var n=/./;try{"/./"[t](n)}catch(e){try{return n[r]=!1,!"/./"[t](n)}catch(e){}}return!0}},{"./_wks":130}],36:[function(e,t,n){t.exports=function(e){try{return!!e()}catch(e){return!0}}},{}],37:[function(e,t,n){"use strict";e("./es6.regexp.exec");var r,l=e("./_redefine"),u=e("./_hide"),c=e("./_fails"),f=e("./_defined"),p=e("./_wks"),d=e("./_regexp-exec"),v=p("species"),y=!c(function(){var e=/./;return e.exec=function(){var e=[];return e.groups={a:"7"},e},"7"!=="".replace(e,"$<a>")}),_=(r=(e=/(?:)/).exec,e.exec=function(){return r.apply(this,arguments)},2===(e="ab".split(e)).length&&"a"===e[0]&&"b"===e[1]);t.exports=function(n,e,t){var a,r,o=p(n),i=!c(function(){var e={};return e[o]=function(){return 7},7!=""[n](e)}),s=i?!c(function(){var e=!1,t=/a/;return t.exec=function(){return e=!0,null},"split"===n&&(t.constructor={},t.constructor[v]=function(){return t}),t[o](""),!e}):void 0;i&&s&&("replace"!==n||y)&&("split"!==n||_)||(a=/./[o],t=(s=t(f,o,""[n],function(e,t,n,r,o){return t.exec===d?i&&!o?{done:!0,value:a.call(t,n,r)}:{done:!0,value:e.call(n,t,r)}:{done:!1}}))[0],r=s[1],
+         l(String.prototype,n,t),u(RegExp.prototype,o,2==e?function(e,t){return r.call(e,this,t)}:function(e){return r.call(e,this)}))}},{"./_defined":29,"./_fails":36,"./_hide":44,"./_redefine":93,"./_regexp-exec":95,"./_wks":130,"./es6.regexp.exec":227}],38:[function(e,t,n){"use strict";var r=e("./_an-object");t.exports=function(){var e=r(this),t="";return e.global&&(t+="g"),e.ignoreCase&&(t+="i"),e.multiline&&(t+="m"),e.unicode&&(t+="u"),e.sticky&&(t+="y"),t}},{"./_an-object":8}],39:[function(e,t,n){"use strict";var v=e("./_is-array"),y=e("./_is-object"),_=e("./_to-length"),h=e("./_ctx"),m=e("./_wks")("isConcatSpreadable");t.exports=function e(t,n,r,o,a,i,s,l){for(var u,c,f=a,p=0,d=!!s&&h(s,l,3);p<o;){if(p in r){if(u=d?d(r[p],p,n):r[p],c=!1,(c=y(u)?void 0!==(c=u[m])?!!c:v(u):c)&&0<i)f=e(t,n,u,_(u.length),f,i-1)-1;else{if(9007199254740991<=f)throw TypeError();t[f]=u}f++}p++}return f}},{"./_ctx":26,"./_is-array":51,"./_is-object":53,"./_to-length":119,"./_wks":130}],40:[function(e,t,n){var f=e("./_ctx"),p=e("./_iter-call"),d=e("./_is-array-iter"),v=e("./_an-object"),y=e("./_to-length"),_=e("./core.get-iterator-method"),h={},m={};(n=t.exports=function(e,t,n,r,o){var a,i,s,l,o=o?function(){return e}:_(e),u=f(n,r,t?2:1),c=0;if("function"!=typeof o)throw TypeError(e+" is not iterable!");if(d(o)){for(a=y(e.length);c<a;c++)if((l=t?u(v(i=e[c])[0],i[1]):u(e[c]))===h||l===m)return l}else for(s=o.call(e);!(i=s.next()).done;)if((l=p(s,u,i.value,t))===h||l===m)return l}).BREAK=h,n.RETURN=m},{"./_an-object":8,"./_ctx":26,"./_is-array-iter":50,"./_iter-call":55,"./_to-length":119,"./core.get-iterator-method":131}],41:[function(e,t,n){t.exports=e("./_shared")("native-function-to-string",Function.toString)},{"./_shared":104}],42:[function(e,t,n){t=t.exports="undefined"!=typeof window&&window.Math==Math?window:"undefined"!=typeof self&&self.Math==Math?self:Function("return this")();"number"==typeof __g&&(__g=t)},{}],43:[function(e,t,n){var r={}.hasOwnProperty;t.exports=function(e,t){return r.call(e,t)}},{}],44:[function(e,t,n){var r=e("./_object-dp"),o=e("./_property-desc");t.exports=e("./_descriptors")?function(e,t,n){return r.f(e,t,o(1,n))}:function(e,t,n){return e[t]=n,e}},{"./_descriptors":30,"./_object-dp":73,"./_property-desc":91}],45:[function(e,t,n){e=e("./_global").document;t.exports=e&&e.documentElement},{"./_global":42}],46:[function(e,t,n){t.exports=!e("./_descriptors")&&!e("./_fails")(function(){return 7!=Object.defineProperty(e("./_dom-create")("div"),"a",{get:function(){return 7}}).a})},{"./_descriptors":30,"./_dom-create":31,"./_fails":36}],47:[function(e,t,n){var r=e("./_is-object"),o=e("./_set-proto").set;t.exports=function(e,t,n){var t=t.constructor;return t!==n&&"function"==typeof t&&(t=t.prototype)!==n.prototype&&r(t)&&o&&o(e,t),e}},{"./_is-object":53,"./_set-proto":100}],48:[function(e,t,n){t.exports=function(e,t,n){var r=void 0===n;switch(t.length){case 0:return r?e():e.call(n);case 1:return r?e(t[0]):e.call(n,t[0]);case 2:return r?e(t[0],t[1]):e.call(n,t[0],t[1]);case 3:return r?e(t[0],t[1],t[2]):e.call(n,t[0],t[1],t[2]);case 4:return r?e(t[0],t[1],t[2],t[3]):e.call(n,t[0],t[1],t[2],t[3])}return e.apply(n,t)}},{}],49:[function(e,t,n){var r=e("./_cof");t.exports=Object("z").propertyIsEnumerable(0)?Object:function(e){return"String"==r(e)?e.split(""):Object(e)}},{"./_cof":19}],50:[function(e,t,n){var r=e("./_iterators"),o=e("./_wks")("iterator"),a=Array.prototype;t.exports=function(e){return void 0!==e&&(r.Array===e||a[o]===e)}},{"./_iterators":60,"./_wks":130}],51:[function(e,t,n){var r=e("./_cof");t.exports=Array.isArray||function(e){return"Array"==r(e)}},{"./_cof":19}],52:[function(e,t,n){var r=e("./_is-object"),o=Math.floor;t.exports=function(e){return!r(e)&&isFinite(e)&&o(e)===e}},{"./_is-object":53}],53:[function(e,t,n){t.exports=function(e){return"object"==typeof e?null!==e:"function"==typeof e}},{}],54:[function(e,t,n){var r=e("./_is-object"),o=e("./_cof"),a=e("./_wks")("match");t.exports=function(e){var t;return r(e)&&(void 0!==(t=e[a])?!!t:"RegExp"==o(e))}},{"./_cof":19,"./_is-object":53,"./_wks":130}],55:[function(e,t,n){var o=e("./_an-object");t.exports=function(t,e,n,r){try{return r?e(o(n)[0],n[1]):e(n)}catch(e){r=t.return;throw void 0!==r&&o(r.call(t)),e}}},{"./_an-object":8}],56:[function(e,t,n){"use strict";var r=e("./_object-create"),o=e("./_property-desc"),a=e("./_set-to-string-tag"),i={};e("./_hide")(i,e("./_wks")("iterator"),function(){return this}),t.exports=function(e,t,n){e.prototype=r(i,{next:o(1,n)}),a(e,t+" Iterator")}},{"./_hide":44,"./_object-create":72,"./_property-desc":91,"./_set-to-string-tag":102,"./_wks":130}],57:[function(e,t,n){"use strict";function h(){return this}var m=e("./_library"),g=e("./_export"),b=e("./_redefine"),x=e("./_hide"),w=e("./_iterators"),j=e("./_iter-create"),A=e("./_set-to-string-tag"),S=e("./_object-gpo"),k=e("./_wks")("iterator"),E=!([].keys&&"next"in[].keys()),I="values";t.exports=function(e,t,n,r,o,a,i){j(n,t,r);function s(e){if(!E&&e in p)return p[e];switch(e){case"keys":case I:return function(){return new n(this,e)}}return function(){return new n(this,e)}}var l,u,r=t+" Iterator",c=o==I,f=!1,p=e.prototype,d=p[k]||p["@@iterator"]||o&&p[o],v=d||s(o),y=o?c?s("entries"):v:void 0,_="Array"==t&&p.entries||d;if(_&&(_=S(_.call(new e)))!==Object.prototype&&_.next&&(A(_,r,!0),m||"function"==typeof _[k]||x(_,k,h)),c&&d&&d.name!==I&&(f=!0,v=function(){return d.call(this)}),m&&!i||!E&&!f&&p[k]||x(p,k,v),w[t]=v,w[r]=h,o)if(l={values:c?v:s(I),keys:a?v:s("keys"),entries:y},i)for(u in l)u in p||b(p,u,l[u]);else g(g.P+g.F*(E||f),t,l);return l}},{"./_export":34,"./_hide":44,"./_iter-create":56,"./_iterators":60,"./_library":61,"./_object-gpo":80,"./_redefine":93,"./_set-to-string-tag":102,"./_wks":130}],58:[function(e,t,n){var a=e("./_wks")("iterator"),i=!1;try{var r=[7][a]();r.return=function(){i=!0},Array.from(r,function(){throw 2})}catch(e){}t.exports=function(e,t){if(!t&&!i)return!1;var n=!1;try{var r=[7],o=r[a]();o.next=function(){return{done:n=!0}},r[a]=function(){return o},e(r)}catch(e){}return n}},{"./_wks":130}],59:[function(e,t,n){t.exports=function(e,t){return{value:t,done:!!e}}},{}],60:[function(e,t,n){t.exports={}},{}],61:[function(e,t,n){t.exports=!1},{}],62:[function(e,t,n){var r=Math.expm1;t.exports=!r||22025.465794806718<r(10)||r(10)<22025.465794806718||-2e-17!=r(-2e-17)?function(e){return 0==(e=+e)?e:-1e-6<e&&e<1e-6?e+e*e/2:Math.exp(e)-1}:r},{}],63:[function(e,t,n){var r=e("./_math-sign"),e=Math.pow,o=e(2,-52),a=e(2,-23),i=e(2,127)*(2-a),s=e(2,-126);t.exports=Math.fround||function(e){var t,n=Math.abs(e),e=r(e);return n<s?e*(n/s/a+1/o-1/o)*s*a:i<(t=(t=(1+a/o)*n)-(t-n))||t!=t?e*(1/0):e*t}},{"./_math-sign":66}],64:[function(e,t,n){t.exports=Math.log1p||function(e){return-1e-8<(e=+e)&&e<1e-8?e-e*e/2:Math.log(1+e)}},{}],65:[function(e,t,n){t.exports=Math.scale||function(e,t,n,r,o){return 0===arguments.length||e!=e||t!=t||n!=n||r!=r||o!=o?NaN:e===1/0||e===-1/0?e:(e-t)*(o-r)/(n-t)+r}},{}],66:[function(e,t,n){t.exports=Math.sign||function(e){return 0==(e=+e)||e!=e?e:e<0?-1:1}},{}],67:[function(e,t,n){function r(e){s(e,o,{value:{i:"O"+ ++l,w:{}}})}var o=e("./_uid")("meta"),a=e("./_is-object"),i=e("./_has"),s=e("./_object-dp").f,l=0,u=Object.isExtensible||function(){return!0},c=!e("./_fails")(function(){return u(Object.preventExtensions({}))}),f=t.exports={KEY:o,NEED:!1,fastKey:function(e,t){if(!a(e))return"symbol"==typeof e?e:("string"==typeof e?"S":"P")+e;if(!i(e,o)){if(!u(e))return"F";if(!t)return"E";r(e)}return e[o].i},getWeak:function(e,t){if(!i(e,o)){if(!u(e))return!0;if(!t)return!1;r(e)}return e[o].w},onFreeze:function(e){return c&&f.NEED&&u(e)&&!i(e,o)&&r(e),e}}},{"./_fails":36,"./_has":43,"./_is-object":53,"./_object-dp":73,"./_uid":125}],68:[function(e,t,n){function o(e,t,n){var r=s.get(e);if(!r){if(!n)return;s.set(e,r=new a)}if(!(e=r.get(t))){if(!n)return;r.set(t,e=new a)}return e}var a=e("./es6.map"),r=e("./_export"),i=e("./_shared")("metadata"),s=i.store||(i.store=new(e("./es6.weak-map")));t.exports={store:s,map:o,has:function(e,t,n){t=o(t,n,!1);return void 0!==t&&t.has(e)},get:function(e,t,n){t=o(t,n,!1);return void 0===t?void 0:t.get(e)},set:function(e,t,n,r){o(n,r,!0).set(e,t)},keys:function(e,t){var e=o(e,t,!1),n=[];return e&&e.forEach(function(e,t){n.push(t)}),n},key:function(e){return void 0===e||"symbol"==typeof e?e:String(e)},exp:function(e){r(r.S,"Reflect",e)}}},{"./_export":34,"./_shared":104,"./es6.map":162,"./es6.weak-map":269}],69:[function(e,t,n){var s=e("./_global"),l=e("./_task").set,u=s.MutationObserver||s.WebKitMutationObserver,c=s.process,f=s.Promise,p="process"==e("./_cof")(c);t.exports=function(){function e(){var e,t;for(p&&(e=c.domain)&&e.exit();n;){t=n.fn,n=n.next;try{t()}catch(e){throw n?o():r=void 0,e}}r=void 0,e&&e.enter()}var n,r,t,o,a,i;return o=p?function(){c.nextTick(e)}:!u||s.navigator&&s.navigator.standalone?f&&f.resolve?(t=f.resolve(void 0),function(){t.then(e)}):function(){l.call(s,e)}:(a=!0,i=document.createTextNode(""),new u(e).observe(i,{characterData:!0}),function(){i.data=a=!a}),function(e){e={fn:e,next:void 0};r&&(r.next=e),n||(n=e,o()),r=e}}},{"./_cof":19,"./_global":42,"./_task":114}],70:[function(e,t,n){"use strict";var o=e("./_a-function");function r(e){var n,r;this.promise=new e(function(e,t){if(void 0!==n||void 0!==r)throw TypeError("Bad Promise constructor");n=e,r=t}),this.resolve=o(n),this.reject=o(r)}t.exports.f=function(e){return new r(e)}},{"./_a-function":3}],71:[function(e,t,n){"use strict";var p=e("./_descriptors"),d=e("./_object-keys"),v=e("./_object-gops"),y=e("./_object-pie"),_=e("./_to-object"),h=e("./_iobject"),o=Object.assign;t.exports=!o||e("./_fails")(function(){var e={},t={},n=Symbol(),r="abcdefghijklmnopqrst";return e[n]=7,r.split("").forEach(function(e){t[e]=e}),7!=o({},e)[n]||Object.keys(o({},t)).join("")!=r})?function(e,t){for(var n=_(e),r=arguments.length,o=1,a=v.f,i=y.f;o<r;)for(var s,l=h(arguments[o++]),u=a?d(l).concat(a(l)):d(l),c=u.length,f=0;f<c;)s=u[f++],p&&!i.call(l,s)||(n[s]=l[s]);return n}:o},{"./_descriptors":30,"./_fails":36,"./_iobject":49,"./_object-gops":79,"./_object-keys":82,"./_object-pie":83,"./_to-object":120}],72:[function(n,e,t){function r(){}var o=n("./_an-object"),a=n("./_object-dps"),i=n("./_enum-bug-keys"),s=n("./_shared-key")("IE_PROTO"),l="prototype",u=function(){var e=n("./_dom-create")("iframe"),t=i.length;for(e.style.display="none",n("./_html").appendChild(e),e.src="javascript:",(e=e.contentWindow.document).open(),e.write("<script>document.F=Object<\/script>"),e.close(),u=e.F;t--;)delete u[l][i[t]];return u()};e.exports=Object.create||function(e,t){var n;return null!==e?(r[l]=o(e),n=new r,r[l]=null,n[s]=e):n=u(),void 0===t?n:a(n,t)}},{"./_an-object":8,"./_dom-create":31,"./_enum-bug-keys":32,"./_html":45,"./_object-dps":74,"./_shared-key":103}],73:[function(e,t,n){var r=e("./_an-object"),o=e("./_ie8-dom-define"),a=e("./_to-primitive"),i=Object.defineProperty;n.f=e("./_descriptors")?Object.defineProperty:function(e,t,n){if(r(e),t=a(t,!0),r(n),o)try{return i(e,t,n)}catch(e){}if("get"in n||"set"in n)throw TypeError("Accessors not supported!");return"value"in n&&(e[t]=n.value),e}},{"./_an-object":8,"./_descriptors":30,"./_ie8-dom-define":46,"./_to-primitive":121}],74:[function(e,t,n){var i=e("./_object-dp"),s=e("./_an-object"),l=e("./_object-keys");t.exports=e("./_descriptors")?Object.defineProperties:function(e,t){s(e);for(var n,r=l(t),o=r.length,a=0;a<o;)i.f(e,n=r[a++],t[n]);return e}},{"./_an-object":8,"./_descriptors":30,"./_object-dp":73,"./_object-keys":82}],75:[function(t,e,n){"use strict";e.exports=t("./_library")||!t("./_fails")(function(){var e=Math.random();__defineSetter__.call(null,e,function(){}),delete t("./_global")[e]})},{"./_fails":36,"./_global":42,"./_library":61}],76:[function(e,t,n){var r=e("./_object-pie"),o=e("./_property-desc"),a=e("./_to-iobject"),i=e("./_to-primitive"),s=e("./_has"),l=e("./_ie8-dom-define"),u=Object.getOwnPropertyDescriptor;n.f=e("./_descriptors")?u:function(e,t){if(e=a(e),t=i(t,!0),l)try{return u(e,t)}catch(e){}if(s(e,t))return o(!r.f.call(e,t),e[t])}},{"./_descriptors":30,"./_has":43,"./_ie8-dom-define":46,"./_object-pie":83,"./_property-desc":91,"./_to-iobject":118,"./_to-primitive":121}],77:[function(e,t,n){var r=e("./_to-iobject"),o=e("./_object-gopn").f,a={}.toString,i="object"==typeof window&&window&&Object.getOwnPropertyNames?Object.getOwnPropertyNames(window):[];t.exports.f=function(e){if(!i||"[object Window]"!=a.call(e))return o(r(e));try{return o(e)}catch(e){return i.slice()}}},{"./_object-gopn":78,"./_to-iobject":118}],78:[function(e,t,n){var r=e("./_object-keys-internal"),o=e("./_enum-bug-keys").concat("length","prototype");n.f=Object.getOwnPropertyNames||function(e){return r(e,o)}},{"./_enum-bug-keys":32,"./_object-keys-internal":81}],79:[function(e,t,n){n.f=Object.getOwnPropertySymbols},{}],80:[function(e,t,n){var r=e("./_has"),o=e("./_to-object"),a=e("./_shared-key")("IE_PROTO"),i=Object.prototype;t.exports=Object.getPrototypeOf||function(e){return e=o(e),r(e,a)?e[a]:"function"==typeof e.constructor&&e instanceof e.constructor?e.constructor.prototype:e instanceof Object?i:null}},{"./_has":43,"./_shared-key":103,"./_to-object":120}],81:[function(e,t,n){var i=e("./_has"),s=e("./_to-iobject"),l=e("./_array-includes")(!1),u=e("./_shared-key")("IE_PROTO");t.exports=function(e,t){var n,r=s(e),o=0,a=[];for(n in r)n!=u&&i(r,n)&&a.push(n);for(;t.length>o;)!i(r,n=t[o++])||~l(a,n)||a.push(n);return a}},{"./_array-includes":12,"./_has":43,"./_shared-key":103,"./_to-iobject":118}],82:[function(e,t,n){var r=e("./_object-keys-internal"),o=e("./_enum-bug-keys");t.exports=Object.keys||function(e){return r(e,o)}},{"./_enum-bug-keys":32,"./_object-keys-internal":81}],83:[function(e,t,n){n.f={}.propertyIsEnumerable},{}],84:[function(e,t,n){var o=e("./_export"),a=e("./_core"),i=e("./_fails");t.exports=function(e,t){var n=(a.Object||{})[e]||Object[e],r={};r[e]=t(n),o(o.S+o.F*i(function(){n(1)}),"Object",r)}},{"./_core":24,"./_export":34,"./_fails":36}],85:[function(e,t,n){var l=e("./_descriptors"),u=e("./_object-keys"),c=e("./_to-iobject"),f=e("./_object-pie").f;t.exports=function(s){return function(e){for(var t,n=c(e),r=u(n),o=r.length,a=0,i=[];a<o;)t=r[a++],l&&!f.call(n,t)||i.push(s?[t,n[t]]:n[t]);return i}}},{"./_descriptors":30,"./_object-keys":82,"./_object-pie":83,"./_to-iobject":118}],86:[function(e,t,n){var r=e("./_object-gopn"),o=e("./_object-gops"),a=e("./_an-object"),e=e("./_global").Reflect;t.exports=e&&e.ownKeys||function(e){var t=r.f(a(e)),n=o.f;return n?t.concat(n(e)):t}},{"./_an-object":8,"./_global":42,"./_object-gopn":78,"./_object-gops":79}],87:[function(e,t,n){var r=e("./_global").parseFloat,o=e("./_string-trim").trim;t.exports=1/r(e("./_string-ws")+"-0")!=-1/0?function(e){var e=o(String(e),3),t=r(e);return 0===t&&"-"==e.charAt(0)?-0:t}:r},{"./_global":42,"./_string-trim":112,"./_string-ws":113}],88:[function(e,t,n){var r=e("./_global").parseInt,o=e("./_string-trim").trim,e=e("./_string-ws"),
+         a=/^[-+]?0[xX]/;t.exports=8!==r(e+"08")||22!==r(e+"0x16")?function(e,t){e=o(String(e),3);return r(e,t>>>0||(a.test(e)?16:10))}:r},{"./_global":42,"./_string-trim":112,"./_string-ws":113}],89:[function(e,t,n){t.exports=function(e){try{return{e:!1,v:e()}}catch(e){return{e:!0,v:e}}}},{}],90:[function(e,t,n){var r=e("./_an-object"),o=e("./_is-object"),a=e("./_new-promise-capability");t.exports=function(e,t){if(r(e),o(t)&&t.constructor===e)return t;e=a.f(e);return(0,e.resolve)(t),e.promise}},{"./_an-object":8,"./_is-object":53,"./_new-promise-capability":70}],91:[function(e,t,n){t.exports=function(e,t){return{enumerable:!(1&e),configurable:!(2&e),writable:!(4&e),value:t}}},{}],92:[function(e,t,n){var o=e("./_redefine");t.exports=function(e,t,n){for(var r in t)o(e,r,t[r],n);return e}},{"./_redefine":93}],93:[function(e,t,n){var a=e("./_global"),i=e("./_hide"),s=e("./_has"),l=e("./_uid")("src"),r=e("./_function-to-string"),o="toString",u=(""+r).split(o);e("./_core").inspectSource=function(e){return r.call(e)},(t.exports=function(e,t,n,r){var o="function"==typeof n;o&&!s(n,"name")&&i(n,"name",t),e[t]!==n&&(o&&!s(n,l)&&i(n,l,e[t]?""+e[t]:u.join(String(t))),e===a?e[t]=n:r?e[t]?e[t]=n:i(e,t,n):(delete e[t],i(e,t,n)))})(Function.prototype,o,function(){return"function"==typeof this&&this[l]||r.call(this)})},{"./_core":24,"./_function-to-string":41,"./_global":42,"./_has":43,"./_hide":44,"./_uid":125}],94:[function(e,t,n){"use strict";var r=e("./_classof"),o=RegExp.prototype.exec;t.exports=function(e,t){var n=e.exec;if("function"==typeof n){n=n.call(e,t);if("object"!=typeof n)throw new TypeError("RegExp exec method returned something other than an Object or null");return n}if("RegExp"!==r(e))throw new TypeError("RegExp#exec called on incompatible receiver");return o.call(e,t)}},{"./_classof":18}],95:[function(e,t,n){"use strict";var r,o,i=e("./_flags"),s=RegExp.prototype.exec,l=String.prototype.replace,e=s,u="lastIndex",c=(r=/a/,o=/b*/g,s.call(r,"a"),s.call(o,"a"),0!==r[u]||0!==o[u]),f=void 0!==/()??/.exec("")[1];t.exports=e=c||f?function(e){var t,n,r,o,a=this;return f&&(n=new RegExp("^"+a.source+"$(?!\\s)",i.call(a))),c&&(t=a[u]),r=s.call(a,e),c&&r&&(a[u]=a.global?r.index+r[0].length:t),f&&r&&1<r.length&&l.call(r[0],n,function(){for(o=1;o<arguments.length-2;o++)void 0===arguments[o]&&(r[o]=void 0)}),r}:e},{"./_flags":38}],96:[function(e,t,n){t.exports=function(t,n){var r=n===Object(n)?function(e){return n[e]}:n;return function(e){return String(e).replace(t,r)}}},{}],97:[function(e,t,n){t.exports=Object.is||function(e,t){return e===t?0!==e||1/e==1/t:e!=e&&t!=t}},{}],98:[function(e,t,n){"use strict";var r=e("./_export"),i=e("./_a-function"),s=e("./_ctx"),l=e("./_for-of");t.exports=function(e){r(r.S,e,{from:function(e){var t,n,r,o,a=arguments[1];return i(this),(t=void 0!==a)&&i(a),null==e?new this:(n=[],t?(r=0,o=s(a,arguments[2],2),l(e,!1,function(e){n.push(o(e,r++))})):l(e,!1,n.push,n),new this(n))}})}},{"./_a-function":3,"./_ctx":26,"./_export":34,"./_for-of":40}],99:[function(e,t,n){"use strict";var r=e("./_export");t.exports=function(e){r(r.S,e,{of:function(){for(var e=arguments.length,t=new Array(e);e--;)t[e]=arguments[e];return new this(t)}})}},{"./_export":34}],100:[function(t,e,n){function o(e,t){if(a(e),!r(t)&&null!==t)throw TypeError(t+": can't set as prototype!")}var r=t("./_is-object"),a=t("./_an-object");e.exports={set:Object.setPrototypeOf||("__proto__"in{}?function(e,n,r){try{(r=t("./_ctx")(Function.call,t("./_object-gopd").f(Object.prototype,"__proto__").set,2))(e,[]),n=!(e instanceof Array)}catch(e){n=!0}return function(e,t){return o(e,t),n?e.__proto__=t:r(e,t),e}}({},!1):void 0),check:o}},{"./_an-object":8,"./_ctx":26,"./_is-object":53,"./_object-gopd":76}],101:[function(e,t,n){"use strict";var r=e("./_global"),o=e("./_object-dp"),a=e("./_descriptors"),i=e("./_wks")("species");t.exports=function(e){e=r[e];a&&e&&!e[i]&&o.f(e,i,{configurable:!0,get:function(){return this}})}},{"./_descriptors":30,"./_global":42,"./_object-dp":73,"./_wks":130}],102:[function(e,t,n){var r=e("./_object-dp").f,o=e("./_has"),a=e("./_wks")("toStringTag");t.exports=function(e,t,n){e&&!o(e=n?e:e.prototype,a)&&r(e,a,{configurable:!0,value:t})}},{"./_has":43,"./_object-dp":73,"./_wks":130}],103:[function(e,t,n){var r=e("./_shared")("keys"),o=e("./_uid");t.exports=function(e){return r[e]||(r[e]=o(e))}},{"./_shared":104,"./_uid":125}],104:[function(e,t,n){var r=e("./_core"),o=e("./_global"),a="__core-js_shared__",i=o[a]||(o[a]={});(t.exports=function(e,t){return i[e]||(i[e]=void 0!==t?t:{})})("versions",[]).push({version:r.version,mode:e("./_library")?"pure":"global",copyright:"\xa9 2020 Denis Pushkarev (zloirock.ru)"})},{"./_core":24,"./_global":42,"./_library":61}],105:[function(e,t,n){var r=e("./_an-object"),o=e("./_a-function"),a=e("./_wks")("species");t.exports=function(e,t){var e=r(e).constructor;return void 0===e||null==(e=r(e)[a])?t:o(e)}},{"./_a-function":3,"./_an-object":8,"./_wks":130}],106:[function(e,t,n){"use strict";var r=e("./_fails");t.exports=function(e,t){return!!e&&r(function(){t?e.call(null,function(){},1):e.call(null)})}},{"./_fails":36}],107:[function(e,t,n){var a=e("./_to-integer"),i=e("./_defined");t.exports=function(o){return function(e,t){var n,e=String(i(e)),t=a(t),r=e.length;return t<0||r<=t?o?"":void 0:(n=e.charCodeAt(t))<55296||56319<n||t+1===r||(r=e.charCodeAt(t+1))<56320||57343<r?o?e.charAt(t):n:o?e.slice(t,t+2):r-56320+(n-55296<<10)+65536}}},{"./_defined":29,"./_to-integer":117}],108:[function(e,t,n){var r=e("./_is-regexp"),o=e("./_defined");t.exports=function(e,t,n){if(r(t))throw TypeError("String#"+n+" doesn't accept regex!");return String(o(e))}},{"./_defined":29,"./_is-regexp":54}],109:[function(e,t,n){function r(e,t,n,r){var e=String(i(e)),o="<"+t;return""!==n&&(o+=" "+n+'="'+String(r).replace(s,"&quot;")+'"'),o+">"+e+"</"+t+">"}var o=e("./_export"),a=e("./_fails"),i=e("./_defined"),s=/"/g;t.exports=function(t,e){var n={};n[t]=e(r),o(o.P+o.F*a(function(){var e=""[t]('"');return e!==e.toLowerCase()||3<e.split('"').length}),"String",n)}},{"./_defined":29,"./_export":34,"./_fails":36}],110:[function(e,t,n){var a=e("./_to-length"),i=e("./_string-repeat"),s=e("./_defined");t.exports=function(e,t,n,r){var e=String(s(e)),o=e.length,n=void 0===n?" ":String(n),t=a(t);if(t<=o||""==n)return e;t-=o,o=i.call(n,Math.ceil(t/n.length));return o.length>t&&(o=o.slice(0,t)),r?o+e:e+o}},{"./_defined":29,"./_string-repeat":111,"./_to-length":119}],111:[function(e,t,n){"use strict";var o=e("./_to-integer"),a=e("./_defined");t.exports=function(e){var t=String(a(this)),n="",r=o(e);if(r<0||r==1/0)throw RangeError("Count can't be negative");for(;0<r;(r>>>=1)&&(t+=t))1&r&&(n+=t);return n}},{"./_defined":29,"./_to-integer":117}],112:[function(e,t,n){function r(e,t,n){var r={},o=i(function(){return!!s[e]()||"\u200b\x85"!="\u200b\x85"[e]()}),t=r[e]=o?t(c):s[e];n&&(r[n]=t),a(a.P+a.F*o,"String",r)}var a=e("./_export"),o=e("./_defined"),i=e("./_fails"),s=e("./_string-ws"),e="["+s+"]",l=RegExp("^"+e+e+"*"),u=RegExp(e+e+"*$"),c=r.trim=function(e,t){return e=String(o(e)),1&t&&(e=e.replace(l,"")),e=2&t?e.replace(u,""):e};t.exports=r},{"./_defined":29,"./_export":34,"./_fails":36,"./_string-ws":113}],113:[function(e,t,n){t.exports="\t\n\v\f\r \xa0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000\u2028\u2029\ufeff"},{}],114:[function(e,t,n){function r(){var e,t=+this;h.hasOwnProperty(t)&&(e=h[t],delete h[t],e())}function o(e){r.call(e.data)}var a,i=e("./_ctx"),s=e("./_invoke"),l=e("./_html"),u=e("./_dom-create"),c=e("./_global"),f=c.process,p=c.setImmediate,d=c.clearImmediate,v=c.MessageChannel,y=c.Dispatch,_=0,h={},m="onreadystatechange";p&&d||(p=function(e){for(var t=[],n=1;n<arguments.length;)t.push(arguments[n++]);return h[++_]=function(){s("function"==typeof e?e:Function(e),t)},a(_),_},d=function(e){delete h[e]},"process"==e("./_cof")(f)?a=function(e){f.nextTick(i(r,e,1))}:y&&y.now?a=function(e){y.now(i(r,e,1))}:v?(v=(e=new v).port2,e.port1.onmessage=o,a=i(v.postMessage,v,1)):c.addEventListener&&"function"==typeof postMessage&&!c.importScripts?(a=function(e){c.postMessage(e+"","*")},c.addEventListener("message",o,!1)):a=m in u("script")?function(e){l.appendChild(u("script"))[m]=function(){l.removeChild(this),r.call(e)}}:function(e){setTimeout(i(r,e,1),0)}),t.exports={set:p,clear:d}},{"./_cof":19,"./_ctx":26,"./_dom-create":31,"./_global":42,"./_html":45,"./_invoke":48}],115:[function(e,t,n){var r=e("./_to-integer"),o=Math.max,a=Math.min;t.exports=function(e,t){return(e=r(e))<0?o(e+t,0):a(e,t)}},{"./_to-integer":117}],116:[function(e,t,n){var r=e("./_to-integer"),o=e("./_to-length");t.exports=function(e){if(void 0===e)return 0;var e=r(e),t=o(e);if(e!==t)throw RangeError("Wrong length!");return t}},{"./_to-integer":117,"./_to-length":119}],117:[function(e,t,n){var r=Math.ceil,o=Math.floor;t.exports=function(e){return isNaN(e=+e)?0:(0<e?o:r)(e)}},{}],118:[function(e,t,n){var r=e("./_iobject"),o=e("./_defined");t.exports=function(e){return r(o(e))}},{"./_defined":29,"./_iobject":49}],119:[function(e,t,n){var r=e("./_to-integer"),o=Math.min;t.exports=function(e){return 0<e?o(r(e),9007199254740991):0}},{"./_to-integer":117}],120:[function(e,t,n){var r=e("./_defined");t.exports=function(e){return Object(r(e))}},{"./_defined":29}],121:[function(e,t,n){var o=e("./_is-object");t.exports=function(e,t){if(!o(e))return e;var n,r;if(t&&"function"==typeof(n=e.toString)&&!o(r=n.call(e)))return r;if("function"==typeof(n=e.valueOf)&&!o(r=n.call(e)))return r;if(t||"function"!=typeof(n=e.toString)||o(r=n.call(e)))throw TypeError("Can't convert object to primitive value");return r}},{"./_is-object":53}],122:[function(e,N,D){"use strict";var d,v,y,_,h,F,H,G,m,t,U,g,W,B,Y,r,z,b,q,X,V,K,x,Q,J,Z,n,o,$,ee,te,ne,re,oe,w,ae,j,ie,a,se,le,ue,A,S,ce,fe,pe,de,ve,ye,_e,he,me,ge,be,xe,we,je,Ae,Se,ke,Ee,k,i,E,I,Ie,C,s,O,Ce,P,Oe,Pe,Le,L,l,f,Me,M,u,Te,Re,Ne,De,Fe,He,Ge,T,Ue,c,p,R;e("./_descriptors")?(d=e("./_library"),v=e("./_global"),y=e("./_fails"),_=e("./_export"),h=e("./_typed"),s=e("./_typed-buffer"),F=e("./_ctx"),H=e("./_an-instance"),G=e("./_property-desc"),m=e("./_hide"),t=e("./_redefine-all"),U=e("./_to-integer"),g=e("./_to-length"),W=e("./_to-index"),B=e("./_to-absolute-index"),Y=e("./_to-primitive"),r=e("./_has"),z=e("./_classof"),b=e("./_is-object"),q=e("./_to-object"),X=e("./_is-array-iter"),V=e("./_object-create"),K=e("./_object-gpo"),x=e("./_object-gopn").f,Q=e("./core.get-iterator-method"),J=e("./_uid"),Z=e("./_wks"),n=e("./_array-methods"),u=e("./_array-includes"),o=e("./_species-constructor"),c=e("./es6.array.iterator"),$=e("./_iterators"),ee=e("./_iter-detect"),te=e("./_set-species"),ne=e("./_array-fill"),re=e("./_array-copy-within"),oe=e("./_object-dp"),e=e("./_object-gopd"),w=oe.f,ae=e.f,j=v.RangeError,ie=v.TypeError,a=v.Uint8Array,le="Shared"+(se="ArrayBuffer"),ue="BYTES_PER_ELEMENT",A="prototype",p=Array[A],S=s.ArrayBuffer,ce=s.DataView,fe=n(0),pe=n(2),de=n(3),ve=n(4),ye=n(5),_e=n(6),he=u(!0),me=u(!1),ge=c.values,be=c.keys,xe=c.entries,we=p.lastIndexOf,je=p.reduce,Ae=p.reduceRight,Se=p.join,ke=p.sort,Ee=p.slice,k=p.toString,i=p.toLocaleString,E=Z("iterator"),I=Z("toStringTag"),Ie=J("typed_constructor"),C=J("def_constructor"),s=h.CONSTR,O=h.TYPED,Ce=h.VIEW,P="Wrong length!",Oe=n(1,function(e,t){return f(o(e,e[C]),t)}),Pe=y(function(){return 1===new a(new Uint16Array([1]).buffer)[0]}),Le=!!a&&!!a[A].set&&y(function(){new a(1).set({})}),L=function(e,t){e=U(e);if(e<0||e%t)throw j("Wrong offset!");return e},l=function(e){if(b(e)&&O in e)return e;throw ie(e+" is not a typed array!")},f=function(e,t){if(b(e)&&Ie in e)return new e(t);throw ie("It is not a typed array constructor!")},Me=function(e,t){return M(o(e,e[C]),t)},M=function(e,t){for(var n=0,r=t.length,o=f(e,r);n<r;)o[n]=t[n++];return o},u=function(e,t,n){w(e,t,{get:function(){return this._d[n]}})},Te=function(e){var t,n,r,o,a,i,s=q(e),e=arguments.length,l=1<e?arguments[1]:void 0,u=void 0!==l,c=Q(s);if(null!=c&&!X(c)){for(i=c.call(s),r=[],t=0;!(a=i.next()).done;t++)r.push(a.value);s=r}for(u&&2<e&&(l=F(l,arguments[2],2)),t=0,n=g(s.length),o=f(this,n);t<n;t++)o[t]=u?l(s[t],t):s[t];return o},Re=function(){for(var e=0,t=arguments.length,n=f(this,t);e<t;)n[e]=arguments[e++];return n},Ne=!!a&&y(function(){i.call(new a(1))}),De=function(){return i.apply(Ne?Ee.call(l(this)):l(this),arguments)},Fe={copyWithin:function(e,t){return re.call(l(this),e,t,2<arguments.length?arguments[2]:void 0)},every:function(e){return ve(l(this),e,1<arguments.length?arguments[1]:void 0)},fill:function(e){return ne.apply(l(this),arguments)},filter:function(e){return Me(this,pe(l(this),e,1<arguments.length?arguments[1]:void 0))},find:function(e){return ye(l(this),e,1<arguments.length?arguments[1]:void 0)},findIndex:function(e){return _e(l(this),e,1<arguments.length?arguments[1]:void 0)},forEach:function(e){fe(l(this),e,1<arguments.length?arguments[1]:void 0)},indexOf:function(e){return me(l(this),e,1<arguments.length?arguments[1]:void 0)},includes:function(e){return he(l(this),e,1<arguments.length?arguments[1]:void 0)},join:function(e){return Se.apply(l(this),arguments)},lastIndexOf:function(e){return we.apply(l(this),arguments)},map:function(e){return Oe(l(this),e,1<arguments.length?arguments[1]:void 0)},reduce:function(e){return je.apply(l(this),arguments)},reduceRight:function(e){return Ae.apply(l(this),arguments)},reverse:function(){for(var e,t=this,n=l(t).length,r=Math.floor(n/2),o=0;o<r;)e=t[o],t[o++]=t[--n],t[n]=e;return t},some:function(e){return de(l(this),e,1<arguments.length?arguments[1]:void 0)},sort:function(e){return ke.call(l(this),e)},subarray:function(e,t){var n=l(this),r=n.length,e=B(e,r);return new(o(n,n[C]))(n.buffer,n.byteOffset+e*n.BYTES_PER_ELEMENT,g((void 0===t?r:B(t,r))-e))}},He=function(e,t){return Me(this,Ee.call(l(this),e,t))},Ge=function(e){l(this);var t=L(arguments[1],1),n=this.length,r=q(e),o=g(r.length),a=0;if(n<o+t)throw j(P);for(;a<o;)this[t+a]=r[a++]},T={entries:function(){return xe.call(l(this))},keys:function(){return be.call(l(this))},values:function(){return ge.call(l(this))}},Ue=function(e,t){return b(e)&&e[O]&&"symbol"!=typeof t&&t in e&&String(+t)==String(t)},c=function(e,t){return Ue(e,t=Y(t,!0))?G(2,e[t]):ae(e,t)},p=function(e,t,n){return!(Ue(e,t=Y(t,!0))&&b(n)&&r(n,"value"))||r(n,"get")||r(n,"set")||n.configurable||r(n,"writable")&&!n.writable||r(n,"enumerable")&&!n.enumerable?w(e,t,n):(e[t]=n.value,e)},s||(e.f=c,oe.f=p),_(_.S+_.F*!s,"Object",{getOwnPropertyDescriptor:c,defineProperty:p}),y(function(){k.call({})})&&(k=i=function(){return Se.call(this)}),R=t({},Fe),t(R,T),m(R,E,T.values),t(R,{slice:He,set:Ge,constructor:function(){},toString:k,toLocaleString:De}),u(R,"buffer","b"),u(R,"byteOffset","o"),u(R,"byteLength","l"),u(R,"length","e"),w(R,I,{get:function(){return this[O]}}),N.exports=function(e,u,t,o){function c(e,r){w(e,r,{get:function(){var e=this,t=r;return(e=e._d).v[n](t*u+e.o,Pe)},set:function(e){var t=this,n=r;t=t._d,o&&(e=(
+         e=Math.round(e))<0?0:255<e?255:255&e),t.v[a](n*u+t.o,e,Pe)},enumerable:!0})}var f=e+((o=!!o)?"Clamped":"")+"Array",n="get"+e,a="set"+e,p=v[f],i=p||{},e=p&&K(p),r=!p||!h.ABV,s={},l=p&&p[A],r=(r?(p=t(function(e,t,n,r){H(e,p,f,"_d");var o,a,i=0,s=0;if(b(t)){if(!(t instanceof S||(l=z(t))==se||l==le))return O in t?M(p,t):Te.call(p,t);var l=t,s=L(n,u),n=t.byteLength;if(void 0===r){if(n%u)throw j(P);if((o=n-s)<0)throw j(P)}else if(n<(o=g(r)*u)+s)throw j(P);a=o/u}else a=W(t),l=new S(o=a*u);for(m(e,"_d",{b:l,o:s,l:o,e:a,v:new ce(l)});i<a;)c(e,i++)}),l=p[A]=V(R),m(l,"constructor",p)):y(function(){p(1)})&&y(function(){new p(-1)})&&ee(function(e){new p,new p(null),new p(1.5),new p(e)},!0)||(p=t(function(e,t,n,r){return H(e,p,f),b(t)?t instanceof S||(e=z(t))==se||e==le?void 0!==r?new i(t,L(n,u),r):void 0!==n?new i(t,L(n,u)):new i(t):O in t?M(p,t):Te.call(p,t):new i(W(t))}),fe(e!==Function.prototype?x(i).concat(x(e)):x(i),function(e){e in p||m(p,e,i[e])}),p[A]=l,d||(l.constructor=p)),l[E]),t=!!r&&("values"==r.name||null==r.name),e=T.values;m(p,Ie,!0),m(l,O,f),m(l,Ce,!0),m(l,C,p),(o?new p(1)[I]==f:I in l)||w(l,I,{get:function(){return f}}),s[f]=p,_(_.G+_.W+_.F*(p!=i),s),_(_.S,f,{BYTES_PER_ELEMENT:u}),_(_.S+_.F*y(function(){i.of.call(p,1)}),f,{from:Te,of:Re}),ue in l||m(l,ue,u),_(_.P,f,Fe),te(f),_(_.P+_.F*Le,f,{set:Ge}),_(_.P+_.F*!t,f,T),d||l.toString==k||(l.toString=k),_(_.P+_.F*y(function(){new p(1).slice()}),f,{slice:He}),_(_.P+_.F*(y(function(){return[1,2].toLocaleString()!=new p([1,2]).toLocaleString()})||!y(function(){l.toLocaleString.call([1,2])})),f,{toLocaleString:De}),$[f]=t?r:e,d||t||m(l,E,e)}):N.exports=function(){}},{"./_an-instance":7,"./_array-copy-within":9,"./_array-fill":10,"./_array-includes":12,"./_array-methods":13,"./_classof":18,"./_ctx":26,"./_descriptors":30,"./_export":34,"./_fails":36,"./_global":42,"./_has":43,"./_hide":44,"./_is-array-iter":50,"./_is-object":53,"./_iter-detect":58,"./_iterators":60,"./_library":61,"./_object-create":72,"./_object-dp":73,"./_object-gopd":76,"./_object-gopn":78,"./_object-gpo":80,"./_property-desc":91,"./_redefine-all":92,"./_set-species":101,"./_species-constructor":105,"./_to-absolute-index":115,"./_to-index":116,"./_to-integer":117,"./_to-length":119,"./_to-object":120,"./_to-primitive":121,"./_typed":124,"./_typed-buffer":123,"./_uid":125,"./_wks":130,"./core.get-iterator-method":131,"./es6.array.iterator":143}],123:[function(e,N,t){"use strict";var n=e("./_global"),r=e("./_descriptors"),D=e("./_library"),o=e("./_typed"),a=e("./_hide"),i=e("./_redefine-all"),s=e("./_fails"),l=e("./_an-instance"),F=e("./_to-integer"),H=e("./_to-length"),c=e("./_to-index"),u=e("./_object-gopn").f,G=e("./_object-dp").f,U=e("./_array-fill"),e=e("./_set-to-string-tag"),f="ArrayBuffer",p="DataView",d="prototype",v="Wrong index!",y=n[f],_=n[p],h=n.Math,m=n.RangeError,g=n.Infinity,b=y,W=h.abs,x=h.pow,B=h.floor,Y=h.log,z=h.LN2,n="byteLength",h="byteOffset",w=r?"_b":"buffer",j=r?"_l":n,A=r?"_o":h;function S(e,t,n){var r,o,a,i=new Array(n),s=8*n-t-1,n=(1<<s)-1,l=n>>1,u=23===t?x(2,-24)-x(2,-77):0,c=0,f=e<0||0===e&&1/e<0?1:0;for((e=W(e))!=e||e===g?(o=e!=e?1:0,r=n):(r=B(Y(e)/z),e*(a=x(2,-r))<1&&(r--,a*=2),2<=(e+=1<=r+l?u/a:u*x(2,1-l))*a&&(r++,a/=2),n<=r+l?(o=0,r=n):1<=r+l?(o=(e*a-1)*x(2,t),r+=l):(o=e*x(2,l-1)*x(2,t),r=0));8<=t;i[c++]=255&o,o/=256,t-=8);for(r=r<<t|o,s+=t;0<s;i[c++]=255&r,r/=256,s-=8);return i[--c]|=128*f,i}function k(e,t,n){var r,o=8*n-t-1,a=(1<<o)-1,i=a>>1,s=o-7,l=n-1,o=e[l--],u=127&o;for(o>>=7;0<s;u=256*u+e[l],l--,s-=8);for(r=u&(1<<-s)-1,u>>=-s,s+=t;0<s;r=256*r+e[l],l--,s-=8);if(0===u)u=1-i;else{if(u===a)return r?NaN:o?-g:g;r+=x(2,t),u-=i}return(o?-1:1)*r*x(2,u-t)}function E(e){return e[3]<<24|e[2]<<16|e[1]<<8|e[0]}function I(e){return[255&e]}function C(e){return[255&e,e>>8&255]}function O(e){return[255&e,e>>8&255,e>>16&255,e>>24&255]}function q(e){return S(e,52,8)}function X(e){return S(e,23,4)}function P(e,t,n){G(e[d],t,{get:function(){return this[n]}})}function L(e,t,n,r){n=c(+n);if(n+t>e[j])throw m(v);var o=e[w]._b,n=n+e[A],e=o.slice(n,n+t);return r?e:e.reverse()}function M(e,t,n,r,o,a){n=c(+n);if(n+t>e[j])throw m(v);for(var i=e[w]._b,s=n+e[A],l=r(+o),u=0;u<t;u++)i[s+u]=l[a?u:t-u-1]}if(o.ABV){if(!s(function(){y(1)})||!s(function(){new y(-1)})||s(function(){return new y,new y(1.5),new y(NaN),y.name!=f})){for(var T,s=(y=function(e){return l(this,y),new b(c(e))})[d]=b[d],R=u(b),V=0;R.length>V;)(T=R[V++])in y||a(y,T,b[T]);D||(s.constructor=y)}var u=new _(new y(2)),K=_[d].setInt8;u.setInt8(0,2147483648),u.setInt8(1,2147483649),!u.getInt8(0)&&u.getInt8(1)||i(_[d],{setInt8:function(e,t){K.call(this,e,t<<24>>24)},setUint8:function(e,t){K.call(this,e,t<<24>>24)}},!0)}else y=function(e){l(this,y,f);e=c(e);this._b=U.call(new Array(e),0),this[j]=e},_=function(e,t,n){l(this,_,p),l(e,y,p);var r=e[j],t=F(t);if(t<0||r<t)throw m("Wrong offset!");if(r<t+(n=void 0===n?r-t:H(n)))throw m("Wrong length!");this[w]=e,this[A]=t,this[j]=n},r&&(P(y,n,"_l"),P(_,"buffer","_b"),P(_,n,"_l"),P(_,h,"_o")),i(_[d],{getInt8:function(e){return L(this,1,e)[0]<<24>>24},getUint8:function(e){return L(this,1,e)[0]},getInt16:function(e){e=L(this,2,e,arguments[1]);return(e[1]<<8|e[0])<<16>>16},getUint16:function(e){e=L(this,2,e,arguments[1]);return e[1]<<8|e[0]},getInt32:function(e){return E(L(this,4,e,arguments[1]))},getUint32:function(e){return E(L(this,4,e,arguments[1]))>>>0},getFloat32:function(e){return k(L(this,4,e,arguments[1]),23,4)},getFloat64:function(e){return k(L(this,8,e,arguments[1]),52,8)},setInt8:function(e,t){M(this,1,e,I,t)},setUint8:function(e,t){M(this,1,e,I,t)},setInt16:function(e,t){M(this,2,e,C,t,arguments[2])},setUint16:function(e,t){M(this,2,e,C,t,arguments[2])},setInt32:function(e,t){M(this,4,e,O,t,arguments[2])},setUint32:function(e,t){M(this,4,e,O,t,arguments[2])},setFloat32:function(e,t){M(this,4,e,X,t,arguments[2])},setFloat64:function(e,t){M(this,8,e,q,t,arguments[2])}});e(y,f),e(_,p),a(_[d],o.VIEW,!0),t[f]=y,t[p]=_},{"./_an-instance":7,"./_array-fill":10,"./_descriptors":30,"./_fails":36,"./_global":42,"./_hide":44,"./_library":61,"./_object-dp":73,"./_object-gopn":78,"./_redefine-all":92,"./_set-to-string-tag":102,"./_to-index":116,"./_to-integer":117,"./_to-length":119,"./_typed":124}],124:[function(e,t,n){for(var r,o=e("./_global"),a=e("./_hide"),e=e("./_uid"),i=e("typed_array"),s=e("view"),e=!(!o.ArrayBuffer||!o.DataView),l=e,u=0,c="Int8Array,Uint8Array,Uint8ClampedArray,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array".split(",");u<9;)(r=o[c[u++]])?(a(r.prototype,i,!0),a(r.prototype,s,!0)):l=!1;t.exports={ABV:e,CONSTR:l,TYPED:i,VIEW:s}},{"./_global":42,"./_hide":44,"./_uid":125}],125:[function(e,t,n){var r=0,o=Math.random();t.exports=function(e){return"Symbol(".concat(void 0===e?"":e,")_",(++r+o).toString(36))}},{}],126:[function(e,t,n){e=e("./_global").navigator;t.exports=e&&e.userAgent||""},{"./_global":42}],127:[function(e,t,n){var r=e("./_is-object");t.exports=function(e,t){if(r(e)&&e._t===t)return e;throw TypeError("Incompatible receiver, "+t+" required!")}},{"./_is-object":53}],128:[function(e,t,n){var r=e("./_global"),o=e("./_core"),a=e("./_library"),i=e("./_wks-ext"),s=e("./_object-dp").f;t.exports=function(e){var t=o.Symbol||(o.Symbol=!a&&r.Symbol||{});"_"==e.charAt(0)||e in t||s(t,e,{value:i.f(e)})}},{"./_core":24,"./_global":42,"./_library":61,"./_object-dp":73,"./_wks-ext":129}],129:[function(e,t,n){n.f=e("./_wks")},{"./_wks":130}],130:[function(e,t,n){var r=e("./_shared")("wks"),o=e("./_uid"),a=e("./_global").Symbol,i="function"==typeof a;(t.exports=function(e){return r[e]||(r[e]=i&&a[e]||(i?a:o)("Symbol."+e))}).store=r},{"./_global":42,"./_shared":104,"./_uid":125}],131:[function(e,t,n){var r=e("./_classof"),o=e("./_wks")("iterator"),a=e("./_iterators");t.exports=e("./_core").getIteratorMethod=function(e){if(null!=e)return e[o]||e["@@iterator"]||a[r(e)]}},{"./_classof":18,"./_core":24,"./_iterators":60,"./_wks":130}],132:[function(e,t,n){var r=e("./_export"),o=e("./_replacer")(/[\\^$*+?.()|[\]{}]/g,"\\$&");r(r.S,"RegExp",{escape:function(e){return o(e)}})},{"./_export":34,"./_replacer":96}],133:[function(e,t,n){var r=e("./_export");r(r.P,"Array",{copyWithin:e("./_array-copy-within")}),e("./_add-to-unscopables")("copyWithin")},{"./_add-to-unscopables":5,"./_array-copy-within":9,"./_export":34}],134:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-methods")(4);r(r.P+r.F*!e("./_strict-method")([].every,!0),"Array",{every:function(e){return o(this,e,arguments[1])}})},{"./_array-methods":13,"./_export":34,"./_strict-method":106}],135:[function(e,t,n){var r=e("./_export");r(r.P,"Array",{fill:e("./_array-fill")}),e("./_add-to-unscopables")("fill")},{"./_add-to-unscopables":5,"./_array-fill":10,"./_export":34}],136:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-methods")(2);r(r.P+r.F*!e("./_strict-method")([].filter,!0),"Array",{filter:function(e){return o(this,e,arguments[1])}})},{"./_array-methods":13,"./_export":34,"./_strict-method":106}],137:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-methods")(6),a="findIndex",i=!0;a in[]&&Array(1)[a](function(){i=!1}),r(r.P+r.F*i,"Array",{findIndex:function(e){return o(this,e,1<arguments.length?arguments[1]:void 0)}}),e("./_add-to-unscopables")(a)},{"./_add-to-unscopables":5,"./_array-methods":13,"./_export":34}],138:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-methods")(5),a="find",i=!0;a in[]&&Array(1)[a](function(){i=!1}),r(r.P+r.F*i,"Array",{find:function(e){return o(this,e,1<arguments.length?arguments[1]:void 0)}}),e("./_add-to-unscopables")(a)},{"./_add-to-unscopables":5,"./_array-methods":13,"./_export":34}],139:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-methods")(0),e=e("./_strict-method")([].forEach,!0);r(r.P+r.F*!e,"Array",{forEach:function(e){return o(this,e,arguments[1])}})},{"./_array-methods":13,"./_export":34,"./_strict-method":106}],140:[function(e,t,n){"use strict";var f=e("./_ctx"),r=e("./_export"),p=e("./_to-object"),d=e("./_iter-call"),v=e("./_is-array-iter"),y=e("./_to-length"),_=e("./_create-property"),h=e("./core.get-iterator-method");r(r.S+r.F*!e("./_iter-detect")(function(e){Array.from(e)}),"Array",{from:function(e){var t,n,r,o,a=p(e),e="function"==typeof this?this:Array,i=arguments.length,s=1<i?arguments[1]:void 0,l=void 0!==s,u=0,c=h(a);if(l&&(s=f(s,2<i?arguments[2]:void 0,2)),null==c||e==Array&&v(c))for(n=new e(t=y(a.length));u<t;u++)_(n,u,l?s(a[u],u):a[u]);else for(o=c.call(a),n=new e;!(r=o.next()).done;u++)_(n,u,l?d(o,s,[r.value,u],!0):r.value);return n.length=u,n}})},{"./_create-property":25,"./_ctx":26,"./_export":34,"./_is-array-iter":50,"./_iter-call":55,"./_iter-detect":58,"./_to-length":119,"./_to-object":120,"./core.get-iterator-method":131}],141:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-includes")(!1),a=[].indexOf,i=!!a&&1/[1].indexOf(1,-0)<0;r(r.P+r.F*(i||!e("./_strict-method")(a)),"Array",{indexOf:function(e){return i?a.apply(this,arguments)||0:o(this,e,arguments[1])}})},{"./_array-includes":12,"./_export":34,"./_strict-method":106}],142:[function(e,t,n){var r=e("./_export");r(r.S,"Array",{isArray:e("./_is-array")})},{"./_export":34,"./_is-array":51}],143:[function(e,t,n){"use strict";var r=e("./_add-to-unscopables"),o=e("./_iter-step"),a=e("./_iterators"),i=e("./_to-iobject");t.exports=e("./_iter-define")(Array,"Array",function(e,t){this._t=i(e),this._i=0,this._k=t},function(){var e=this._t,t=this._k,n=this._i++;return!e||n>=e.length?(this._t=void 0,o(1)):o(0,"keys"==t?n:"values"==t?e[n]:[n,e[n]])},"values"),a.Arguments=a.Array,r("keys"),r("values"),r("entries")},{"./_add-to-unscopables":5,"./_iter-define":57,"./_iter-step":59,"./_iterators":60,"./_to-iobject":118}],144:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-iobject"),a=[].join;r(r.P+r.F*(e("./_iobject")!=Object||!e("./_strict-method")(a)),"Array",{join:function(e){return a.call(o(this),void 0===e?",":e)}})},{"./_export":34,"./_iobject":49,"./_strict-method":106,"./_to-iobject":118}],145:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-iobject"),a=e("./_to-integer"),i=e("./_to-length"),s=[].lastIndexOf,l=!!s&&1/[1].lastIndexOf(1,-0)<0;r(r.P+r.F*(l||!e("./_strict-method")(s)),"Array",{lastIndexOf:function(e){if(l)return s.apply(this,arguments)||0;var t=o(this),n=i(t.length),r=n-1;for((r=1<arguments.length?Math.min(r,a(arguments[1])):r)<0&&(r=n+r);0<=r;r--)if(r in t&&t[r]===e)return r||0;return-1}})},{"./_export":34,"./_strict-method":106,"./_to-integer":117,"./_to-iobject":118,"./_to-length":119}],146:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-methods")(1);r(r.P+r.F*!e("./_strict-method")([].map,!0),"Array",{map:function(e){return o(this,e,arguments[1])}})},{"./_array-methods":13,"./_export":34,"./_strict-method":106}],147:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_create-property");r(r.S+r.F*e("./_fails")(function(){function e(){}return!(Array.of.call(e)instanceof e)}),"Array",{of:function(){for(var e=0,t=arguments.length,n=new("function"==typeof this?this:Array)(t);e<t;)o(n,e,arguments[e++]);return n.length=t,n}})},{"./_create-property":25,"./_export":34,"./_fails":36}],148:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-reduce");r(r.P+r.F*!e("./_strict-method")([].reduceRight,!0),"Array",{reduceRight:function(e){return o(this,e,arguments.length,arguments[1],!0)}})},{"./_array-reduce":14,"./_export":34,"./_strict-method":106}],149:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-reduce");r(r.P+r.F*!e("./_strict-method")([].reduce,!0),"Array",{reduce:function(e){return o(this,e,arguments.length,arguments[1],!1)}})},{"./_array-reduce":14,"./_export":34,"./_strict-method":106}],150:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_html"),l=e("./_cof"),u=e("./_to-absolute-index"),c=e("./_to-length"),f=[].slice;r(r.P+r.F*e("./_fails")(function(){o&&f.call(o)}),"Array",{slice:function(e,t){var n=c(this.length),r=l(this);if(t=void 0===t?n:t,"Array"==r)return f.call(this,e,t);for(var o=u(e,n),e=u(t,n),a=c(e-o),i=new Array(a),s=0;s<a;s++)i[s]="String"==r?this.charAt(o+s):this[o+s];return i}})},{"./_cof":19,"./_export":34,"./_fails":36,"./_html":45,"./_to-absolute-index":115,"./_to-length":119}],151:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-methods")(3);r(r.P+r.F*!e("./_strict-method")([].some,!0),"Array",{some:function(e){return o(this,e,arguments[1])}})},{"./_array-methods":13,"./_export":34,"./_strict-method":106}],152:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_a-function"),a=e("./_to-object"),i=e("./_fails"),s=[].sort,l=[1,2,3];r(r.P+r.F*(i(function(){l.sort(void 0)})||!i(function(){l.sort(null)})||!e("./_strict-method")(s)),"Array",{sort:function(e){return void 0===e?s.call(a(this)):s.call(a(this),o(e))}})},{"./_a-function":3,"./_export":34,"./_fails":36,"./_strict-method":106,"./_to-object":120}],153:[function(e,t,n){e("./_set-species")("Array")},{
+         "./_set-species":101}],154:[function(e,t,n){e=e("./_export");e(e.S,"Date",{now:function(){return(new Date).getTime()}})},{"./_export":34}],155:[function(e,t,n){var r=e("./_export"),e=e("./_date-to-iso-string");r(r.P+r.F*(Date.prototype.toISOString!==e),"Date",{toISOString:e})},{"./_date-to-iso-string":27,"./_export":34}],156:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-object"),a=e("./_to-primitive");r(r.P+r.F*e("./_fails")(function(){return null!==new Date(NaN).toJSON()||1!==Date.prototype.toJSON.call({toISOString:function(){return 1}})}),"Date",{toJSON:function(e){var t=o(this),n=a(t);return"number"!=typeof n||isFinite(n)?t.toISOString():null}})},{"./_export":34,"./_fails":36,"./_to-object":120,"./_to-primitive":121}],157:[function(e,t,n){var r=e("./_wks")("toPrimitive"),o=Date.prototype;r in o||e("./_hide")(o,r,e("./_date-to-primitive"))},{"./_date-to-primitive":28,"./_hide":44,"./_wks":130}],158:[function(e,t,n){var r=Date.prototype,o="Invalid Date",a="toString",i=r[a],s=r.getTime;new Date(NaN)+""!=o&&e("./_redefine")(r,a,function(){var e=s.call(this);return e==e?i.call(this):o})},{"./_redefine":93}],159:[function(e,t,n){var r=e("./_export");r(r.P,"Function",{bind:e("./_bind")})},{"./_bind":17,"./_export":34}],160:[function(e,t,n){"use strict";var r=e("./_is-object"),o=e("./_object-gpo"),a=e("./_wks")("hasInstance"),i=Function.prototype;a in i||e("./_object-dp").f(i,a,{value:function(e){if("function"!=typeof this||!r(e))return!1;if(!r(this.prototype))return e instanceof this;for(;e=o(e);)if(this.prototype===e)return!0;return!1}})},{"./_is-object":53,"./_object-dp":73,"./_object-gpo":80,"./_wks":130}],161:[function(e,t,n){var r=e("./_object-dp").f,o=Function.prototype,a=/^\s*function ([^ (]*)/;"name"in o||e("./_descriptors")&&r(o,"name",{configurable:!0,get:function(){try{return(""+this).match(a)[1]}catch(e){return""}}})},{"./_descriptors":30,"./_object-dp":73}],162:[function(e,t,n){"use strict";var r=e("./_collection-strong"),o=e("./_validate-collection");t.exports=e("./_collection")("Map",function(e){return function(){return e(this,0<arguments.length?arguments[0]:void 0)}},{get:function(e){e=r.getEntry(o(this,"Map"),e);return e&&e.v},set:function(e,t){return r.def(o(this,"Map"),0===e?0:e,t)}},r,!0)},{"./_collection":23,"./_collection-strong":20,"./_validate-collection":127}],163:[function(e,t,n){var r=e("./_export"),o=e("./_math-log1p"),a=Math.sqrt,e=Math.acosh;r(r.S+r.F*!(e&&710==Math.floor(e(Number.MAX_VALUE))&&e(1/0)==1/0),"Math",{acosh:function(e){return(e=+e)<1?NaN:94906265.62425156<e?Math.log(e)+Math.LN2:o(e-1+a(e-1)*a(e+1))}})},{"./_export":34,"./_math-log1p":64}],164:[function(e,t,n){var e=e("./_export"),r=Math.asinh;e(e.S+e.F*!(r&&0<1/r(0)),"Math",{asinh:function e(t){return isFinite(t=+t)&&0!=t?t<0?-e(-t):Math.log(t+Math.sqrt(t*t+1)):t}})},{"./_export":34}],165:[function(e,t,n){var e=e("./_export"),r=Math.atanh;e(e.S+e.F*!(r&&1/r(-0)<0),"Math",{atanh:function(e){return 0==(e=+e)?e:Math.log((1+e)/(1-e))/2}})},{"./_export":34}],166:[function(e,t,n){var r=e("./_export"),o=e("./_math-sign");r(r.S,"Math",{cbrt:function(e){return o(e=+e)*Math.pow(Math.abs(e),1/3)}})},{"./_export":34,"./_math-sign":66}],167:[function(e,t,n){e=e("./_export");e(e.S,"Math",{clz32:function(e){return(e>>>=0)?31-Math.floor(Math.log(e+.5)*Math.LOG2E):32}})},{"./_export":34}],168:[function(e,t,n){var e=e("./_export"),r=Math.exp;e(e.S,"Math",{cosh:function(e){return(r(e=+e)+r(-e))/2}})},{"./_export":34}],169:[function(e,t,n){var r=e("./_export"),e=e("./_math-expm1");r(r.S+r.F*(e!=Math.expm1),"Math",{expm1:e})},{"./_export":34,"./_math-expm1":62}],170:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{fround:e("./_math-fround")})},{"./_export":34,"./_math-fround":63}],171:[function(e,t,n){var e=e("./_export"),l=Math.abs;e(e.S,"Math",{hypot:function(e,t){for(var n,r,o=0,a=0,i=arguments.length,s=0;a<i;)s<(n=l(arguments[a++]))?(o=o*(r=s/n)*r+1,s=n):o+=0<n?(r=n/s)*r:n;return s===1/0?1/0:s*Math.sqrt(o)}})},{"./_export":34}],172:[function(e,t,n){var r=e("./_export"),o=Math.imul;r(r.S+r.F*e("./_fails")(function(){return-5!=o(4294967295,5)||2!=o.length}),"Math",{imul:function(e,t){var n=65535,e=+e,t=+t,r=n&e,o=n&t;return 0|r*o+((n&e>>>16)*o+r*(n&t>>>16)<<16>>>0)}})},{"./_export":34,"./_fails":36}],173:[function(e,t,n){e=e("./_export");e(e.S,"Math",{log10:function(e){return Math.log(e)*Math.LOG10E}})},{"./_export":34}],174:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{log1p:e("./_math-log1p")})},{"./_export":34,"./_math-log1p":64}],175:[function(e,t,n){e=e("./_export");e(e.S,"Math",{log2:function(e){return Math.log(e)/Math.LN2}})},{"./_export":34}],176:[function(e,t,n){var r=e("./_export");r(r.S,"Math",{sign:e("./_math-sign")})},{"./_export":34,"./_math-sign":66}],177:[function(e,t,n){var r=e("./_export"),o=e("./_math-expm1"),a=Math.exp;r(r.S+r.F*e("./_fails")(function(){return-2e-17!=!Math.sinh(-2e-17)}),"Math",{sinh:function(e){return Math.abs(e=+e)<1?(o(e)-o(-e))/2:(a(e-1)-a(-e-1))*(Math.E/2)}})},{"./_export":34,"./_fails":36,"./_math-expm1":62}],178:[function(e,t,n){var r=e("./_export"),o=e("./_math-expm1"),a=Math.exp;r(r.S,"Math",{tanh:function(e){var t=o(e=+e),n=o(-e);return t==1/0?1:n==1/0?-1:(t-n)/(a(e)+a(-e))}})},{"./_export":34,"./_math-expm1":62}],179:[function(e,t,n){e=e("./_export");e(e.S,"Math",{trunc:function(e){return(0<e?Math.floor:Math.ceil)(e)}})},{"./_export":34}],180:[function(e,t,n){"use strict";function r(e){if("string"==typeof(t=u(e,!1))&&2<t.length){var t,n,r,o,e=(t=m?t.trim():d(t,3)).charCodeAt(0);if(43===e||45===e){if(88===(n=t.charCodeAt(2))||120===n)return NaN}else if(48===e){switch(t.charCodeAt(1)){case 66:case 98:r=2,o=49;break;case 79:case 111:r=8,o=55;break;default:return+t}for(var a,i=t.slice(2),s=0,l=i.length;s<l;s++)if((a=i.charCodeAt(s))<48||o<a)return NaN;return parseInt(i,r)}}return+t}var o=e("./_global"),a=e("./_has"),i=e("./_cof"),s=e("./_inherit-if-required"),u=e("./_to-primitive"),l=e("./_fails"),c=e("./_object-gopn").f,f=e("./_object-gopd").f,p=e("./_object-dp").f,d=e("./_string-trim").trim,v="Number",y=b=o[v],_=b.prototype,h=i(e("./_object-create")(_))==v,m="trim"in String.prototype;if(!b(" 0o1")||!b("0b1")||b("+0x1")){for(var g,b=function(e){var e=arguments.length<1?0:e,t=this;return t instanceof b&&(h?l(function(){_.valueOf.call(t)}):i(t)!=v)?s(new y(r(e)),t,b):r(e)},x=e("./_descriptors")?c(y):"MAX_VALUE,MIN_VALUE,NaN,NEGATIVE_INFINITY,POSITIVE_INFINITY,EPSILON,isFinite,isInteger,isNaN,isSafeInteger,MAX_SAFE_INTEGER,MIN_SAFE_INTEGER,parseFloat,parseInt,isInteger".split(","),w=0;x.length>w;w++)a(y,g=x[w])&&!a(b,g)&&p(b,g,f(y,g));(b.prototype=_).constructor=b,e("./_redefine")(o,v,b)}},{"./_cof":19,"./_descriptors":30,"./_fails":36,"./_global":42,"./_has":43,"./_inherit-if-required":47,"./_object-create":72,"./_object-dp":73,"./_object-gopd":76,"./_object-gopn":78,"./_redefine":93,"./_string-trim":112,"./_to-primitive":121}],181:[function(e,t,n){e=e("./_export");e(e.S,"Number",{EPSILON:Math.pow(2,-52)})},{"./_export":34}],182:[function(e,t,n){var r=e("./_export"),o=e("./_global").isFinite;r(r.S,"Number",{isFinite:function(e){return"number"==typeof e&&o(e)}})},{"./_export":34,"./_global":42}],183:[function(e,t,n){var r=e("./_export");r(r.S,"Number",{isInteger:e("./_is-integer")})},{"./_export":34,"./_is-integer":52}],184:[function(e,t,n){e=e("./_export");e(e.S,"Number",{isNaN:function(e){return e!=e}})},{"./_export":34}],185:[function(e,t,n){var r=e("./_export"),o=e("./_is-integer"),a=Math.abs;r(r.S,"Number",{isSafeInteger:function(e){return o(e)&&a(e)<=9007199254740991}})},{"./_export":34,"./_is-integer":52}],186:[function(e,t,n){e=e("./_export");e(e.S,"Number",{MAX_SAFE_INTEGER:9007199254740991})},{"./_export":34}],187:[function(e,t,n){e=e("./_export");e(e.S,"Number",{MIN_SAFE_INTEGER:-9007199254740991})},{"./_export":34}],188:[function(e,t,n){var r=e("./_export"),e=e("./_parse-float");r(r.S+r.F*(Number.parseFloat!=e),"Number",{parseFloat:e})},{"./_export":34,"./_parse-float":87}],189:[function(e,t,n){var r=e("./_export"),e=e("./_parse-int");r(r.S+r.F*(Number.parseInt!=e),"Number",{parseInt:e})},{"./_export":34,"./_parse-int":88}],190:[function(e,t,n){"use strict";function i(e,t){for(var n=-1,r=t;++n<6;)r+=e*d[n],d[n]=r%1e7,r=a(r/1e7)}function s(e){for(var t=6,n=0;0<=--t;)n+=d[t],d[t]=a(n/e),n=n%e*1e7}function l(){for(var e,t=6,n="";0<=--t;)""===n&&0!==t&&0===d[t]||(e=String(d[t]),n=""===n?e:n+p.call("0",7-e.length)+e);return n}function u(e,t,n){return 0===t?n:t%2==1?u(e,t-1,n*e):u(e*e,t/2,n)}var r=e("./_export"),c=e("./_to-integer"),f=e("./_a-number-value"),p=e("./_string-repeat"),o=1..toFixed,a=Math.floor,d=[0,0,0,0,0,0],v="Number.toFixed: incorrect invocation!";r(r.P+r.F*(!!o&&("0.000"!==8e-5.toFixed(3)||"1"!==.9.toFixed(0)||"1.25"!==1.255.toFixed(2)||"1000000000000000128"!==0xde0b6b3a7640080.toFixed(0))||!e("./_fails")(function(){o.call({})})),"Number",{toFixed:function(e){var t,n,r=f(this,v),e=c(e),o="",a="0";if(e<0||20<e)throw RangeError(v);if(r!=r)return"NaN";if(r<=-1e21||1e21<=r)return String(r);if(r<0&&(o="-",r=-r),1e-21<r)if(r=(t=function(e){for(var t=0,n=e;4096<=n;)t+=12,n/=4096;for(;2<=n;)t+=1,n/=2;return t}(r*u(2,69,1))-69)<0?r*u(2,-t,1):r/u(2,t,1),r*=4503599627370496,0<(t=52-t)){for(i(0,r),n=e;7<=n;)i(1e7,0),n-=7;for(i(u(10,n,1),0),n=t-1;23<=n;)s(1<<23),n-=23;s(1<<n),i(1,1),s(2),a=l()}else i(0,r),i(1<<-t,0),a=l()+p.call("0",e);return a=0<e?o+((r=a.length)<=e?"0."+p.call("0",e-r)+a:a.slice(0,r-e)+"."+a.slice(r-e)):o+a}})},{"./_a-number-value":4,"./_export":34,"./_fails":36,"./_string-repeat":111,"./_to-integer":117}],191:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_fails"),a=e("./_a-number-value"),i=1..toPrecision;r(r.P+r.F*(o(function(){return"1"!==i.call(1,void 0)})||!o(function(){i.call({})})),"Number",{toPrecision:function(e){var t=a(this,"Number#toPrecision: incorrect invocation!");return void 0===e?i.call(t):i.call(t,e)}})},{"./_a-number-value":4,"./_export":34,"./_fails":36}],192:[function(e,t,n){var r=e("./_export");r(r.S+r.F,"Object",{assign:e("./_object-assign")})},{"./_export":34,"./_object-assign":71}],193:[function(e,t,n){var r=e("./_export");r(r.S,"Object",{create:e("./_object-create")})},{"./_export":34,"./_object-create":72}],194:[function(e,t,n){var r=e("./_export");r(r.S+r.F*!e("./_descriptors"),"Object",{defineProperties:e("./_object-dps")})},{"./_descriptors":30,"./_export":34,"./_object-dps":74}],195:[function(e,t,n){var r=e("./_export");r(r.S+r.F*!e("./_descriptors"),"Object",{defineProperty:e("./_object-dp").f})},{"./_descriptors":30,"./_export":34,"./_object-dp":73}],196:[function(e,t,n){var r=e("./_is-object"),o=e("./_meta").onFreeze;e("./_object-sap")("freeze",function(t){return function(e){return t&&r(e)?t(o(e)):e}})},{"./_is-object":53,"./_meta":67,"./_object-sap":84}],197:[function(e,t,n){var r=e("./_to-iobject"),o=e("./_object-gopd").f;e("./_object-sap")("getOwnPropertyDescriptor",function(){return function(e,t){return o(r(e),t)}})},{"./_object-gopd":76,"./_object-sap":84,"./_to-iobject":118}],198:[function(e,t,n){e("./_object-sap")("getOwnPropertyNames",function(){return e("./_object-gopn-ext").f})},{"./_object-gopn-ext":77,"./_object-sap":84}],199:[function(e,t,n){var r=e("./_to-object"),o=e("./_object-gpo");e("./_object-sap")("getPrototypeOf",function(){return function(e){return o(r(e))}})},{"./_object-gpo":80,"./_object-sap":84,"./_to-object":120}],200:[function(e,t,n){var r=e("./_is-object");e("./_object-sap")("isExtensible",function(t){return function(e){return!!r(e)&&(!t||t(e))}})},{"./_is-object":53,"./_object-sap":84}],201:[function(e,t,n){var r=e("./_is-object");e("./_object-sap")("isFrozen",function(t){return function(e){return!r(e)||!!t&&t(e)}})},{"./_is-object":53,"./_object-sap":84}],202:[function(e,t,n){var r=e("./_is-object");e("./_object-sap")("isSealed",function(t){return function(e){return!r(e)||!!t&&t(e)}})},{"./_is-object":53,"./_object-sap":84}],203:[function(e,t,n){var r=e("./_export");r(r.S,"Object",{is:e("./_same-value")})},{"./_export":34,"./_same-value":97}],204:[function(e,t,n){var r=e("./_to-object"),o=e("./_object-keys");e("./_object-sap")("keys",function(){return function(e){return o(r(e))}})},{"./_object-keys":82,"./_object-sap":84,"./_to-object":120}],205:[function(e,t,n){var r=e("./_is-object"),o=e("./_meta").onFreeze;e("./_object-sap")("preventExtensions",function(t){return function(e){return t&&r(e)?t(o(e)):e}})},{"./_is-object":53,"./_meta":67,"./_object-sap":84}],206:[function(e,t,n){var r=e("./_is-object"),o=e("./_meta").onFreeze;e("./_object-sap")("seal",function(t){return function(e){return t&&r(e)?t(o(e)):e}})},{"./_is-object":53,"./_meta":67,"./_object-sap":84}],207:[function(e,t,n){var r=e("./_export");r(r.S,"Object",{setPrototypeOf:e("./_set-proto").set})},{"./_export":34,"./_set-proto":100}],208:[function(e,t,n){"use strict";var r=e("./_classof"),o={};o[e("./_wks")("toStringTag")]="z",o+""!="[object z]"&&e("./_redefine")(Object.prototype,"toString",function(){return"[object "+r(this)+"]"},!0)},{"./_classof":18,"./_redefine":93,"./_wks":130}],209:[function(e,t,n){var r=e("./_export"),e=e("./_parse-float");r(r.G+r.F*(parseFloat!=e),{parseFloat:e})},{"./_export":34,"./_parse-float":87}],210:[function(e,t,n){var r=e("./_export"),e=e("./_parse-int");r(r.G+r.F*(parseInt!=e),{parseInt:e})},{"./_export":34,"./_parse-int":88}],211:[function(n,R,N){"use strict";function r(){}var t,o,a,i,s=n("./_library"),p=n("./_global"),l=n("./_ctx"),e=n("./_classof"),u=n("./_export"),c=n("./_is-object"),f=n("./_a-function"),d=n("./_an-instance"),v=n("./_for-of"),y=n("./_species-constructor"),_=n("./_task").set,h=n("./_microtask")(),m=n("./_new-promise-capability"),g=n("./_perform"),b=n("./_user-agent"),x=n("./_promise-resolve"),w="Promise",j=p.TypeError,A=p.process,S=A&&A.versions,k=S&&S.v8||"",E=p[w],I="process"==e(A),C=o=m.f,S=!!function(){try{var e=E.resolve(1),t=(e.constructor={})[n("./_wks")("species")]=function(e){e(r,r)};return(I||"function"==typeof PromiseRejectionEvent)&&e.then(r)instanceof t&&0!==k.indexOf("6.6")&&-1===b.indexOf("Chrome/66")}catch(e){}}(),O=function(e){var t;return!(!c(e)||"function"!=typeof(t=e.then))&&t},P=function(f,n){var r;f._n||(f._n=!0,r=f._c,h(function(){for(var o,u=f._v,c=1==f._s,e=0,t=function(e){var t,n,r,o,a=c?e.ok:e.fail,i=e.resolve,s=e.reject,l=e.domain;try{a?(c||(2==f._h&&(o=f,_.call(p,function(){var e;I?A.emit("rejectionHandled",o):(e=p.onrejectionhandled)&&e({promise:o,reason:o._v})})),f._h=1),!0===a?t=u:(l&&l.enter(),t=a(u),l&&(l.exit(),r=!0)),t===e.promise?s(j("Promise-chain cycle")):(n=O(t))?n.call(t,i,s):i(t)):s(u)}catch(e){l&&!r&&l.exit(),s(e)}};r.length>e;)t(r[e++]);f._c=[],f._n=!1,n&&!f._h&&(o=f,_.call(p,function(){var e,t,n=o._v,r=L(o);if(r&&(e=g(function(){I?A.emit("unhandledRejection",n,o):(t=p.onunhandledrejection)?t({promise:o,reason:n}):(t=p.console)&&t.error&&t.error("Unhandled promise rejection",n)}),o._h=I||L(o)?2:1),o._a=void 0,r&&e.e)throw e.v}))}))},L=function(e){return 1!==e._h&&0===(e._a||e._c).length},M=function(e){var t=this;
+         t._d||(t._d=!0,(t=t._w||t)._v=e,t._s=2,t._a||(t._a=t._c.slice()),P(t,!0))},T=function(e){var n,r=this;if(!r._d){r._d=!0,r=r._w||r;try{if(r===e)throw j("Promise can't be resolved itself");(n=O(e))?h(function(){var t={_w:r,_d:!1};try{n.call(e,l(T,t,1),l(M,t,1))}catch(e){M.call(t,e)}}):(r._v=e,r._s=1,P(r,!1))}catch(e){M.call({_w:r,_d:!1},e)}}};S||(E=function(e){d(this,E,w,"_h"),f(e),t.call(this);try{e(l(T,this,1),l(M,this,1))}catch(e){M.call(this,e)}},(t=function(e){this._c=[],this._a=void 0,this._s=0,this._d=!1,this._v=void 0,this._h=0,this._n=!1}).prototype=n("./_redefine-all")(E.prototype,{then:function(e,t){var n=C(y(this,E));return n.ok="function"!=typeof e||e,n.fail="function"==typeof t&&t,n.domain=I?A.domain:void 0,this._c.push(n),this._a&&this._a.push(n),this._s&&P(this,!1),n.promise},catch:function(e){return this.then(void 0,e)}}),a=function(){var e=new t;this.promise=e,this.resolve=l(T,e,1),this.reject=l(M,e,1)},m.f=C=function(e){return e===E||e===i?new a:o(e)}),u(u.G+u.W+u.F*!S,{Promise:E}),n("./_set-to-string-tag")(E,w),n("./_set-species")(w),i=n("./_core")[w],u(u.S+u.F*!S,w,{reject:function(e){var t=C(this);return(0,t.reject)(e),t.promise}}),u(u.S+u.F*(s||!S),w,{resolve:function(e){return x(s&&this===i?E:this,e)}}),u(u.S+u.F*!(S&&n("./_iter-detect")(function(e){E.all(e).catch(r)})),w,{all:function(e){var i=this,t=C(i),s=t.resolve,l=t.reject,n=g(function(){var r=[],o=0,a=1;v(e,!1,function(e){var t=o++,n=!1;r.push(void 0),a++,i.resolve(e).then(function(e){n||(n=!0,r[t]=e,--a||s(r))},l)}),--a||s(r)});return n.e&&l(n.v),t.promise},race:function(e){var t=this,n=C(t),r=n.reject,o=g(function(){v(e,!1,function(e){t.resolve(e).then(n.resolve,r)})});return o.e&&r(o.v),n.promise}})},{"./_a-function":3,"./_an-instance":7,"./_classof":18,"./_core":24,"./_ctx":26,"./_export":34,"./_for-of":40,"./_global":42,"./_is-object":53,"./_iter-detect":58,"./_library":61,"./_microtask":69,"./_new-promise-capability":70,"./_perform":89,"./_promise-resolve":90,"./_redefine-all":92,"./_set-species":101,"./_set-to-string-tag":102,"./_species-constructor":105,"./_task":114,"./_user-agent":126,"./_wks":130}],212:[function(e,t,n){var r=e("./_export"),o=e("./_a-function"),a=e("./_an-object"),i=(e("./_global").Reflect||{}).apply,s=Function.apply;r(r.S+r.F*!e("./_fails")(function(){i(function(){})}),"Reflect",{apply:function(e,t,n){e=o(e),n=a(n);return i?i(e,t,n):s.call(e,t,n)}})},{"./_a-function":3,"./_an-object":8,"./_export":34,"./_fails":36,"./_global":42}],213:[function(e,t,n){var r=e("./_export"),o=e("./_object-create"),a=e("./_a-function"),i=e("./_an-object"),s=e("./_is-object"),l=e("./_fails"),u=e("./_bind"),c=(e("./_global").Reflect||{}).construct,f=l(function(){function e(){}return!(c(function(){},[],e)instanceof e)}),p=!l(function(){c(function(){})});r(r.S+r.F*(f||p),"Reflect",{construct:function(e,t){a(e),i(t);var n=arguments.length<3?e:a(arguments[2]);if(p&&!f)return c(e,t,n);if(e==n){switch(t.length){case 0:return new e;case 1:return new e(t[0]);case 2:return new e(t[0],t[1]);case 3:return new e(t[0],t[1],t[2]);case 4:return new e(t[0],t[1],t[2],t[3])}var r=[null];return r.push.apply(r,t),new(u.apply(e,r))}r=n.prototype,n=o(s(r)?r:Object.prototype),r=Function.apply.call(e,n,t);return s(r)?r:n}})},{"./_a-function":3,"./_an-object":8,"./_bind":17,"./_export":34,"./_fails":36,"./_global":42,"./_is-object":53,"./_object-create":72}],214:[function(e,t,n){var r=e("./_object-dp"),o=e("./_export"),a=e("./_an-object"),i=e("./_to-primitive");o(o.S+o.F*e("./_fails")(function(){Reflect.defineProperty(r.f({},1,{value:1}),1,{value:2})}),"Reflect",{defineProperty:function(e,t,n){a(e),t=i(t,!0),a(n);try{return r.f(e,t,n),!0}catch(e){return!1}}})},{"./_an-object":8,"./_export":34,"./_fails":36,"./_object-dp":73,"./_to-primitive":121}],215:[function(e,t,n){var r=e("./_export"),o=e("./_object-gopd").f,a=e("./_an-object");r(r.S,"Reflect",{deleteProperty:function(e,t){var n=o(a(e),t);return!(n&&!n.configurable)&&delete e[t]}})},{"./_an-object":8,"./_export":34,"./_object-gopd":76}],216:[function(e,t,n){"use strict";function r(e){this._t=a(e),this._i=0;var t,n=this._k=[];for(t in e)n.push(t)}var o=e("./_export"),a=e("./_an-object");e("./_iter-create")(r,"Object",function(){var e,t=this._k;do{if(this._i>=t.length)return{value:void 0,done:!0}}while(!((e=t[this._i++])in this._t));return{value:e,done:!1}}),o(o.S,"Reflect",{enumerate:function(e){return new r(e)}})},{"./_an-object":8,"./_export":34,"./_iter-create":56}],217:[function(e,t,n){var r=e("./_object-gopd"),o=e("./_export"),a=e("./_an-object");o(o.S,"Reflect",{getOwnPropertyDescriptor:function(e,t){return r.f(a(e),t)}})},{"./_an-object":8,"./_export":34,"./_object-gopd":76}],218:[function(e,t,n){var r=e("./_export"),o=e("./_object-gpo"),a=e("./_an-object");r(r.S,"Reflect",{getPrototypeOf:function(e){return o(a(e))}})},{"./_an-object":8,"./_export":34,"./_object-gpo":80}],219:[function(e,t,n){var a=e("./_object-gopd"),i=e("./_object-gpo"),s=e("./_has"),r=e("./_export"),l=e("./_is-object"),u=e("./_an-object");r(r.S,"Reflect",{get:function e(t,n){var r,o=arguments.length<3?t:arguments[2];return u(t)===o?t[n]:(r=a.f(t,n))?s(r,"value")?r.value:void 0!==r.get?r.get.call(o):void 0:l(r=i(t))?e(r,n,o):void 0}})},{"./_an-object":8,"./_export":34,"./_has":43,"./_is-object":53,"./_object-gopd":76,"./_object-gpo":80}],220:[function(e,t,n){e=e("./_export");e(e.S,"Reflect",{has:function(e,t){return t in e}})},{"./_export":34}],221:[function(e,t,n){var r=e("./_export"),o=e("./_an-object"),a=Object.isExtensible;r(r.S,"Reflect",{isExtensible:function(e){return o(e),!a||a(e)}})},{"./_an-object":8,"./_export":34}],222:[function(e,t,n){var r=e("./_export");r(r.S,"Reflect",{ownKeys:e("./_own-keys")})},{"./_export":34,"./_own-keys":86}],223:[function(e,t,n){var r=e("./_export"),o=e("./_an-object"),a=Object.preventExtensions;r(r.S,"Reflect",{preventExtensions:function(e){o(e);try{return a&&a(e),!0}catch(e){return!1}}})},{"./_an-object":8,"./_export":34}],224:[function(e,t,n){var r=e("./_export"),o=e("./_set-proto");o&&r(r.S,"Reflect",{setPrototypeOf:function(e,t){o.check(e,t);try{return o.set(e,t),!0}catch(e){return!1}}})},{"./_export":34,"./_set-proto":100}],225:[function(e,t,n){var s=e("./_object-dp"),l=e("./_object-gopd"),u=e("./_object-gpo"),c=e("./_has"),r=e("./_export"),f=e("./_property-desc"),p=e("./_an-object"),d=e("./_is-object");r(r.S,"Reflect",{set:function e(t,n,r){var o,a=arguments.length<4?t:arguments[3],i=l.f(p(t),n);if(!i){if(d(o=u(t)))return e(o,n,r,a);i=f(0)}if(c(i,"value")){if(!1===i.writable||!d(a))return!1;if(o=l.f(a,n)){if(o.get||o.set||!1===o.writable)return!1;o.value=r,s.f(a,n,o)}else s.f(a,n,f(0,r));return!0}return void 0!==i.set&&(i.set.call(a,r),!0)}})},{"./_an-object":8,"./_export":34,"./_has":43,"./_is-object":53,"./_object-dp":73,"./_object-gopd":76,"./_object-gpo":80,"./_property-desc":91}],226:[function(e,t,n){var r=e("./_global"),a=e("./_inherit-if-required"),o=e("./_object-dp").f,i=e("./_object-gopn").f,s=e("./_is-regexp"),l=e("./_flags"),u=v=r.RegExp,c=v.prototype,f=/a/g,p=/a/g,d=new v(f)!==f;if(e("./_descriptors")&&(!d||e("./_fails")(function(){return p[e("./_wks")("match")]=!1,v(f)!=f||v(p)==p||"/a/i"!=v(f,"i")}))){for(var v=function(e,t){var n=this instanceof v,r=s(e),o=void 0===t;return!n&&r&&e.constructor===v&&o?e:a(d?new u(r&&!o?e.source:e,t):u((r=e instanceof v)?e.source:e,r&&o?l.call(e):t),n?this:c,v)},y=i(u),_=0;y.length>_;)!function(t){t in v||o(v,t,{configurable:!0,get:function(){return u[t]},set:function(e){u[t]=e}})}(y[_++]);(c.constructor=v).prototype=c,e("./_redefine")(r,"RegExp",v)}e("./_set-species")("RegExp")},{"./_descriptors":30,"./_fails":36,"./_flags":38,"./_global":42,"./_inherit-if-required":47,"./_is-regexp":54,"./_object-dp":73,"./_object-gopn":78,"./_redefine":93,"./_set-species":101,"./_wks":130}],227:[function(e,t,n){"use strict";var r=e("./_regexp-exec");e("./_export")({target:"RegExp",proto:!0,forced:r!==/./.exec},{exec:r})},{"./_export":34,"./_regexp-exec":95}],228:[function(e,t,n){e("./_descriptors")&&"g"!=/./g.flags&&e("./_object-dp").f(RegExp.prototype,"flags",{configurable:!0,get:e("./_flags")})},{"./_descriptors":30,"./_flags":38,"./_object-dp":73}],229:[function(e,t,n){"use strict";var c=e("./_an-object"),f=e("./_to-length"),p=e("./_advance-string-index"),d=e("./_regexp-exec-abstract");e("./_fix-re-wks")("match",1,function(r,o,l,u){return[function(e){var t=r(this),n=null==e?void 0:e[o];return void 0!==n?n.call(e,t):new RegExp(e)[o](String(t))},function(e){var t=u(l,e,this);if(t.done)return t.value;var n=c(e),r=String(this);if(!n.global)return d(n,r);for(var o=n.unicode,a=[],i=n.lastIndex=0;null!==(s=d(n,r));){var s=String(s[0]);""===(a[i]=s)&&(n.lastIndex=p(r,f(n.lastIndex),o)),i++}return 0===i?null:a}]})},{"./_advance-string-index":6,"./_an-object":8,"./_fix-re-wks":37,"./_regexp-exec-abstract":94,"./_to-length":119}],230:[function(e,t,n){"use strict";var w=e("./_an-object"),j=e("./_to-object"),A=e("./_to-length"),S=e("./_to-integer"),k=e("./_advance-string-index"),E=e("./_regexp-exec-abstract"),I=Math.max,C=Math.min,O=Math.floor,P=/\$([$&`']|\d\d?|<[^>]*>)/g,L=/\$([$&`']|\d\d?)/g;e("./_fix-re-wks")("replace",2,function(o,a,b,x){return[function(e,t){var n=o(this),r=null==e?void 0:e[a];return void 0!==r?r.call(e,n,t):b.call(String(n),e,t)},function(e,t){var n=x(b,e,this,t);if(n.done)return n.value;for(var r,o=w(e),a=String(this),i="function"==typeof t,s=(i||(t=String(t)),o.global),l=(s&&(r=o.unicode,o.lastIndex=0),[]);null!==(d=E(o,a))&&(l.push(d),s);)""===String(d[0])&&(o.lastIndex=k(a,A(o.lastIndex),r));for(var u,c="",f=0,p=0;p<l.length;p++){for(var d=l[p],v=String(d[0]),y=I(C(S(d.index),a.length),0),_=[],h=1;h<d.length;h++)_.push(void 0===(u=d[h])?u:String(u));var m=d.groups,g=i?(g=[v].concat(_,y,a),void 0!==m&&g.push(m),String(t.apply(void 0,g))):function(a,i,s,l,u,e){var c=s+a.length,f=l.length,t=L;void 0!==u&&(u=j(u),t=P);return b.call(e,t,function(e,t){var n;switch(t.charAt(0)){case"$":return"$";case"&":return a;case"`":return i.slice(0,s);case"'":return i.slice(c);case"<":n=u[t.slice(1,-1)];break;default:var r,o=+t;if(0==o)return e;if(f<o)return 0!==(r=O(o/10))&&r<=f?void 0===l[r-1]?t.charAt(1):l[r-1]+t.charAt(1):e;n=l[o-1]}return void 0===n?"":n})}(v,a,y,_,m,t);f<=y&&(c+=a.slice(f,y)+g,f=y+v.length)}return c+a.slice(f)}]})},{"./_advance-string-index":6,"./_an-object":8,"./_fix-re-wks":37,"./_regexp-exec-abstract":94,"./_to-integer":117,"./_to-length":119,"./_to-object":120}],231:[function(e,t,n){"use strict";var s=e("./_an-object"),l=e("./_same-value"),u=e("./_regexp-exec-abstract");e("./_fix-re-wks")("search",1,function(r,o,a,i){return[function(e){var t=r(this),n=null==e?void 0:e[o];return void 0!==n?n.call(e,t):new RegExp(e)[o](String(t))},function(e){var t=i(a,e,this);if(t.done)return t.value;var t=s(e),e=String(this),n=t.lastIndex,e=(l(n,0)||(t.lastIndex=0),u(t,e));return l(t.lastIndex,n)||(t.lastIndex=n),null===e?-1:e.index}]})},{"./_an-object":8,"./_fix-re-wks":37,"./_regexp-exec-abstract":94,"./_same-value":97}],232:[function(e,t,n){"use strict";var f=e("./_is-regexp"),h=e("./_an-object"),m=e("./_species-constructor"),g=e("./_advance-string-index"),b=e("./_to-length"),x=e("./_regexp-exec-abstract"),p=e("./_regexp-exec"),r=e("./_fails"),w=Math.min,d=[].push,i="split",j="length",A="lastIndex",S=4294967295,k=!r(function(){RegExp(S,"y")});e("./_fix-re-wks")("split",2,function(o,a,v,y){var _="c"=="abbc"[i](/(b)*/)[1]||4!="test"[i](/(?:)/,-1)[j]||2!="ab"[i](/(?:ab)*/)[j]||4!="."[i](/(.?)(.?)/)[j]||1<"."[i](/()()/)[j]||""[i](/.?/)[j]?function(e,t){var n=String(this);if(void 0===e&&0===t)return[];if(!f(e))return v.call(n,e,t);for(var r,o,a,i=[],s=(e.ignoreCase?"i":"")+(e.multiline?"m":"")+(e.unicode?"u":"")+(e.sticky?"y":""),l=0,u=void 0===t?S:t>>>0,c=new RegExp(e.source,s+"g");(r=p.call(c,n))&&!(l<(o=c[A])&&(i.push(n.slice(l,r.index)),1<r[j]&&r.index<n[j]&&d.apply(i,r.slice(1)),a=r[0][j],l=o,i[j]>=u));)c[A]===r.index&&c[A]++;return l===n[j]?!a&&c.test("")||i.push(""):i.push(n.slice(l)),i[j]>u?i.slice(0,u):i}:"0"[i](void 0,0)[j]?function(e,t){return void 0===e&&0===t?[]:v.call(this,e,t)}:v;return[function(e,t){var n=o(this),r=null==e?void 0:e[a];return void 0!==r?r.call(e,n,t):_.call(String(n),e,t)},function(e,t){var n=y(_,e,this,t,_!==v);if(n.done)return n.value;var n=h(e),r=String(this),e=m(n,RegExp),o=n.unicode,a=(n.ignoreCase?"i":"")+(n.multiline?"m":"")+(n.unicode?"u":"")+(k?"y":"g"),i=new e(k?n:"^(?:"+n.source+")",a),s=void 0===t?S:t>>>0;if(0==s)return[];if(0===r.length)return null===x(i,r)?[r]:[];for(var l=0,u=0,c=[];u<r.length;){i.lastIndex=k?u:0;var f,p=x(i,k?r:r.slice(u));if(null===p||(f=w(b(i.lastIndex+(k?0:u)),r.length))===l)u=g(r,u,o);else{if(c.push(r.slice(l,u)),c.length===s)return c;for(var d=1;d<=p.length-1;d++)if(c.push(p[d]),c.length===s)return c;u=l=f}}return c.push(r.slice(l)),c}]})},{"./_advance-string-index":6,"./_an-object":8,"./_fails":36,"./_fix-re-wks":37,"./_is-regexp":54,"./_regexp-exec":95,"./_regexp-exec-abstract":94,"./_species-constructor":105,"./_to-length":119}],233:[function(t,e,n){"use strict";t("./es6.regexp.flags");function r(e){t("./_redefine")(RegExp.prototype,s,e,!0)}var o=t("./_an-object"),a=t("./_flags"),i=t("./_descriptors"),s="toString",l=/./[s];t("./_fails")(function(){return"/a/b"!=l.call({source:"a",flags:"b"})})?r(function(){var e=o(this);return"/".concat(e.source,"/","flags"in e?e.flags:!i&&e instanceof RegExp?a.call(e):void 0)}):l.name!=s&&r(function(){return l.call(this)})},{"./_an-object":8,"./_descriptors":30,"./_fails":36,"./_flags":38,"./_redefine":93,"./es6.regexp.flags":228}],234:[function(e,t,n){"use strict";var r=e("./_collection-strong"),o=e("./_validate-collection");t.exports=e("./_collection")("Set",function(e){return function(){return e(this,0<arguments.length?arguments[0]:void 0)}},{add:function(e){return r.def(o(this,"Set"),e=0===e?0:e,e)}},r)},{"./_collection":23,"./_collection-strong":20,"./_validate-collection":127}],235:[function(e,t,n){"use strict";e("./_string-html")("anchor",function(t){return function(e){return t(this,"a","name",e)}})},{"./_string-html":109}],236:[function(e,t,n){"use strict";e("./_string-html")("big",function(e){return function(){return e(this,"big","","")}})},{"./_string-html":109}],237:[function(e,t,n){"use strict";e("./_string-html")("blink",function(e){return function(){return e(this,"blink","","")}})},{"./_string-html":109}],238:[function(e,t,n){"use strict";e("./_string-html")("bold",function(e){return function(){return e(this,"b","","")}})},{"./_string-html":109}],239:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_string-at")(!1);r(r.P,"String",{codePointAt:function(e){return o(this,e)}})},{"./_export":34,"./_string-at":107}],240:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-length"),a=e("./_string-context"),i="endsWith",s=""[i];r(r.P+r.F*e("./_fails-is-regexp")(i),"String",{endsWith:function(e){var t=a(this,e,i),n=1<arguments.length?arguments[1]:void 0,r=o(t.length),n=void 0===n?r:Math.min(o(n),r),r=String(e)
+         return s?s.call(t,r,n):t.slice(n-r.length,n)===r}})},{"./_export":34,"./_fails-is-regexp":35,"./_string-context":108,"./_to-length":119}],241:[function(e,t,n){"use strict";e("./_string-html")("fixed",function(e){return function(){return e(this,"tt","","")}})},{"./_string-html":109}],242:[function(e,t,n){"use strict";e("./_string-html")("fontcolor",function(t){return function(e){return t(this,"font","color",e)}})},{"./_string-html":109}],243:[function(e,t,n){"use strict";e("./_string-html")("fontsize",function(t){return function(e){return t(this,"font","size",e)}})},{"./_string-html":109}],244:[function(e,t,n){var r=e("./_export"),a=e("./_to-absolute-index"),i=String.fromCharCode,e=String.fromCodePoint;r(r.S+r.F*(!!e&&1!=e.length),"String",{fromCodePoint:function(e){for(var t,n=[],r=arguments.length,o=0;o<r;){if(t=+arguments[o++],a(t,1114111)!==t)throw RangeError(t+" is not a valid code point");n.push(t<65536?i(t):i(55296+((t-=65536)>>10),t%1024+56320))}return n.join("")}})},{"./_export":34,"./_to-absolute-index":115}],245:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_string-context"),a="includes";r(r.P+r.F*e("./_fails-is-regexp")(a),"String",{includes:function(e){return!!~o(this,e,a).indexOf(e,1<arguments.length?arguments[1]:void 0)}})},{"./_export":34,"./_fails-is-regexp":35,"./_string-context":108}],246:[function(e,t,n){"use strict";e("./_string-html")("italics",function(e){return function(){return e(this,"i","","")}})},{"./_string-html":109}],247:[function(e,t,n){"use strict";var r=e("./_string-at")(!0);e("./_iter-define")(String,"String",function(e){this._t=String(e),this._i=0},function(){var e=this._t,t=this._i;return t>=e.length?{value:void 0,done:!0}:(e=r(e,t),this._i+=e.length,{value:e,done:!1})})},{"./_iter-define":57,"./_string-at":107}],248:[function(e,t,n){"use strict";e("./_string-html")("link",function(t){return function(e){return t(this,"a","href",e)}})},{"./_string-html":109}],249:[function(e,t,n){var r=e("./_export"),i=e("./_to-iobject"),s=e("./_to-length");r(r.S,"String",{raw:function(e){for(var t=i(e.raw),n=s(t.length),r=arguments.length,o=[],a=0;a<n;)o.push(String(t[a++])),a<r&&o.push(String(arguments[a]));return o.join("")}})},{"./_export":34,"./_to-iobject":118,"./_to-length":119}],250:[function(e,t,n){var r=e("./_export");r(r.P,"String",{repeat:e("./_string-repeat")})},{"./_export":34,"./_string-repeat":111}],251:[function(e,t,n){"use strict";e("./_string-html")("small",function(e){return function(){return e(this,"small","","")}})},{"./_string-html":109}],252:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-length"),a=e("./_string-context"),i="startsWith",s=""[i];r(r.P+r.F*e("./_fails-is-regexp")(i),"String",{startsWith:function(e){var t=a(this,e,i),n=o(Math.min(1<arguments.length?arguments[1]:void 0,t.length)),e=String(e);return s?s.call(t,e,n):t.slice(n,n+e.length)===e}})},{"./_export":34,"./_fails-is-regexp":35,"./_string-context":108,"./_to-length":119}],253:[function(e,t,n){"use strict";e("./_string-html")("strike",function(e){return function(){return e(this,"strike","","")}})},{"./_string-html":109}],254:[function(e,t,n){"use strict";e("./_string-html")("sub",function(e){return function(){return e(this,"sub","","")}})},{"./_string-html":109}],255:[function(e,t,n){"use strict";e("./_string-html")("sup",function(e){return function(){return e(this,"sup","","")}})},{"./_string-html":109}],256:[function(e,t,n){"use strict";e("./_string-trim")("trim",function(e){return function(){return e(this,3)}})},{"./_string-trim":112}],257:[function(e,N,D){"use strict";function r(e){var t=I[e]=g(w[S]);return t._k=e,t}function n(e,t){y(e);for(var n,r=B(t=_(t)),o=0,a=r.length;o<a;)R(e,n=r[o++],t[n]);return e}function t(e){var t=ee.call(this,e=h(e,!0));return!(this===O&&l(I,e)&&!l(C,e))&&(!(t||!l(this,e)||!l(I,e)||l(this,k)&&this[k][e])||t)}function o(e,t){var n;if(e=_(e),t=h(t,!0),e!==O||!l(I,t)||l(C,t))return!(n=J(e,t))||!l(I,t)||l(e,k)&&e[k][t]||(n.enumerable=!0),n}function a(e){for(var t,n=Z(_(e)),r=[],o=0;n.length>o;)l(I,t=n[o++])||t==k||t==H||r.push(t);return r}function i(e){for(var t,n=e===O,r=Z(n?C:_(e)),o=[],a=0;r.length>a;)!l(I,t=r[a++])||n&&!l(O,t)||o.push(I[t]);return o}var s=e("./_global"),l=e("./_has"),u=e("./_descriptors"),c=e("./_export"),F=e("./_redefine"),H=e("./_meta").KEY,f=e("./_fails"),p=e("./_shared"),d=e("./_set-to-string-tag"),G=e("./_uid"),v=e("./_wks"),U=e("./_wks-ext"),W=e("./_wks-define"),B=e("./_enum-keys"),Y=e("./_is-array"),y=e("./_an-object"),z=e("./_is-object"),q=e("./_to-object"),_=e("./_to-iobject"),h=e("./_to-primitive"),m=e("./_property-desc"),g=e("./_object-create"),X=e("./_object-gopn-ext"),V=e("./_object-gopd"),b=e("./_object-gops"),K=e("./_object-dp"),Q=e("./_object-keys"),J=V.f,x=K.f,Z=X.f,w=s.Symbol,j=s.JSON,A=j&&j.stringify,S="prototype",k=v("_hidden"),$=v("toPrimitive"),ee={}.propertyIsEnumerable,E=p("symbol-registry"),I=p("symbols"),C=p("op-symbols"),O=Object[S],p="function"==typeof w&&!!b.f,P=s.QObject,L=!P||!P[S]||!P[S].findChild,M=u&&f(function(){return 7!=g(x({},"a",{get:function(){return x(this,"a",{value:7}).a}})).a})?function(e,t,n){var r=J(O,t);r&&delete O[t],x(e,t,n),r&&e!==O&&x(O,t,r)}:x,T=p&&"symbol"==typeof w.iterator?function(e){return"symbol"==typeof e}:function(e){return e instanceof w},R=function(e,t,n){return e===O&&R(C,t,n),y(e),t=h(t,!0),y(n),l(I,t)?(n.enumerable?(l(e,k)&&e[k][t]&&(e[k][t]=!1),n=g(n,{enumerable:m(0,!1)})):(l(e,k)||x(e,k,m(1,{})),e[k][t]=!0),M(e,t,n)):x(e,t,n)};p||(F((w=function(){if(this instanceof w)throw TypeError("Symbol is not a constructor!");var t=G(0<arguments.length?arguments[0]:void 0),n=function(e){this===O&&n.call(C,e),l(this,k)&&l(this[k],t)&&(this[k][t]=!1),M(this,t,m(1,e))};return u&&L&&M(O,t,{configurable:!0,set:n}),r(t)})[S],"toString",function(){return this._k}),V.f=o,K.f=R,e("./_object-gopn").f=X.f=a,e("./_object-pie").f=t,b.f=i,u&&!e("./_library")&&F(O,"propertyIsEnumerable",t,!0),U.f=function(e){return r(v(e))}),c(c.G+c.W+c.F*!p,{Symbol:w});for(var te="hasInstance,isConcatSpreadable,iterator,match,replace,search,species,split,toPrimitive,toStringTag,unscopables".split(","),ne=0;te.length>ne;)v(te[ne++]);for(var re=Q(v.store),oe=0;re.length>oe;)W(re[oe++]);c(c.S+c.F*!p,"Symbol",{for:function(e){return l(E,e+="")?E[e]:E[e]=w(e)},keyFor:function(e){if(!T(e))throw TypeError(e+" is not a symbol!");for(var t in E)if(E[t]===e)return t},useSetter:function(){L=!0},useSimple:function(){L=!1}}),c(c.S+c.F*!p,"Object",{create:function(e,t){return void 0===t?g(e):n(g(e),t)},defineProperty:R,defineProperties:n,getOwnPropertyDescriptor:o,getOwnPropertyNames:a,getOwnPropertySymbols:i});P=f(function(){b.f(1)});c(c.S+c.F*P,"Object",{getOwnPropertySymbols:function(e){return b.f(q(e))}}),j&&c(c.S+c.F*(!p||f(function(){var e=w();return"[null]"!=A([e])||"{}"!=A({a:e})||"{}"!=A(Object(e))})),"JSON",{stringify:function(e){for(var t,n,r=[e],o=1;o<arguments.length;)r.push(arguments[o++]);if(n=t=r[1],(z(t)||void 0!==e)&&!T(e))return Y(t)||(t=function(e,t){if("function"==typeof n&&(t=n.call(this,e,t)),!T(t))return t}),r[1]=t,A.apply(j,r)}}),w[S][$]||e("./_hide")(w[S],$,w[S].valueOf),d(w,"Symbol"),d(Math,"Math",!0),d(s.JSON,"JSON",!0)},{"./_an-object":8,"./_descriptors":30,"./_enum-keys":33,"./_export":34,"./_fails":36,"./_global":42,"./_has":43,"./_hide":44,"./_is-array":51,"./_is-object":53,"./_library":61,"./_meta":67,"./_object-create":72,"./_object-dp":73,"./_object-gopd":76,"./_object-gopn":78,"./_object-gopn-ext":77,"./_object-gops":79,"./_object-keys":82,"./_object-pie":83,"./_property-desc":91,"./_redefine":93,"./_set-to-string-tag":102,"./_shared":104,"./_to-iobject":118,"./_to-object":120,"./_to-primitive":121,"./_uid":125,"./_wks":130,"./_wks-define":128,"./_wks-ext":129}],258:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_typed"),a=e("./_typed-buffer"),l=e("./_an-object"),u=e("./_to-absolute-index"),c=e("./_to-length"),i=e("./_is-object"),s=e("./_global").ArrayBuffer,f=e("./_species-constructor"),p=a.ArrayBuffer,d=a.DataView,v=o.ABV&&s.isView,y=p.prototype.slice,_=o.VIEW,a="ArrayBuffer";r(r.G+r.W+r.F*(s!==p),{ArrayBuffer:p}),r(r.S+r.F*!o.CONSTR,a,{isView:function(e){return v&&v(e)||i(e)&&_ in e}}),r(r.P+r.U+r.F*e("./_fails")(function(){return!new p(2).slice(1,void 0).byteLength}),a,{slice:function(e,t){if(void 0!==y&&void 0===t)return y.call(l(this),e);for(var n=l(this).byteLength,r=u(e,n),o=u(void 0===t?n:t,n),e=new(f(this,p))(c(o-r)),a=new d(this),i=new d(e),s=0;r<o;)i.setUint8(s++,a.getUint8(r++));return e}}),e("./_set-species")(a)},{"./_an-object":8,"./_export":34,"./_fails":36,"./_global":42,"./_is-object":53,"./_set-species":101,"./_species-constructor":105,"./_to-absolute-index":115,"./_to-length":119,"./_typed":124,"./_typed-buffer":123}],259:[function(e,t,n){var r=e("./_export");r(r.G+r.W+r.F*!e("./_typed").ABV,{DataView:e("./_typed-buffer").DataView})},{"./_export":34,"./_typed":124,"./_typed-buffer":123}],260:[function(e,t,n){e("./_typed-array")("Float32",4,function(r){return function(e,t,n){return r(this,e,t,n)}})},{"./_typed-array":122}],261:[function(e,t,n){e("./_typed-array")("Float64",8,function(r){return function(e,t,n){return r(this,e,t,n)}})},{"./_typed-array":122}],262:[function(e,t,n){e("./_typed-array")("Int16",2,function(r){return function(e,t,n){return r(this,e,t,n)}})},{"./_typed-array":122}],263:[function(e,t,n){e("./_typed-array")("Int32",4,function(r){return function(e,t,n){return r(this,e,t,n)}})},{"./_typed-array":122}],264:[function(e,t,n){e("./_typed-array")("Int8",1,function(r){return function(e,t,n){return r(this,e,t,n)}})},{"./_typed-array":122}],265:[function(e,t,n){e("./_typed-array")("Uint16",2,function(r){return function(e,t,n){return r(this,e,t,n)}})},{"./_typed-array":122}],266:[function(e,t,n){e("./_typed-array")("Uint32",4,function(r){return function(e,t,n){return r(this,e,t,n)}})},{"./_typed-array":122}],267:[function(e,t,n){e("./_typed-array")("Uint8",1,function(r){return function(e,t,n){return r(this,e,t,n)}})},{"./_typed-array":122}],268:[function(e,t,n){e("./_typed-array")("Uint8",1,function(r){return function(e,t,n){return r(this,e,t,n)}},!0)},{"./_typed-array":122}],269:[function(e,t,n){"use strict";function r(e){return function(){return e(this,0<arguments.length?arguments[0]:void 0)}}var a,o=e("./_global"),i=e("./_array-methods")(0),s=e("./_redefine"),l=e("./_meta"),u=e("./_object-assign"),c=e("./_collection-weak"),f=e("./_is-object"),p=e("./_validate-collection"),d=e("./_validate-collection"),o=!o.ActiveXObject&&"ActiveXObject"in o,v="WeakMap",y=l.getWeak,_=Object.isExtensible,h=c.ufstore,m={get:function(e){var t;if(f(e))return!0===(t=y(e))?h(p(this,v)).get(e):t?t[this._i]:void 0},set:function(e,t){return c.def(p(this,v),e,t)}},g=t.exports=e("./_collection")(v,r,m,c,!0,!0);d&&o&&(u((a=c.getConstructor(r,v)).prototype,m),l.NEED=!0,i(["delete","has","get","set"],function(r){var e=g.prototype,o=e[r];s(e,r,function(e,t){var n;return f(e)&&!_(e)?(this._f||(this._f=new a),n=this._f[r](e,t),"set"==r?this:n):o.call(this,e,t)})}))},{"./_array-methods":13,"./_collection":23,"./_collection-weak":22,"./_global":42,"./_is-object":53,"./_meta":67,"./_object-assign":71,"./_redefine":93,"./_validate-collection":127}],270:[function(e,t,n){"use strict";var r=e("./_collection-weak"),o=e("./_validate-collection"),a="WeakSet";e("./_collection")(a,function(e){return function(){return e(this,0<arguments.length?arguments[0]:void 0)}},{add:function(e){return r.def(o(this,a),e,!0)}},r,!1,!0)},{"./_collection":23,"./_collection-weak":22,"./_validate-collection":127}],271:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_flatten-into-array"),a=e("./_to-object"),i=e("./_to-length"),s=e("./_a-function"),l=e("./_array-species-create");r(r.P,"Array",{flatMap:function(e){var t,n,r=a(this);return s(e),t=i(r.length),n=l(r,0),o(n,r,r,t,0,1,e,arguments[1]),n}}),e("./_add-to-unscopables")("flatMap")},{"./_a-function":3,"./_add-to-unscopables":5,"./_array-species-create":16,"./_export":34,"./_flatten-into-array":39,"./_to-length":119,"./_to-object":120}],272:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_flatten-into-array"),a=e("./_to-object"),i=e("./_to-length"),s=e("./_to-integer"),l=e("./_array-species-create");r(r.P,"Array",{flatten:function(){var e=arguments[0],t=a(this),n=i(t.length),r=l(t,0);return o(r,t,t,n,0,void 0===e?1:s(e)),r}}),e("./_add-to-unscopables")("flatten")},{"./_add-to-unscopables":5,"./_array-species-create":16,"./_export":34,"./_flatten-into-array":39,"./_to-integer":117,"./_to-length":119,"./_to-object":120}],273:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_array-includes")(!0);r(r.P,"Array",{includes:function(e){return o(this,e,1<arguments.length?arguments[1]:void 0)}}),e("./_add-to-unscopables")("includes")},{"./_add-to-unscopables":5,"./_array-includes":12,"./_export":34}],274:[function(e,t,n){var r=e("./_export"),o=e("./_microtask")(),a=e("./_global").process,i="process"==e("./_cof")(a);r(r.G,{asap:function(e){var t=i&&a.domain;o(t?t.bind(e):e)}})},{"./_cof":19,"./_export":34,"./_global":42,"./_microtask":69}],275:[function(e,t,n){var r=e("./_export"),o=e("./_cof");r(r.S,"Error",{isError:function(e){return"Error"===o(e)}})},{"./_cof":19,"./_export":34}],276:[function(e,t,n){var r=e("./_export");r(r.G,{global:e("./_global")})},{"./_export":34,"./_global":42}],277:[function(e,t,n){e("./_set-collection-from")("Map")},{"./_set-collection-from":98}],278:[function(e,t,n){e("./_set-collection-of")("Map")},{"./_set-collection-of":99}],279:[function(e,t,n){var r=e("./_export");r(r.P+r.R,"Map",{toJSON:e("./_collection-to-json")("Map")})},{"./_collection-to-json":21,"./_export":34}],280:[function(e,t,n){e=e("./_export");e(e.S,"Math",{clamp:function(e,t,n){return Math.min(n,Math.max(t,e))}})},{"./_export":34}],281:[function(e,t,n){e=e("./_export");e(e.S,"Math",{DEG_PER_RAD:Math.PI/180})},{"./_export":34}],282:[function(e,t,n){var e=e("./_export"),r=180/Math.PI;e(e.S,"Math",{degrees:function(e){return e*r}})},{"./_export":34}],283:[function(e,t,n){var r=e("./_export"),a=e("./_math-scale"),i=e("./_math-fround");r(r.S,"Math",{fscale:function(e,t,n,r,o){return i(a(e,t,n,r,o))}})},{"./_export":34,"./_math-fround":63,"./_math-scale":65}],284:[function(e,t,n){e=e("./_export");e(e.S,"Math",{iaddh:function(e,t,n,r){e>>>=0,n>>>=0;return(t>>>0)+(r>>>0)+((e&n|(e|n)&~(e+n>>>0))>>>31)|0}})},{"./_export":34}],285:[function(e,t,n){e=e("./_export");e(e.S,"Math",{imulh:function(e,t){var e=+e,t=+t,n=65535&e,r=65535&t,e=e>>16,t=t>>16,r=(e*r>>>0)+(n*r>>>16);return e*t+(r>>16)+((n*t>>>0)+(65535&r)>>16)}})},{"./_export":34}],286:[function(e,t,n){e=e("./_export");e(e.S,"Math",{isubh:function(e,t,n,r){e>>>=0,n>>>=0;return(t>>>0)-(r>>>0)-((~e&n|~(e^n)&e-n>>>0)>>>31)|0}})},{"./_export":34}],287:[function(e,t,n){e=e("./_export");e(e.S,"Math",{RAD_PER_DEG:180/Math.PI})},{"./_export":34}],288:[function(e,t,n){var e=e("./_export"),r=Math.PI/180;e(e.S,"Math",{radians:function(e){return e*r}})},{"./_export":34}],289:[function(e,t,n){var r=e(
+         "./_export");r(r.S,"Math",{scale:e("./_math-scale")})},{"./_export":34,"./_math-scale":65}],290:[function(e,t,n){e=e("./_export");e(e.S,"Math",{signbit:function(e){return(e=+e)!=e?e:0==e?1/e==1/0:0<e}})},{"./_export":34}],291:[function(e,t,n){e=e("./_export");e(e.S,"Math",{umulh:function(e,t){var e=+e,t=+t,n=65535&e,r=65535&t,e=e>>>16,t=t>>>16,r=(e*r>>>0)+(n*r>>>16);return e*t+(r>>>16)+((n*t>>>0)+(65535&r)>>>16)}})},{"./_export":34}],292:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-object"),a=e("./_a-function"),i=e("./_object-dp");e("./_descriptors")&&r(r.P+e("./_object-forced-pam"),"Object",{__defineGetter__:function(e,t){i.f(o(this),e,{get:a(t),enumerable:!0,configurable:!0})}})},{"./_a-function":3,"./_descriptors":30,"./_export":34,"./_object-dp":73,"./_object-forced-pam":75,"./_to-object":120}],293:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-object"),a=e("./_a-function"),i=e("./_object-dp");e("./_descriptors")&&r(r.P+e("./_object-forced-pam"),"Object",{__defineSetter__:function(e,t){i.f(o(this),e,{set:a(t),enumerable:!0,configurable:!0})}})},{"./_a-function":3,"./_descriptors":30,"./_export":34,"./_object-dp":73,"./_object-forced-pam":75,"./_to-object":120}],294:[function(e,t,n){var r=e("./_export"),o=e("./_object-to-array")(!0);r(r.S,"Object",{entries:function(e){return o(e)}})},{"./_export":34,"./_object-to-array":85}],295:[function(e,t,n){var r=e("./_export"),l=e("./_own-keys"),u=e("./_to-iobject"),c=e("./_object-gopd"),f=e("./_create-property");r(r.S,"Object",{getOwnPropertyDescriptors:function(e){for(var t,n,r=u(e),o=c.f,a=l(r),i={},s=0;a.length>s;)void 0!==(n=o(r,t=a[s++]))&&f(i,t,n);return i}})},{"./_create-property":25,"./_export":34,"./_object-gopd":76,"./_own-keys":86,"./_to-iobject":118}],296:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-object"),a=e("./_to-primitive"),i=e("./_object-gpo"),s=e("./_object-gopd").f;e("./_descriptors")&&r(r.P+e("./_object-forced-pam"),"Object",{__lookupGetter__:function(e){var t,n=o(this),r=a(e,!0);do{if(t=s(n,r))return t.get}while(n=i(n))}})},{"./_descriptors":30,"./_export":34,"./_object-forced-pam":75,"./_object-gopd":76,"./_object-gpo":80,"./_to-object":120,"./_to-primitive":121}],297:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_to-object"),a=e("./_to-primitive"),i=e("./_object-gpo"),s=e("./_object-gopd").f;e("./_descriptors")&&r(r.P+e("./_object-forced-pam"),"Object",{__lookupSetter__:function(e){var t,n=o(this),r=a(e,!0);do{if(t=s(n,r))return t.set}while(n=i(n))}})},{"./_descriptors":30,"./_export":34,"./_object-forced-pam":75,"./_object-gopd":76,"./_object-gpo":80,"./_to-object":120,"./_to-primitive":121}],298:[function(e,t,n){var r=e("./_export"),o=e("./_object-to-array")(!1);r(r.S,"Object",{values:function(e){return o(e)}})},{"./_export":34,"./_object-to-array":85}],299:[function(e,t,n){"use strict";function o(e){return null==e?void 0:d(e)}function a(e){var t=e._c;t&&(e._c=void 0,t())}function i(e){return void 0===e._o}function s(e){i(e)||(e._o=void 0,a(e))}function r(t,e){v(t),this._c=void 0,this._o=t,t=new b(this);try{var n=e(t),r=n;null!=n&&("function"==typeof n.unsubscribe?n=function(){r.unsubscribe()}:d(n),this._c=n)}catch(e){return void t.error(e)}i(this)&&a(this)}var l=e("./_export"),u=e("./_global"),c=e("./_core"),f=e("./_microtask")(),p=e("./_wks")("observable"),d=e("./_a-function"),v=e("./_an-object"),y=e("./_an-instance"),_=e("./_redefine-all"),h=e("./_hide"),m=e("./_for-of"),g=m.RETURN,b=(r.prototype=_({},{unsubscribe:function(){s(this)}}),function(e){this._s=e}),x=(b.prototype=_({},{next:function(e){var t=this._s;if(!i(t)){var n=t._o;try{var r=o(n.next);if(r)return r.call(n,e)}catch(e){try{s(t)}finally{throw e}}}},error:function(e){var t=this._s;if(i(t))throw e;var n=t._o;t._o=void 0;try{var r=o(n.error);if(!r)throw e;e=r.call(n,e)}catch(e){try{a(t)}finally{throw e}}return a(t),e},complete:function(e){var t=this._s;if(!i(t)){var n=t._o;t._o=void 0;try{var r=o(n.complete);e=r?r.call(n,e):void 0}catch(e){try{a(t)}finally{throw e}}return a(t),e}}}),function(e){y(this,x,"Observable","_f")._f=d(e)});_(x.prototype,{subscribe:function(e){return new r(e,this._f)},forEach:function(r){var o=this;return new(c.Promise||u.Promise)(function(e,t){d(r);var n=o.subscribe({next:function(e){try{return r(e)}catch(e){t(e),n.unsubscribe()}},error:t,complete:e})})}}),_(x,{from:function(e){var t,n="function"==typeof this?this:x,r=o(v(e)[p]);return r?(t=v(r.call(e))).constructor===n?t:new n(function(e){return t.subscribe(e)}):new n(function(t){var n=!1;return f(function(){if(!n){try{if(m(e,!1,function(e){if(t.next(e),n)return g})===g)return}catch(e){if(n)throw e;return void t.error(e)}t.complete()}}),function(){n=!0}})},of:function(){for(var e=0,t=arguments.length,r=new Array(t);e<t;)r[e]=arguments[e++];return new("function"==typeof this?this:x)(function(t){var n=!1;return f(function(){if(!n){for(var e=0;e<r.length;++e)if(t.next(r[e]),n)return;t.complete()}}),function(){n=!0}})}}),h(x.prototype,p,function(){return this}),l(l.G,{Observable:x}),e("./_set-species")("Observable")},{"./_a-function":3,"./_an-instance":7,"./_an-object":8,"./_core":24,"./_export":34,"./_for-of":40,"./_global":42,"./_hide":44,"./_microtask":69,"./_redefine-all":92,"./_set-species":101,"./_wks":130}],300:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_core"),a=e("./_global"),i=e("./_species-constructor"),s=e("./_promise-resolve");r(r.P+r.R,"Promise",{finally:function(t){var n=i(this,o.Promise||a.Promise),e="function"==typeof t;return this.then(e?function(e){return s(n,t()).then(function(){return e})}:t,e?function(e){return s(n,t()).then(function(){throw e})}:t)}})},{"./_core":24,"./_export":34,"./_global":42,"./_promise-resolve":90,"./_species-constructor":105}],301:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_new-promise-capability"),a=e("./_perform");r(r.S,"Promise",{try:function(e){var t=o.f(this),e=a(e);return(e.e?t.reject:t.resolve)(e.v),t.promise}})},{"./_export":34,"./_new-promise-capability":70,"./_perform":89}],302:[function(e,t,n){var r=e("./_metadata"),o=e("./_an-object"),a=r.key,i=r.set;r.exp({defineMetadata:function(e,t,n,r){i(e,t,o(n),a(r))}})},{"./_an-object":8,"./_metadata":68}],303:[function(e,t,n){var r=e("./_metadata"),o=e("./_an-object"),a=r.key,i=r.map,s=r.store;r.exp({deleteMetadata:function(e,t){var n=arguments.length<3?void 0:a(arguments[2]),r=i(o(t),n,!1);if(void 0===r||!r.delete(e))return!1;if(r.size)return!0;r=s.get(t);return r.delete(n),!!r.size||s.delete(t)}})},{"./_an-object":8,"./_metadata":68}],304:[function(e,t,n){function r(e,t){var n=u(e,t);return null!==(e=l(e))&&(e=r(e,t)).length?n.length?a(new o(n.concat(e))):e:n}var o=e("./es6.set"),a=e("./_array-from-iterable"),i=e("./_metadata"),s=e("./_an-object"),l=e("./_object-gpo"),u=i.keys,c=i.key;i.exp({getMetadataKeys:function(e){return r(s(e),arguments.length<2?void 0:c(arguments[1]))}})},{"./_an-object":8,"./_array-from-iterable":11,"./_metadata":68,"./_object-gpo":80,"./es6.set":234}],305:[function(e,t,n){function r(e,t,n){return s(e,t,n)?l(e,t,n):null!==(t=i(t))?r(e,t,n):void 0}var o=e("./_metadata"),a=e("./_an-object"),i=e("./_object-gpo"),s=o.has,l=o.get,u=o.key;o.exp({getMetadata:function(e,t){return r(e,a(t),arguments.length<3?void 0:u(arguments[2]))}})},{"./_an-object":8,"./_metadata":68,"./_object-gpo":80}],306:[function(e,t,n){var r=e("./_metadata"),o=e("./_an-object"),a=r.keys,i=r.key;r.exp({getOwnMetadataKeys:function(e){return a(o(e),arguments.length<2?void 0:i(arguments[1]))}})},{"./_an-object":8,"./_metadata":68}],307:[function(e,t,n){var r=e("./_metadata"),o=e("./_an-object"),a=r.get,i=r.key;r.exp({getOwnMetadata:function(e,t){return a(e,o(t),arguments.length<3?void 0:i(arguments[2]))}})},{"./_an-object":8,"./_metadata":68}],308:[function(e,t,n){function r(e,t,n){return!!s(e,t,n)||null!==(t=i(t))&&r(e,t,n)}var o=e("./_metadata"),a=e("./_an-object"),i=e("./_object-gpo"),s=o.has,l=o.key;o.exp({hasMetadata:function(e,t){return r(e,a(t),arguments.length<3?void 0:l(arguments[2]))}})},{"./_an-object":8,"./_metadata":68,"./_object-gpo":80}],309:[function(e,t,n){var r=e("./_metadata"),o=e("./_an-object"),a=r.has,i=r.key;r.exp({hasOwnMetadata:function(e,t){return a(e,o(t),arguments.length<3?void 0:i(arguments[2]))}})},{"./_an-object":8,"./_metadata":68}],310:[function(e,t,n){var r=e("./_metadata"),o=e("./_an-object"),a=e("./_a-function"),i=r.key,s=r.set;r.exp({metadata:function(n,r){return function(e,t){s(n,r,(void 0!==t?o:a)(e),i(t))}}})},{"./_a-function":3,"./_an-object":8,"./_metadata":68}],311:[function(e,t,n){e("./_set-collection-from")("Set")},{"./_set-collection-from":98}],312:[function(e,t,n){e("./_set-collection-of")("Set")},{"./_set-collection-of":99}],313:[function(e,t,n){var r=e("./_export");r(r.P+r.R,"Set",{toJSON:e("./_collection-to-json")("Set")})},{"./_collection-to-json":21,"./_export":34}],314:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_string-at")(!0),e=e("./_fails")(function(){return"\ud842\udfb7"!=="\ud842\udfb7".at(0)});r(r.P+r.F*e,"String",{at:function(e){return o(this,e)}})},{"./_export":34,"./_fails":36,"./_string-at":107}],315:[function(e,t,n){"use strict";function r(e,t){this._r=e,this._s=t}var o=e("./_export"),a=e("./_defined"),i=e("./_to-length"),s=e("./_is-regexp"),l=e("./_flags"),u=RegExp.prototype;e("./_iter-create")(r,"RegExp String",function(){var e=this._r.exec(this._s);return{value:e,done:null===e}}),o(o.P,"String",{matchAll:function(e){if(a(this),!s(e))throw TypeError(e+" is not a regexp!");var t=String(this),n="flags"in u?String(e.flags):l.call(e),n=new RegExp(e.source,~n.indexOf("g")?n:"g"+n);return n.lastIndex=i(e.lastIndex),new r(n,t)}})},{"./_defined":29,"./_export":34,"./_flags":38,"./_is-regexp":54,"./_iter-create":56,"./_to-length":119}],316:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_string-pad"),e=e("./_user-agent"),e=/Version\/10\.\d+(\.\d+)?( Mobile\/\w+)? Safari\//.test(e);r(r.P+r.F*e,"String",{padEnd:function(e){return o(this,e,1<arguments.length?arguments[1]:void 0,!1)}})},{"./_export":34,"./_string-pad":110,"./_user-agent":126}],317:[function(e,t,n){"use strict";var r=e("./_export"),o=e("./_string-pad"),e=e("./_user-agent"),e=/Version\/10\.\d+(\.\d+)?( Mobile\/\w+)? Safari\//.test(e);r(r.P+r.F*e,"String",{padStart:function(e){return o(this,e,1<arguments.length?arguments[1]:void 0,!0)}})},{"./_export":34,"./_string-pad":110,"./_user-agent":126}],318:[function(e,t,n){"use strict";e("./_string-trim")("trimLeft",function(e){return function(){return e(this,1)}},"trimStart")},{"./_string-trim":112}],319:[function(e,t,n){"use strict";e("./_string-trim")("trimRight",function(e){return function(){return e(this,2)}},"trimEnd")},{"./_string-trim":112}],320:[function(e,t,n){e("./_wks-define")("asyncIterator")},{"./_wks-define":128}],321:[function(e,t,n){e("./_wks-define")("observable")},{"./_wks-define":128}],322:[function(e,t,n){var r=e("./_export");r(r.S,"System",{global:e("./_global")})},{"./_export":34,"./_global":42}],323:[function(e,t,n){e("./_set-collection-from")("WeakMap")},{"./_set-collection-from":98}],324:[function(e,t,n){e("./_set-collection-of")("WeakMap")},{"./_set-collection-of":99}],325:[function(e,t,n){e("./_set-collection-from")("WeakSet")},{"./_set-collection-from":98}],326:[function(e,t,n){e("./_set-collection-of")("WeakSet")},{"./_set-collection-of":99}],327:[function(e,t,n){for(var r=e("./es6.array.iterator"),o=e("./_object-keys"),a=e("./_redefine"),i=e("./_global"),s=e("./_hide"),l=e("./_iterators"),e=e("./_wks"),u=e("iterator"),c=e("toStringTag"),f=l.Array,p={CSSRuleList:!0,CSSStyleDeclaration:!1,CSSValueList:!1,ClientRectList:!1,DOMRectList:!1,DOMStringList:!1,DOMTokenList:!0,DataTransferItemList:!1,FileList:!1,HTMLAllCollection:!1,HTMLCollection:!1,HTMLFormElement:!1,HTMLSelectElement:!1,MediaList:!0,MimeTypeArray:!1,NamedNodeMap:!1,NodeList:!0,PaintRequestList:!1,Plugin:!1,PluginArray:!1,SVGLengthList:!1,SVGNumberList:!1,SVGPathSegList:!1,SVGPointList:!1,SVGStringList:!1,SVGTransformList:!1,SourceBufferList:!1,StyleSheetList:!0,TextTrackCueList:!1,TextTrackList:!1,TouchList:!1},d=o(p),v=0;v<d.length;v++){var y,_=d[v],h=p[_],m=i[_],g=m&&m.prototype;if(g&&(g[u]||s(g,u,f),g[c]||s(g,c,_),l[_]=f,h))for(y in r)g[y]||a(g,y,r[y],!0)}},{"./_global":42,"./_hide":44,"./_iterators":60,"./_object-keys":82,"./_redefine":93,"./_wks":130,"./es6.array.iterator":143}],328:[function(e,t,n){var r=e("./_export"),e=e("./_task");r(r.G+r.B,{setImmediate:e.set,clearImmediate:e.clear})},{"./_export":34,"./_task":114}],329:[function(e,t,n){function r(o){return function(e,t){var n=2<arguments.length,r=n&&i.call(arguments,2);return o(n?function(){("function"==typeof e?e:Function(e)).apply(this,r)}:e,t)}}var o=e("./_global"),a=e("./_export"),e=e("./_user-agent"),i=[].slice,e=/MSIE .\./.test(e);a(a.G+a.B+a.F*e,{setTimeout:r(o.setTimeout),setInterval:r(o.setInterval)})},{"./_export":34,"./_global":42,"./_user-agent":126}],330:[function(e,t,n){e("./modules/es6.symbol"),e("./modules/es6.object.create"),e("./modules/es6.object.define-property"),e("./modules/es6.object.define-properties"),e("./modules/es6.object.get-own-property-descriptor"),e("./modules/es6.object.get-prototype-of"),e("./modules/es6.object.keys"),e("./modules/es6.object.get-own-property-names"),e("./modules/es6.object.freeze"),e("./modules/es6.object.seal"),e("./modules/es6.object.prevent-extensions"),e("./modules/es6.object.is-frozen"),e("./modules/es6.object.is-sealed"),e("./modules/es6.object.is-extensible"),e("./modules/es6.object.assign"),e("./modules/es6.object.is"),e("./modules/es6.object.set-prototype-of"),e("./modules/es6.object.to-string"),e("./modules/es6.function.bind"),e("./modules/es6.function.name"),e("./modules/es6.function.has-instance"),e("./modules/es6.parse-int"),e("./modules/es6.parse-float"),e("./modules/es6.number.constructor"),e("./modules/es6.number.to-fixed"),e("./modules/es6.number.to-precision"),e("./modules/es6.number.epsilon"),e("./modules/es6.number.is-finite"),e("./modules/es6.number.is-integer"),e("./modules/es6.number.is-nan"),e("./modules/es6.number.is-safe-integer"),e("./modules/es6.number.max-safe-integer"),e("./modules/es6.number.min-safe-integer"),e("./modules/es6.number.parse-float"),e("./modules/es6.number.parse-int"),e("./modules/es6.math.acosh"),e("./modules/es6.math.asinh"),e("./modules/es6.math.atanh"),e("./modules/es6.math.cbrt"),e("./modules/es6.math.clz32"),e("./modules/es6.math.cosh"),e("./modules/es6.math.expm1"),e("./modules/es6.math.fround"),e("./modules/es6.math.hypot"),e("./modules/es6.math.imul"),e("./modules/es6.math.log10"),e("./modules/es6.math.log1p"),e("./modules/es6.math.log2"),e("./modules/es6.math.sign"),e("./modules/es6.math.sinh"),e("./modules/es6.math.tanh"),e("./modules/es6.math.trunc"),e("./modules/es6.string.from-code-point"),e("./modules/es6.string.raw"),e("./modules/es6.string.trim"),e("./modules/es6.string.iterator"),e("./modules/es6.string.code-point-at"),e("./modules/es6.string.ends-with"),e(
+         "./modules/es6.string.includes"),e("./modules/es6.string.repeat"),e("./modules/es6.string.starts-with"),e("./modules/es6.string.anchor"),e("./modules/es6.string.big"),e("./modules/es6.string.blink"),e("./modules/es6.string.bold"),e("./modules/es6.string.fixed"),e("./modules/es6.string.fontcolor"),e("./modules/es6.string.fontsize"),e("./modules/es6.string.italics"),e("./modules/es6.string.link"),e("./modules/es6.string.small"),e("./modules/es6.string.strike"),e("./modules/es6.string.sub"),e("./modules/es6.string.sup"),e("./modules/es6.date.now"),e("./modules/es6.date.to-json"),e("./modules/es6.date.to-iso-string"),e("./modules/es6.date.to-string"),e("./modules/es6.date.to-primitive"),e("./modules/es6.array.is-array"),e("./modules/es6.array.from"),e("./modules/es6.array.of"),e("./modules/es6.array.join"),e("./modules/es6.array.slice"),e("./modules/es6.array.sort"),e("./modules/es6.array.for-each"),e("./modules/es6.array.map"),e("./modules/es6.array.filter"),e("./modules/es6.array.some"),e("./modules/es6.array.every"),e("./modules/es6.array.reduce"),e("./modules/es6.array.reduce-right"),e("./modules/es6.array.index-of"),e("./modules/es6.array.last-index-of"),e("./modules/es6.array.copy-within"),e("./modules/es6.array.fill"),e("./modules/es6.array.find"),e("./modules/es6.array.find-index"),e("./modules/es6.array.species"),e("./modules/es6.array.iterator"),e("./modules/es6.regexp.constructor"),e("./modules/es6.regexp.exec"),e("./modules/es6.regexp.to-string"),e("./modules/es6.regexp.flags"),e("./modules/es6.regexp.match"),e("./modules/es6.regexp.replace"),e("./modules/es6.regexp.search"),e("./modules/es6.regexp.split"),e("./modules/es6.promise"),e("./modules/es6.map"),e("./modules/es6.set"),e("./modules/es6.weak-map"),e("./modules/es6.weak-set"),e("./modules/es6.typed.array-buffer"),e("./modules/es6.typed.data-view"),e("./modules/es6.typed.int8-array"),e("./modules/es6.typed.uint8-array"),e("./modules/es6.typed.uint8-clamped-array"),e("./modules/es6.typed.int16-array"),e("./modules/es6.typed.uint16-array"),e("./modules/es6.typed.int32-array"),e("./modules/es6.typed.uint32-array"),e("./modules/es6.typed.float32-array"),e("./modules/es6.typed.float64-array"),e("./modules/es6.reflect.apply"),e("./modules/es6.reflect.construct"),e("./modules/es6.reflect.define-property"),e("./modules/es6.reflect.delete-property"),e("./modules/es6.reflect.enumerate"),e("./modules/es6.reflect.get"),e("./modules/es6.reflect.get-own-property-descriptor"),e("./modules/es6.reflect.get-prototype-of"),e("./modules/es6.reflect.has"),e("./modules/es6.reflect.is-extensible"),e("./modules/es6.reflect.own-keys"),e("./modules/es6.reflect.prevent-extensions"),e("./modules/es6.reflect.set"),e("./modules/es6.reflect.set-prototype-of"),e("./modules/es7.array.includes"),e("./modules/es7.array.flat-map"),e("./modules/es7.array.flatten"),e("./modules/es7.string.at"),e("./modules/es7.string.pad-start"),e("./modules/es7.string.pad-end"),e("./modules/es7.string.trim-left"),e("./modules/es7.string.trim-right"),e("./modules/es7.string.match-all"),e("./modules/es7.symbol.async-iterator"),e("./modules/es7.symbol.observable"),e("./modules/es7.object.get-own-property-descriptors"),e("./modules/es7.object.values"),e("./modules/es7.object.entries"),e("./modules/es7.object.define-getter"),e("./modules/es7.object.define-setter"),e("./modules/es7.object.lookup-getter"),e("./modules/es7.object.lookup-setter"),e("./modules/es7.map.to-json"),e("./modules/es7.set.to-json"),e("./modules/es7.map.of"),e("./modules/es7.set.of"),e("./modules/es7.weak-map.of"),e("./modules/es7.weak-set.of"),e("./modules/es7.map.from"),e("./modules/es7.set.from"),e("./modules/es7.weak-map.from"),e("./modules/es7.weak-set.from"),e("./modules/es7.global"),e("./modules/es7.system.global"),e("./modules/es7.error.is-error"),e("./modules/es7.math.clamp"),e("./modules/es7.math.deg-per-rad"),e("./modules/es7.math.degrees"),e("./modules/es7.math.fscale"),e("./modules/es7.math.iaddh"),e("./modules/es7.math.isubh"),e("./modules/es7.math.imulh"),e("./modules/es7.math.rad-per-deg"),e("./modules/es7.math.radians"),e("./modules/es7.math.scale"),e("./modules/es7.math.umulh"),e("./modules/es7.math.signbit"),e("./modules/es7.promise.finally"),e("./modules/es7.promise.try"),e("./modules/es7.reflect.define-metadata"),e("./modules/es7.reflect.delete-metadata"),e("./modules/es7.reflect.get-metadata"),e("./modules/es7.reflect.get-metadata-keys"),e("./modules/es7.reflect.get-own-metadata"),e("./modules/es7.reflect.get-own-metadata-keys"),e("./modules/es7.reflect.has-metadata"),e("./modules/es7.reflect.has-own-metadata"),e("./modules/es7.reflect.metadata"),e("./modules/es7.asap"),e("./modules/es7.observable"),e("./modules/web.timers"),e("./modules/web.immediate"),e("./modules/web.dom.iterable"),t.exports=e("./modules/_core")},{"./modules/_core":24,"./modules/es6.array.copy-within":133,"./modules/es6.array.every":134,"./modules/es6.array.fill":135,"./modules/es6.array.filter":136,"./modules/es6.array.find":138,"./modules/es6.array.find-index":137,"./modules/es6.array.for-each":139,"./modules/es6.array.from":140,"./modules/es6.array.index-of":141,"./modules/es6.array.is-array":142,"./modules/es6.array.iterator":143,"./modules/es6.array.join":144,"./modules/es6.array.last-index-of":145,"./modules/es6.array.map":146,"./modules/es6.array.of":147,"./modules/es6.array.reduce":149,"./modules/es6.array.reduce-right":148,"./modules/es6.array.slice":150,"./modules/es6.array.some":151,"./modules/es6.array.sort":152,"./modules/es6.array.species":153,"./modules/es6.date.now":154,"./modules/es6.date.to-iso-string":155,"./modules/es6.date.to-json":156,"./modules/es6.date.to-primitive":157,"./modules/es6.date.to-string":158,"./modules/es6.function.bind":159,"./modules/es6.function.has-instance":160,"./modules/es6.function.name":161,"./modules/es6.map":162,"./modules/es6.math.acosh":163,"./modules/es6.math.asinh":164,"./modules/es6.math.atanh":165,"./modules/es6.math.cbrt":166,"./modules/es6.math.clz32":167,"./modules/es6.math.cosh":168,"./modules/es6.math.expm1":169,"./modules/es6.math.fround":170,"./modules/es6.math.hypot":171,"./modules/es6.math.imul":172,"./modules/es6.math.log10":173,"./modules/es6.math.log1p":174,"./modules/es6.math.log2":175,"./modules/es6.math.sign":176,"./modules/es6.math.sinh":177,"./modules/es6.math.tanh":178,"./modules/es6.math.trunc":179,"./modules/es6.number.constructor":180,"./modules/es6.number.epsilon":181,"./modules/es6.number.is-finite":182,"./modules/es6.number.is-integer":183,"./modules/es6.number.is-nan":184,"./modules/es6.number.is-safe-integer":185,"./modules/es6.number.max-safe-integer":186,"./modules/es6.number.min-safe-integer":187,"./modules/es6.number.parse-float":188,"./modules/es6.number.parse-int":189,"./modules/es6.number.to-fixed":190,"./modules/es6.number.to-precision":191,"./modules/es6.object.assign":192,"./modules/es6.object.create":193,"./modules/es6.object.define-properties":194,"./modules/es6.object.define-property":195,"./modules/es6.object.freeze":196,"./modules/es6.object.get-own-property-descriptor":197,"./modules/es6.object.get-own-property-names":198,"./modules/es6.object.get-prototype-of":199,"./modules/es6.object.is":203,"./modules/es6.object.is-extensible":200,"./modules/es6.object.is-frozen":201,"./modules/es6.object.is-sealed":202,"./modules/es6.object.keys":204,"./modules/es6.object.prevent-extensions":205,"./modules/es6.object.seal":206,"./modules/es6.object.set-prototype-of":207,"./modules/es6.object.to-string":208,"./modules/es6.parse-float":209,"./modules/es6.parse-int":210,"./modules/es6.promise":211,"./modules/es6.reflect.apply":212,"./modules/es6.reflect.construct":213,"./modules/es6.reflect.define-property":214,"./modules/es6.reflect.delete-property":215,"./modules/es6.reflect.enumerate":216,"./modules/es6.reflect.get":219,"./modules/es6.reflect.get-own-property-descriptor":217,"./modules/es6.reflect.get-prototype-of":218,"./modules/es6.reflect.has":220,"./modules/es6.reflect.is-extensible":221,"./modules/es6.reflect.own-keys":222,"./modules/es6.reflect.prevent-extensions":223,"./modules/es6.reflect.set":225,"./modules/es6.reflect.set-prototype-of":224,"./modules/es6.regexp.constructor":226,"./modules/es6.regexp.exec":227,"./modules/es6.regexp.flags":228,"./modules/es6.regexp.match":229,"./modules/es6.regexp.replace":230,"./modules/es6.regexp.search":231,"./modules/es6.regexp.split":232,"./modules/es6.regexp.to-string":233,"./modules/es6.set":234,"./modules/es6.string.anchor":235,"./modules/es6.string.big":236,"./modules/es6.string.blink":237,"./modules/es6.string.bold":238,"./modules/es6.string.code-point-at":239,"./modules/es6.string.ends-with":240,"./modules/es6.string.fixed":241,"./modules/es6.string.fontcolor":242,"./modules/es6.string.fontsize":243,"./modules/es6.string.from-code-point":244,"./modules/es6.string.includes":245,"./modules/es6.string.italics":246,"./modules/es6.string.iterator":247,"./modules/es6.string.link":248,"./modules/es6.string.raw":249,"./modules/es6.string.repeat":250,"./modules/es6.string.small":251,"./modules/es6.string.starts-with":252,"./modules/es6.string.strike":253,"./modules/es6.string.sub":254,"./modules/es6.string.sup":255,"./modules/es6.string.trim":256,"./modules/es6.symbol":257,"./modules/es6.typed.array-buffer":258,"./modules/es6.typed.data-view":259,"./modules/es6.typed.float32-array":260,"./modules/es6.typed.float64-array":261,"./modules/es6.typed.int16-array":262,"./modules/es6.typed.int32-array":263,"./modules/es6.typed.int8-array":264,"./modules/es6.typed.uint16-array":265,"./modules/es6.typed.uint32-array":266,"./modules/es6.typed.uint8-array":267,"./modules/es6.typed.uint8-clamped-array":268,"./modules/es6.weak-map":269,"./modules/es6.weak-set":270,"./modules/es7.array.flat-map":271,"./modules/es7.array.flatten":272,"./modules/es7.array.includes":273,"./modules/es7.asap":274,"./modules/es7.error.is-error":275,"./modules/es7.global":276,"./modules/es7.map.from":277,"./modules/es7.map.of":278,"./modules/es7.map.to-json":279,"./modules/es7.math.clamp":280,"./modules/es7.math.deg-per-rad":281,"./modules/es7.math.degrees":282,"./modules/es7.math.fscale":283,"./modules/es7.math.iaddh":284,"./modules/es7.math.imulh":285,"./modules/es7.math.isubh":286,"./modules/es7.math.rad-per-deg":287,"./modules/es7.math.radians":288,"./modules/es7.math.scale":289,"./modules/es7.math.signbit":290,"./modules/es7.math.umulh":291,"./modules/es7.object.define-getter":292,"./modules/es7.object.define-setter":293,"./modules/es7.object.entries":294,"./modules/es7.object.get-own-property-descriptors":295,"./modules/es7.object.lookup-getter":296,"./modules/es7.object.lookup-setter":297,"./modules/es7.object.values":298,"./modules/es7.observable":299,"./modules/es7.promise.finally":300,"./modules/es7.promise.try":301,"./modules/es7.reflect.define-metadata":302,"./modules/es7.reflect.delete-metadata":303,"./modules/es7.reflect.get-metadata":305,"./modules/es7.reflect.get-metadata-keys":304,"./modules/es7.reflect.get-own-metadata":307,"./modules/es7.reflect.get-own-metadata-keys":306,"./modules/es7.reflect.has-metadata":308,"./modules/es7.reflect.has-own-metadata":309,"./modules/es7.reflect.metadata":310,"./modules/es7.set.from":311,"./modules/es7.set.of":312,"./modules/es7.set.to-json":313,"./modules/es7.string.at":314,"./modules/es7.string.match-all":315,"./modules/es7.string.pad-end":316,"./modules/es7.string.pad-start":317,"./modules/es7.string.trim-left":318,"./modules/es7.string.trim-right":319,"./modules/es7.symbol.async-iterator":320,"./modules/es7.symbol.observable":321,"./modules/es7.system.global":322,"./modules/es7.weak-map.from":323,"./modules/es7.weak-map.of":324,"./modules/es7.weak-set.from":325,"./modules/es7.weak-set.of":326,"./modules/web.dom.iterable":327,"./modules/web.immediate":328,"./modules/web.timers":329}],331:[function(e,t,n){var r,o,t=t.exports={};function a(){throw new Error("setTimeout has not been defined")}function i(){throw new Error("clearTimeout has not been defined")}try{r="function"==typeof setTimeout?setTimeout:a}catch(e){r=a}try{o="function"==typeof clearTimeout?clearTimeout:i}catch(e){o=i}function s(t){if(r===setTimeout)return setTimeout(t,0);if((r===a||!r)&&setTimeout)return(r=setTimeout)(t,0);try{return r(t,0)}catch(e){try{return r.call(null,t,0)}catch(e){return r.call(this,t,0)}}}var l,u=[],c=!1,f=-1;function p(){c&&l&&(c=!1,l.length?u=l.concat(u):f=-1,u.length&&d())}function d(){if(!c){for(var e=s(p),t=(c=!0,u.length);t;){for(l=u,u=[];++f<t;)l&&l[f].run();f=-1,t=u.length}l=null,c=!1,!function(t){if(o===clearTimeout)return clearTimeout(t);if((o===i||!o)&&clearTimeout)return(o=clearTimeout)(t);try{o(t)}catch(e){try{return o.call(null,t)}catch(e){return o.call(this,t)}}}(e)}}function v(e,t){this.fun=e,this.array=t}function y(){}t.nextTick=function(e){var t=new Array(arguments.length-1);if(1<arguments.length)for(var n=1;n<arguments.length;n++)t[n-1]=arguments[n];u.push(new v(e,t)),1!==u.length||c||s(d)},v.prototype.run=function(){this.fun.apply(null,this.array)},t.title="browser",t.browser=!0,t.env={},t.argv=[],t.version="",t.versions={},t.on=y,t.addListener=y,t.once=y,t.off=y,t.removeListener=y,t.removeAllListeners=y,t.emit=y,t.prependListener=y,t.prependOnceListener=y,t.listeners=function(e){return[]},t.binding=function(e){throw new Error("process.binding is not supported")},t.cwd=function(){return"/"},t.chdir=function(e){throw new Error("process.chdir is not supported")},t.umask=function(){return 0}},{}],332:[function(e,I,t){!function(e){!function(){!function(e){"use strict";var l,u,c,f,p,d,t,n,r=Object.prototype,v=r.hasOwnProperty,o="function"==typeof Symbol?Symbol:{},a=o.iterator||"@@iterator",i=o.asyncIterator||"@@asyncIterator",s=o.toStringTag||"@@toStringTag",o="object"==typeof I,y=e.regeneratorRuntime;function _(e,t,n,r){var o,a,i,s,t=t&&t.prototype instanceof m?t:m,t=Object.create(t.prototype),r=new S(r||[]);return t._invoke=(o=e,a=n,i=r,s=u,function(e,t){if(s===f)throw new Error("Generator is already running");if(s===p){if("throw"===e)throw t;return E()}for(i.method=e,i.arg=t;;){var n=i.delegate;if(n){n=function e(t,n){var r=t.iterator[n.method];if(r===l){if(n.delegate=null,"throw"===n.method){if(t.iterator.return&&(n.method="return",n.arg=l,e(t,n),"throw"===n.method))return d;n.method="throw",n.arg=new TypeError("The iterator does not provide a 'throw' method")}return d}r=h(r,t.iterator,n.arg);if("throw"===r.type)return n.method="throw",n.arg=r.arg,n.delegate=null,d;r=r.arg;if(!r)return n.method="throw",n.arg=new TypeError("iterator result is not an object"),n.delegate=null,d;{if(!r.done)return r;n[t.resultName]=r.value,n.next=t.nextLoc,"return"!==n.method&&(n.method="next",n.arg=l)}n.delegate=null;return d}(n,i);if(n){if(n===d)continue;return n}}if("next"===i.method)i.sent=i._sent=i.arg;else if("throw"===i.method){if(s===u)throw s=p,i.arg;i.dispatchException(i.arg)}else"return"===i.method&&i.abrupt("return",i.arg);s=f;n=h(o,a,i);if("normal"===n.type){if(s=i.done?p:c,n.arg!==d)return{value:n.arg,
+         done:i.done}}else"throw"===n.type&&(s=p,i.method="throw",i.arg=n.arg)}}),t}function h(e,t,n){try{return{type:"normal",arg:e.call(t,n)}}catch(e){return{type:"throw",arg:e}}}function m(){}function g(){}function b(){}function x(e){["next","throw","return"].forEach(function(t){e[t]=function(e){return this._invoke(t,e)}})}function w(a){function i(e,t,n,r){var o,e=h(a[e],a,t);if("throw"!==e.type)return(t=(o=e.arg).value)&&"object"==typeof t&&v.call(t,"__await")?Promise.resolve(t.__await).then(function(e){i("next",e,n,r)},function(e){i("throw",e,n,r)}):Promise.resolve(t).then(function(e){o.value=e,n(o)},r);r(e.arg)}var t;"object"==typeof e.process&&e.process.domain&&(i=e.process.domain.bind(i)),this._invoke=function(n,r){function e(){return new Promise(function(e,t){i(n,r,e,t)})}return t=t?t.then(e,e):e()}}function j(e){var t={tryLoc:e[0]};1 in e&&(t.catchLoc=e[1]),2 in e&&(t.finallyLoc=e[2],t.afterLoc=e[3]),this.tryEntries.push(t)}function A(e){var t=e.completion||{};t.type="normal",delete t.arg,e.completion=t}function S(e){this.tryEntries=[{tryLoc:"root"}],e.forEach(j,this),this.reset(!0)}function k(t){if(t){var n,e=t[a];if(e)return e.call(t);if("function"==typeof t.next)return t;if(!isNaN(t.length))return n=-1,(e=function e(){for(;++n<t.length;)if(v.call(t,n))return e.value=t[n],e.done=!1,e;return e.value=l,e.done=!0,e}).next=e}return{next:E}}function E(){return{value:l,done:!0}}y?o&&(I.exports=y):((y=e.regeneratorRuntime=o?I.exports:{}).wrap=_,u="suspendedStart",c="suspendedYield",f="executing",p="completed",d={},(o={})[a]=function(){return this},t=(t=Object.getPrototypeOf)&&t(t(k([]))),t&&t!==r&&v.call(t,a)&&(o=t),n=b.prototype=m.prototype=Object.create(o),(g.prototype=n.constructor=b).constructor=g,b[s]=g.displayName="GeneratorFunction",y.isGeneratorFunction=function(e){e="function"==typeof e&&e.constructor;return!!e&&(e===g||"GeneratorFunction"===(e.displayName||e.name))},y.mark=function(e){return Object.setPrototypeOf?Object.setPrototypeOf(e,b):(e.__proto__=b,s in e||(e[s]="GeneratorFunction")),e.prototype=Object.create(n),e},y.awrap=function(e){return{__await:e}},x(w.prototype),w.prototype[i]=function(){return this},y.AsyncIterator=w,y.async=function(e,t,n,r){var o=new w(_(e,t,n,r));return y.isGeneratorFunction(t)?o:o.next().then(function(e){return e.done?e.value:o.next()})},x(n),n[s]="Generator",n[a]=function(){return this},n.toString=function(){return"[object Generator]"},y.keys=function(n){var e,r=[];for(e in n)r.push(e);return r.reverse(),function e(){for(;r.length;){var t=r.pop();if(t in n)return e.value=t,e.done=!1,e}return e.done=!0,e}},y.values=k,S.prototype={constructor:S,reset:function(e){if(this.prev=0,this.next=0,this.sent=this._sent=l,this.done=!1,this.delegate=null,this.method="next",this.arg=l,this.tryEntries.forEach(A),!e)for(var t in this)"t"===t.charAt(0)&&v.call(this,t)&&!isNaN(+t.slice(1))&&(this[t]=l)},stop:function(){this.done=!0;var e=this.tryEntries[0].completion;if("throw"===e.type)throw e.arg;return this.rval},dispatchException:function(n){if(this.done)throw n;var r=this;function e(e,t){return a.type="throw",a.arg=n,r.next=e,t&&(r.method="next",r.arg=l),!!t}for(var t=this.tryEntries.length-1;0<=t;--t){var o=this.tryEntries[t],a=o.completion;if("root"===o.tryLoc)return e("end");if(o.tryLoc<=this.prev){var i=v.call(o,"catchLoc"),s=v.call(o,"finallyLoc");if(i&&s){if(this.prev<o.catchLoc)return e(o.catchLoc,!0);if(this.prev<o.finallyLoc)return e(o.finallyLoc)}else if(i){if(this.prev<o.catchLoc)return e(o.catchLoc,!0)}else{if(!s)throw new Error("try statement without catch or finally");if(this.prev<o.finallyLoc)return e(o.finallyLoc)}}}},abrupt:function(e,t){for(var n=this.tryEntries.length-1;0<=n;--n){var r=this.tryEntries[n];if(r.tryLoc<=this.prev&&v.call(r,"finallyLoc")&&this.prev<r.finallyLoc){var o=r;break}}var a=(o=o&&("break"===e||"continue"===e)&&o.tryLoc<=t&&t<=o.finallyLoc?null:o)?o.completion:{};return a.type=e,a.arg=t,o?(this.method="next",this.next=o.finallyLoc,d):this.complete(a)},complete:function(e,t){if("throw"===e.type)throw e.arg;return"break"===e.type||"continue"===e.type?this.next=e.arg:"return"===e.type?(this.rval=this.arg=e.arg,this.method="return",this.next="end"):"normal"===e.type&&t&&(this.next=t),d},finish:function(e){for(var t=this.tryEntries.length-1;0<=t;--t){var n=this.tryEntries[t];if(n.finallyLoc===e)return this.complete(n.completion,n.afterLoc),A(n),d}},catch:function(e){for(var t=this.tryEntries.length-1;0<=t;--t){var n,r,o=this.tryEntries[t];if(o.tryLoc===e)return"throw"===(n=o.completion).type&&(r=n.arg,A(o)),r}throw new Error("illegal catch attempt")},delegateYield:function(e,t,n){return this.delegate={iterator:k(e),resultName:t,nextLoc:n},"next"===this.method&&(this.arg=l),d}})}("object"==typeof e?e:"object"==typeof window?window:"object"==typeof self?self:this)}.call(this)}.call(this,"undefined"!=typeof global?global:"undefined"!=typeof self?self:"undefined"!=typeof window?window:{})},{}],333:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.collect=function(){var e=0<arguments.length&&void 0!==arguments[0]?arguments[0]:{},t="localhost"===location.hostname||"127.0.0.1"===location.hostname,n=t?"Local":"Remote";window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)},ga.l=+new Date,ga("create","UA-83005064-2",t?{clientId:e.InstanceGUID||o.get(i)||function(){var e="xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g,function(e){var t=16*Math.random()|0;return("x"==e?t:3&t|8).toString(16)});return o.set(i,e),e}()}:"auto"),ga("set","appName","WebTerminal"),ga("set","appVersion",r.VERSION),ga("set","screenName",n),e.zv&&ga("set","appInstallerId",e.zv);ga("send","pageview",n)};var r=a(e("../index")),o=a(e("../storage"));function a(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}var i="terminal-guid"},{"../index":340,"../storage":361}],334:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0});var c=o(e("../output")),a=o(e("../input/caret")),r=e("../elements");function o(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}function i(){this.visible=!1,this.element=document.createElement("div"),this.element.className="hintBox",this.element.style.display="none",r.output.appendChild(this.element),this.maxVariantLength=10,this.displayUnder=!0,this.displayInLine=!0,this.lastSeek=1,this.firstDisplay=!0,this.variants=[],this.variant=0}i.prototype.add=function(){var t=this,e=0<arguments.length&&void 0!==arguments[0]?arguments[0]:[];e instanceof Array||(e=[e]),this.reset(),this.variants=e.map(function(e){return e.length>t.maxVariantLength&&(t.maxVariantLength=e.length),{value:e,element:null}}),this.variants.length?(this.update(),this.show()):this.hide()},i.prototype.reset=function(){this.element.textContent="",this.variants=[],this.variant=0,this.lastSeek=0,this.maxVariantLength=0,this.firstDisplay=!0},i.prototype.get=function(){return(this.variants[this.variant]||{}).value||""},i.prototype.next=function(){var e=this.variant;this.variant=(this.variant+(0<arguments.length&&void 0!==arguments[0]?arguments[0]:1)+this.variants.length)%this.variants.length,e!==this.variant&&(this.lastSeek=this.variant-e),this.updateVariants()},i.prototype.updateVariants=function(){var o=this;if(this.visible){var s=this.variants.slice(this.variant,this.variant+5),a=this.displayUnder?"top":"bottom",e=!0,t=!1,n=void 0;try{for(var r,i=function(){var e=r.value;if(function(e){var t=!0,n=!1,r=void 0;try{for(var o,a=s[Symbol.iterator]();!(t=(o=a.next()).done);t=!0){var i=o.value;if(i.element===e)return i}}catch(e){n=!0,r=e}finally{try{!t&&a.return&&a.return()}finally{if(n)throw r}}}(e)||e.DECAY)return"continue";e.DECAY=!0,e.style[a]=parseFloat(e.style[a])-o.lastSeek*c.SYMBOL_HEIGHT+"px",e.style.opacity=0,setTimeout(function(){e.parentNode&&e.parentNode.removeChild(e)},300)},l=this.element.childNodes[Symbol.iterator]();!(e=(r=l.next()).done);e=!0)i()}catch(e){t=!0,n=e}finally{try{!e&&l.return&&l.return()}finally{if(t)throw n}}for(var u=0;u<s.length;u++)!function(e){var t,n,r=s[e];r.element&&!r.element.DECAY||(t=Math.sign(o.lastSeek)*Math.min(Math.abs(o.lastSeek),5),r.element=document.createElement("div"),r.element.textContent=r.value,o.firstDisplay||(r.element.style.opacity=0),r.element.style[a]=(e+t)*c.SYMBOL_HEIGHT+"px",o.element.appendChild(r.element)),setTimeout((n=r.element,function(){n.style[a]=e*c.SYMBOL_HEIGHT+"px",n.style.opacity=1}),25)}(u)}},i.prototype.update=function(){var e,t,n,r,o;this.visible&&(e=c.getLinesNumber(),t=c.getTopLineIndex()+a.getY(),n=a.getX(),r=Math.min(this.maxVariantLength,Math.ceil(c.WIDTH/2)),o=Math.min(5,this.variants.length),this.displayInLine=n+r<c.WIDTH,this.displayUnder=t+o+1<Math.max(e,c.HEIGHT),this.element.style.top=((this.displayUnder?t+1:t-o)+(this.displayInLine?this.displayUnder?-1:1:0))*c.SYMBOL_HEIGHT+"px",this.element.style.left=Math.min(n,c.WIDTH-r)*c.SYMBOL_WIDTH+"px",this.element.style.width=r*c.SYMBOL_WIDTH+"px",this.element.style.height=o*c.SYMBOL_HEIGHT+"px",this.updateVariants(),this.firstDisplay=!1)},i.prototype.show=function(){this.visible||(this.visible=!0,this.update(),this.element.style.display="block")},i.prototype.hide=function(){this.visible&&(this.visible=!1,this.element.style.display="none")},n.default=new i},{"../elements":338,"../input/caret":342,"../output":356}],335:[function(e,t,d){"use strict";Object.defineProperty(d,"__esModule",{value:!0}),d.CURRENT=void 0,d.suggest=function(e){var t=1<arguments.length&&void 0!==arguments[1]?arguments[1]:"",g=[],b=(0,n.getAutomaton)();return function e(t,n,r,o){var a=2<arguments.length&&void 0!==r?r:null,i=3<arguments.length&&void 0!==o?o:null;if(g[t])return[];g[t]=!0;var r=b[t],s=[];if(!r)return console.error("No state "+t),[];var l=!0,o=!1,t=void 0;try{for(var u,c=r[Symbol.iterator]();!(l=(u=c.next()).done);l=!0){var f=u.value;if(null===f[0]){if(0===f[1])break;s=s.concat(e(f[1],n));break}if(!0!==f[0]&&0!==f[0]&&(f[0].type===x.TYPE_CHAR||f[0].type===x.TYPE_ID)&&!(f[0].type===x.TYPE_CHAR&&null===i&&f[0].value&&","===f[0].value.value||a&&f[0].value.class&&f[0].value.class!==a||i&&f[0].value.type&&f[0].value.type!==i)){if(f[0].type===x.TYPE_CHAR){if(""!==n&&0!==(("string"==typeof f[0].value?f[0]:f[0].value).value||"").indexOf(n))continue;if(0===f[1])continue;var p=e(f[1],n.substr(1),f[0].value.class||a,f[0].value.type||i),d=!0,v=!1,y=void 0;try{for(var _,h=p[Symbol.iterator]();!(d=(_=h.next()).done);d=!0){var m=_.value;m[0]&&m[0].value&&s.push([f[0].value].concat(m))}}catch(e){v=!0,y=e}finally{try{!d&&h.return&&h.return()}finally{if(v)throw y}}}if(f[0].type===x.TYPE_ID)if(""!==n&&"string"==typeof f[0].value.value){if(f[0].value.value===n)break;0===f[0].value.value.indexOf(n)&&s.push([{value:f[0].value.value.substr(n.length),class:f[0].value.class,type:f[0].value.type}])}else s.push([f[0].value])}}}catch(e){o=!0,t=e}finally{try{!l&&c.return&&c.return()}finally{if(o)throw t}}return s}(e,t)},d.showSuggestions=function(e){var t=1<arguments.length&&void 0!==arguments[1]?arguments[1]:[],n=2<arguments.length&&void 0!==arguments[2]?arguments[2]:[],r=!1,o=d.CURRENT=_+=1,a=[];if(v.default.reset(),e){var i=!0,s=!1,l=void 0;try{for(var u,c=t[Symbol.iterator]();!(i=(u=c.next()).done);i=!0){var f,p=u.value;p[0].value?(f=p.map(function(e){return e.value}).join("")).length&&(r=!0,a.push(f)):p[0].type&&"function"==typeof y.default[p[0].type]&&(y.default[p[0].type](n.slice(),function(e){o===_&&!function(){var e=0<arguments.length&&void 0!==arguments[0]?arguments[0]:[];v.default.add(e)}(e)}),r=!0)}}catch(e){s=!0,l=e}finally{try{!i&&c.return&&c.return()}finally{if(s)throw l}}}a.length&&v.default.add(a);r&&e||v.default.hide()};var n=e("../parser"),x=e("../parser/pushdownAutomaton"),r=e("../init"),o=function(e){{if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}}(e("../input")),v=a(e("./hint")),y=a(e("./types"));function a(e){return e&&e.__esModule?e:{default:e}}var _=d.CURRENT=0;(0,r.onInit)(function(){return o.onKeyDown(function(e){var t,n;17===e.keyCode?v.default.visible&&v.default.next(2===e.location?-1:1):9===e.keyCode&&(e.preventDefault(),v.default.visible&&(e=o.getValue(),t=o.getCaretPosition(),n=v.default.get(),o.setValue(e.substr(0,t)+n+e.substr(t),t+n.length)))})})},{"../init":341,"../input":345,"../parser":357,"../parser/pushdownAutomaton":358,"./hint":334,"./types":336}],336:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0});var r=a(e("../server")),o=a(e("../favorite"));function a(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}function i(e,t){for(var n=[],r=e.length-1;0<=r&&e[r].type===t;r--)n.push(e[r].value);return n.length&&e.splice(e.length-n.length,n.length),n.reverse().join("")}n.default={classname:function(e,t){var n=i(e,"classname");r.send("ClassAutocomplete",n,function(e){e&&0<e.length&&t(e.split(",").map(function(e){var t=e.indexOf(".",n.length);return 0<t?e.substring(n.length,t+1):e.substr(n.length)}).filter(function(e,t,n){return!n[t-1]||n[t-1]!==e}))})},global:function(e,t){var n=i(e,"global").substr(1);r.send("GlobalAutocomplete",n,function(e){e&&0<e.length&&t(e.split(",").map(function(e){var t=e.indexOf(".",n.length);return 0<t?e.substring(n.length,t+1):e.substr(n.length)}).filter(function(e,t,n){return!n[t-1]||n[t-1]!==e}))})},publicClassMember:function(e,t){var n=i(e,"publicClassMember"),e=i(e,"classname");r.send("ClassMemberAutocomplete",{className:e,part:n},function(e){e&&0<e.length&&t(e.split(",").map(function(e){return e.substr(n.length)}))})},parameter:function(e,t){var n=i(e,"parameter").substr(1),e=i(e,"classname");r.send("ParameterAutocomplete",{className:e,part:n},function(e){e&&0<e.length&&t(e.split(",").map(function(e){return e.substr(n.length)}))})},variable:function(e,t){var n=i(e,"variable");r.send("LocalAutocomplete",null,function(e){e&&t(Object.keys(e).filter(function(e){return 0===e.indexOf(n)&&e.length!==n.length}).map(function(e){return e.substr(n.length)}))})},favorites:function(e,t){var n=i(e,"favorites");t(Object.keys(o.list()).filter(function(e){return 0===e.indexOf(n)&&e.length!==n.length}).map(function(e){return e.substr(n.length)}))},member:function(e,t){var n=i(e,"member"),e=i(e,"variable");e&&r.send("MemberAutocomplete",{variable:e,part:n},function(e){e&&t(e.split(",").filter(function(e){return 0===e.indexOf(n)}).map(function(e){return e.substr(n.length)}))})},memberMethod:function(e,t){var n=i(e,"memberMethod"),e=i(e,"variable");e&&r.send("MemberAutocomplete",{variable:e,part:n,methodsOnly:1},function(e){e&&t(e.split(",").filter(function(e){return 0===e.indexOf(n)}).map(function(e){return e.substr(n.length)}))})},routine:function(e,t){var n=i(e,"routine");r.send("RoutineAutocomplete",n,function(e){
+         e&&0<e.length&&t(e.split(",").filter(function(e){return!/\.[0-9]+$/.test(e)}).map(function(e){var t=e.indexOf(".",n.length);return 0<t?e.substring(n.length,t+1):e.substr(n.length)}).filter(function(e,t,n){return!n[t-1]||n[t-1]!==e}))})}}},{"../favorite":339,"../server":360}],337:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.get=function(e){return void 0!==p[e]?p[e]:void 0===y[e]?null:y[e]},n.set=function(t,e){var n=2<arguments.length&&void 0!==arguments[2]&&arguments[2];if(!d.hasOwnProperty(t))return o.get("confNoKey",t);if(d[t].values&&-1===d[t].values.indexOf(e))return o.get("confInvVal",t,d[t].values.map(function(e){return"\x1b[(constant)m"+e+"\x1b[0m"}).join(", "));var e=d[t].transform?d[t].transform(e):e,r=y[t];!n&&d[t]&&d[t].global&&a.send(t+"ConfigSet",e,function(e){1!==e&&(y[t]=r,_(new Set([t])))});y[t]=e,d[t].onSet&&d[t].onSet(e);return _(new Set([t])),""},n.setTemp=function(e,t){!d.hasOwnProperty(e)||d[e].values&&-1===d[e].values.indexOf(t)||(p[e]=d[e].transform?d[e].transform(t):t)},n.reset=function(){for(var e in y)d[e]&&!d[e].global&&(y[e]=d[e].default);_(new Set(Object.keys(d)))},n.list=function(){var e,t={};for(e in y)t[e]={value:y[e],global:!!d[e].global};return t};var r=s(e("./storage")),o=s(e("./localization")),a=s(e("./server")),i=s(e("./output")),n=e("./init");function s(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}function l(e){return"true"===e}function u(e){return parseInt(e)}var c,f="terminal-config",e=["true","false"],p={},d={defaultNamespace:{default:""},initMessage:{default:!0,values:e,transform:l},language:{default:o.suggestLocale(),values:o.getLocales()},maxHistorySize:{default:200,transform:u},serverName:{default:"",global:!0},sqlMaxResults:{default:777,transform:u},suggestions:{default:!0,values:e,transform:l},syntaxHighlight:{default:!0,values:e,transform:l},updateCheck:{default:!0,values:e,transform:l,onSet:function(e){return i.print(e?":)":":(")}}},v={};for(c in d)v[c]=d[c].default;var y=Object.assign(Object.assign({},v),function(){var e,t=JSON.parse(r.get(f));for(e in t)d.hasOwnProperty(e)||delete t[e];return t}()||{});function _(e){e.has("language")&&o.setLocale(y.language),e.has("serverName")&&(document.title=y.serverName),r.set(f,JSON.stringify(y))}(0,n.onInit)(function(){return o.setLocale(y.language)})},{"./init":341,"./localization":349,"./output":356,"./server":360,"./storage":361}],338:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.faviconLink=n.themeLink=n.input=n.output=n.terminal=void 0;function r(e,t){return e=document.createElement(e),t&&(e.className=t),e}var e=e("./lib"),o=n.terminal=r("div","terminal"),a=n.output=r("div","output"),i=(n.input=r("textarea","input"),n.themeLink=r("link")),s=n.faviconLink=r("link");s.setAttribute("rel","shortcut icon"),s.setAttribute("href",e.images.favicon),i.setAttribute("rel","stylesheet"),o.appendChild(a),(0,e.onWindowLoad)(function(){document.head.appendChild(s),document.head.appendChild(i),document.body.appendChild(o)})},{"./lib":347}],339:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.get=function(e){return a[e]||""},n.set=function(e,t){a[e]=t,i()},n.list=function(){return Object.assign({},a)},n.clear=function(e){var t=!1;e?(a.hasOwnProperty(e)&&(t=!0),delete a[e]):(Object.keys(a).length&&(t=!0),a={});return i(),t};var r=function(e){{if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}}(e("./storage"));var o="terminal-favorites",a=JSON.parse(r.get(o))||{};function i(){r.set(o,JSON.stringify(a))}},{"./storage":361}],340:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.onOutput=n.onUserInput=n.inputActivated=n.MODE=n.NAMESPACE=n.VERSION=void 0;var r="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e};n.onAuth=g,n.authDone=function(){h||(h=!0,p.forEach(function(e){return e(m)}))},n.Terminal=b,n.promptCallback=function(e){"function"==typeof x&&(x([e]),x=null)},e("babel-polyfill"),e("./network");var o=f(e("./output")),a=f(e("./input")),i=f(e("./localization")),s=f(e("./server")),l=f(e("./config")),u=e("./init"),c=e("./lib");function f(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}var p=[],d=[],v=[],y=[],_=!1,h=!1,m=null;n.VERSION="4.9.4",n.NAMESPACE="USER",n.MODE=b.prototype.MODE_PROMPT;function g(e){h?e(m):p.push(e)}n.inputActivated=function(){if(_=!0,y.length){var e=!0,t=!1,n=void 0;try{for(var r,o=v[Symbol.iterator]();!(e=(r=o.next()).done);e=!0){var a=r.value;a.stream||a.callback(y)}}catch(e){t=!0,n=e}finally{try{!e&&o.return&&o.return()}finally{if(t)throw n}}y=[]}},n.onUserInput=function(t,n){d.forEach(function(e){return e(t,n)}),_=!(y=[])},n.onOutput=function(e){y.push(e);var t=!0,n=!1,r=void 0;try{for(var o,a=v[Symbol.iterator]();!(t=(o=a.next()).done);t=!0){var i=o.value;i.stream&&!_&&i.callback([e])}}catch(e){n=!0,r=e}finally{try{!t&&a.return&&a.return()}finally{if(n)throw r}}};function b(){(0,u.initDone)(this)}window.onTerminalInit=g,b.prototype.MODE_PROMPT=1,b.prototype.MODE_SQL=2,b.prototype.MODE_READ=3,b.prototype.MODE_READ_CHAR=4,b.prototype.MODE_SPECIAL=5,b.prototype.onOutput=function(e,t){return e&&"function"!=typeof e||(t=e||function(){throw new Error("onOutput: no callback provided!")},e={}),void 0===e.stream&&(e.stream=!1),e.callback=t,v.push(e),t},b.prototype.onUserInput=function(e){if("function"!=typeof e)throw new Error("onUserInput: no callback provided!");return d.push(e),e},b.prototype.print=function(e){a.clearPrompt(),o.print(e),a.reprompt()};var x=null;b.prototype.execute=function(e,t,n){if("function"==typeof t&&(n=t),"object"!==(void 0===t?"undefined":r(t))&&(t={}),s.send("Execute",{command:e,echo:+(t.echo||0),prompt:+(t.prompt||0),bufferOutput:+("function"==typeof n)}),"function"==typeof n)return x=n},b.prototype.removeCallback=function(e){var t=void 0,n=!1;if(-1!==(t=d.indexOf(e)))return d.splice(t,1),!0;if("function"==typeof x)return!(x=null);for(t=0;t<v.length;++t)v[t].callback===e&&(v.splice(t,1),--t,n=!0);return n},window[addEventListener?"addEventListener":"attachEvent"](addEventListener?"load":"onload",function(){var t=i.get("beforeInit"),e=(0,c.getURLParams)(),e=(m=new b,o.printLine(t),e.NS||e.ns||l.get("defaultNamespace")),e=null===location.search.match(/ns=[^&]*/i)?""===location.search?e?"?ns="+encodeURIComponent(e):"":location.search+(e?"&ns="+encodeURIComponent(e):""):e?location.search.replace(/ns=[^&]*/i,"ns="+encodeURIComponent(e)):location.search;(0,c.get)("auth"+e,function(e){if(e.key)try{o.print("\x1b[1;1H"+new Array(t.length+1).join(" ")+"\x1b[1;1H"),s.connect({key:e.key})}catch(e){o.printLine(i.get("jsErr",e.message))}else o.printLine(i.get("unSerRes"),JSON.stringify(e))})})},{"./config":337,"./init":341,"./input":345,"./lib":347,"./localization":349,"./network":350,"./output":356,"./server":360,"babel-polyfill":1}],341:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.onInit=function(e){o?e(a):r.push(e)},n.initDone=function(e){a=e,o=!0,r.forEach(function(e){return e(a)})};var r=[],o=!1,a=null},{}],342:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.getX=function(){return s},n.getY=function(){return l},n.update=function(){i.style.left=(s=(0,r.getCursorX)()-1)*r.SYMBOL_WIDTH+"px",i.style.top=(0,r.getTopLineIndex)()*r.SYMBOL_HEIGHT+(l=(0,r.getCursorY)()-1)*r.SYMBOL_HEIGHT+"px",a||i.parentNode||o.output.appendChild(i)},n.hide=function(){i.parentNode&&i.parentNode.removeChild(i)};var r=e("../output"),o=e("../elements"),a=-1!==window.navigator.userAgent.indexOf("MSIE ")||-1!==window.navigator.userAgent.indexOf("Trident/"),i=document.createElement("div"),s=(i.className="caret",0),l=0},{"../elements":338,"../output":356}],343:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0});var r=e("./special"),o=(r=r)&&r.__esModule?r:{default:r},a=p(e("./index")),i=p(e("../output")),s=p(e("../localization")),l=p(e("../server")),u=e("../index"),c=p(u),f=p(e("../config"));function p(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}n.default={special:function(e,t){c.onUserInput(e,u.Terminal.prototype.MODE_SPECIAL);var e=(t[1]||{}).value,n=void 0;a.clear(),"function"==typeof o.default[e]?(i.print("\r\n"),n=o.default[e](t),i.print("\r\n")):void 0===e?i.print("\r\n"+s.get("askEnSpec")+"\r\n"):i.print("\r\n"+s.get("noSpecComm",e)+"\r\n"),!1!==n&&a.reprompt()},normal:function(e,t,n){c.onUserInput(e,n)},sql:function(e){var t=f.get("sqlMaxResults");c.onUserInput(e,u.Terminal.prototype.MODE_SQL),i.newLine(),l.send("SQL",{sql:e,max:t},function(e){e.error?i.printLine("\x1b[(wrong)m"+s.parse(e.error)+"\x1b[0m"):(e.headers=e.headers||[],e.data=e.data||[],e=["<table><thead><tr><th>",e.headers.join("</th><th>"),"</th></tr></thead><tbody><tr>",e.data.slice(0,t).map(function(e){return"<td>"+(e||[]).join("</td><td>")+"</td>"}).join("</tr><tr>"),"</tr>",e.data.length>=t?'<tr><td colspan="'+e.headers.length+'">'+s.get("sqlMaxRows",t)+"</td></tr>":0===e.data.length?'<tr><td colspan="'+e.headers.length+'">'+s.get("sqlNoData")+"</td></tr>":"","</tbody></table>"],i.printLine("\r\n\x1b!<HTML>"+e.join("")+"</HTML>")),a.prompt(c.NAMESPACE+":SQL > ")})}}},{"../config":337,"../index":340,"../localization":349,"../output":356,"../server":360,"./index":345,"./special":346}],344:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.get=function(){var e=0<arguments.length&&void 0!==arguments[0]?arguments[0]:0;e&&s.length&&(l=(l+s.length+e)%s.length);return s[l]||""},n.set=function(e){var t=s.length-1;s[t<0?0:t]=e},n.isLast=function(){return l===s.length-1},n.setLast=function(){var e=0<arguments.length&&void 0!==arguments[0]?arguments[0]:"",t=s.length-1;l=t<0?0:t,e&&(s[l]=e)},n.push=function(e){e&&s[s.length-2]!==e?(s[s.length-1]=e,s.push(""),l=s.length-1,r.set(i,JSON.stringify(s.slice(-o.get("maxHistorySize"))))):l=s.length-1};var r=a(e("../storage")),o=a(e("../config"));function a(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}var i="terminal-history",s=JSON.parse(r.get(i))||[""],l=s.length-1},{"../config":337,"../storage":361}],345:[function(e,N,o){"use strict";Object.defineProperty(o,"__esModule",{value:!0}),o.PROMPT_CLEARED=o.ENABLED=void 0,o.focusInput=I,o.prompt=C,o.clearPrompt=function(){b&&(y.setCursorYToLineIndex(i),y.setCursorX(s),y.immediatePlainPrint(new Array(l[0].length+v.input.value.length+1).join(" ")),y.setCursorYToLineIndex(i),y.setCursorX(s),o.PROMPT_CLEARED=!0)},o.reprompt=function(){var e,t;b&&(e=v.input.value,t=v.input.selectionEnd,C.apply(this,l),v.input.value=e,O(t),M())},o.getKey=function(){var e=0<arguments.length&&void 0!==arguments[0]?arguments[0]:{},t=arguments[1];b&&T();u=h.Terminal.prototype.MODE_READ_CHAR,m.inputActivated(),W(),I(),_.hide();function n(e){!1!==function(e,t){if(e.stopPropagation(),e.preventDefault(),-1!==[16,17,18].indexOf(e.keyCode))return!1;var e=String.fromCharCode(e.keyCode)[e.shiftKey?"toUpperCase":"toLowerCase"](),n=e.charCodeAt(0),r=u;R(),31<n&&y.print(e);(0,h.onUserInput)(String.fromCharCode(n),r),t(n)}(e,t)&&window.removeEventListener("keydown",n)}window.addEventListener("keydown",n),clearTimeout(f),e.timeout&&(f=setTimeout(function(){f=0,window.removeEventListener("keydown",n),R(),t(-1)},1e3*e.timeout))},o.setCaretPosition=O,o.getCaretPosition=function(){{if(void 0!==v.input.selectionEnd)return v.input.selectionEnd;if(document.selection&&document.selection.createRange)return document.selection.createRange().getBookmark().charCodeAt(2)-2}return v.input.length},o.onKeyDown=function(e){d.push(e)},o.onUpdate=function(e){p.push(e)},o.setValue=function(e,t){v.input.value=e,t&&O(t);M()},o.getValue=function(){return v.input.value},o.update=M,o.clear=function(){v.input.value=""},o.hideInput=R;var v=a(e("../elements")),y=a(e("../output")),_=a(e("./caret")),n=a(e("./history")),h=e("../index"),m=a(h),D=e("../parser"),F=e("../autocomplete"),H=e("../server"),g=a(e("../config")),r=t(e("./handlers")),G=t(e("../autocomplete/hint"));function t(e){return e&&e.__esModule?e:{default:e}}function a(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}var b=o.ENABLED=!1,U=(o.PROMPT_CLEARED=!1,"selected"),x=0,w=0,i=0,s=0,l=[],j=!1,u=0,A=0,c=null,f=0,S=0,p=[],d=[],k=[],E=(window.addEventListener("keydown",function(e){I(),P(e)},!0),window.addEventListener("click",I,!0),v.input.addEventListener("input",function(){/\r?\n/.test(v.input.value)&&(v.input.value=v.input.value.replace(/(?:\r?\n)+/g," ")),n.setLast(v.input.value),M(),L()}),v.input.addEventListener("keydown",function(e){P(e)}),[void 0,void 0]);function I(){return!!b&&(""===document.getSelection().toString()&&(document.activeElement!==v.input&&(v.input.focus(),!0)))}function C(e){var t=1<arguments.length&&void 0!==arguments[1]?arguments[1]:{},n=2<arguments.length&&void 0!==arguments[2]?arguments[2]:null,r=!(3<arguments.length&&void 0!==arguments[3])||arguments[3];u=e?h.Terminal.prototype.MODE_PROMPT:h.Terminal.prototype.MODE_READ,s=y.getCursorX(),i=y.getCurrentLineIndex(),l=arguments,o.PROMPT_CLEARED=!1,j=r,m.inputActivated(),e&&y.print(e),o.ENABLED=b=!0,w=y.getCursorX(),x=y.getCurrentLineIndex(),c="function"==typeof n?n:null,clearTimeout(f),t.timeout&&(f=setTimeout(T,1e3*t.timeout)),S=t.length||0,W()}function O(e){var t;I(),v.input.createTextRange?((t=v.input.createTextRange()).move("character",e),t.select()):void 0!==v.input.selectionStart&&v.input.setSelectionRange(e,e)}function P(t){if(!t.handled&&(t.handled=!0,67===t.keyCode&&t.ctrlKey&&h.MODE!==h.Terminal.prototype.MODE_SQL&&""===function(){var e="";window.getSelection?e=window.getSelection().toString():document.selection&&"Control"!==document.selection.type&&(e=document.selection.createRange().text);return e}()&&((0,H.send)("Interrupt",{}),t.cancelBubble=!0),b&&!t.cancelBubble)){if(t.cancelBubble=!0,13===t.keyCode)return t.preventDefault(),void T();-1!==[35,36,37,39].indexOf(t.keyCode)&&setTimeout(function(){M(),L()},1),38!==t.keyCode&&40!==t.keyCode||(n.isLast()&&n.set(v.input.value),v.input.value=n.get(t.keyCode-39),M(),L(),setTimeout(function(){return O(v.input.value.length)},1)),d.forEach(function(e){return e(t)})}}function W(){A=0,v.input.value="",v.input.style.textIndent=(w-1)*y.SYMBOL_WIDTH+"px",v.input.style.top=x*y.SYMBOL_HEIGHT+"px",v.output.appendChild(v.input),M()}function L(){p.forEach(function(e){return e(v.input.value,v.input.selectionStart
+         )})}function M(){if(b){for(var e=j&&g.get("syntaxHighlight"),t=j&&g.get("suggestions"),n=(y.setCursorYToLineIndex(x),y.setCursorX(w),void 0===v.input.selectionStart?v.input.value.length:v.input.selectionStart),r=void 0===v.input.selectionEnd?v.input.value.length:v.input.selectionEnd,o=r-n,a=(0,D.process)(v.input.value,n,t,m.MODE===h.Terminal.prototype.MODE_SQL?"SQLMode":"CWTInput"),i=a.lexemes,s=a.suggestions,a=a.collector,l=0,u="",c=0;c<i.length;c++){var f=l<=n&&n<l+i[c].value.length,p=l<=r&&r<l+i[c].value.length;e&&i[c].class!==u&&(u=i[c].class,0<o&&n<l&&l<r||y.print("\x1b["+(""===u?0:"("+u+")")+"m")),f&&(y.print(i[c].value.substring(0,n-l)),_.update(),0<o&&y.print("\x1b[("+U+")m")),p?y.print(i[c].value.substring(f?n-l:0,r-l)):f&&y.print(i[c].value.substr(n-l)),p&&(0<o&&y.print("\x1b["+(""===u?0:"("+u+")")+"m"),y.print(i[c].value.substr(r-l))),f||p||y.print(i[c].value),l+=i[c].value.length}n===l&&_.update(),(u||l<A)&&y.print("\x1b[0m"),l<A&&y.print(new Array(A-l+1).join(" ")),A=l;var d=(y.getCurrentLineIndex()-x+1)*y.SYMBOL_HEIGHT;v.input.style.height!==d+"px"&&(v.input.style.height=d+"px"),b&&S&&v.input.value.length>=S?T():(k=i,(0,F.showSuggestions)(t&&0<n&&0<v.input.value.length&&0==o,s,a))}}function T(){var e=v.input.value,t=(k[0]||{}).value;if(n.push(e),G.default.hide(),j&&"/"===t)return r.default.special(e,k);r.default[m.MODE===h.Terminal.prototype.MODE_SQL?"sql":"normal"](e,k,u),o.ENABLED=b=!1,clearTimeout(f),f=0,c&&c(e),c=null,R()}function R(){u=0,v.input.parentNode&&v.input.parentNode.removeChild(v.input),o.ENABLED=b=!1,_.hide()}v.input.addEventListener("mousemove",function(){v.input.selectionStart===E[0]&&v.input.selectionEnd===E[1]||(E[0]=v.input.selectionStart,E[1]=v.input.selectionEnd,M())})},{"../autocomplete":335,"../autocomplete/hint":334,"../config":337,"../elements":338,"../index":340,"../output":356,"../parser":357,"../server":360,"./caret":342,"./handlers":343,"./history":344}],346:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0});var u=v(e("../localization")),c=v(e("../output")),f=v(e("../input")),a=v(e("../config")),r=e("../index"),o=v(r),i=v(e("../server")),s=v(e("../tracing")),p=v(e("../favorite")),l=e("../server/handlers"),d=e("../network");function v(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}n.default={help:function(){c.print(u.get("help")+"\r\n")},clear:function(){c.reset()},config:function(e){function t(e,t,n){for(var r in e){var o;e[r].global===n&&(o="string"==typeof e[r].value&&0===e[r].value.length?'\x1b[(string)m""\x1b[0m':"\x1b[(constant)m"+e[r].value+"\x1b[0m",c.print("\x1b[(variable)m"+r+"\x1b[0m\x1b["+t+"G= "+o+"\r\n"))}}if(e.length<4){var n,r=a.list(),o=0;for(n in r)n.length>o&&(o=n.length);return o+=2,c.print(u.get("availConfLoc")+"\r\n"),t(r,o,!1),c.print(u.get("availConfGlob")+"\r\n"),t(r,o,!0),void c.print(u.get("confHintSet")+"\r\n")}e.filter(function(e){return"global"===e.class})[0]?a.reset():e.length<5?c.print(u.get("confHintSet")+"\r\n"):(r=e.filter(function(e){return"variable"===e.class})[0],e=e.filter(function(e){return"constant"===e.class||"string"===e.class})[0],r&&e?""!==(r=a.set(r.value,"string"===e.class?e.value.substr(1,e.value.length-2):e.value))&&c.print(r+"\r\n"):c.print(u.get("confHintSet")+"\r\n"))},favorite:function(e){if(e.length<4){var t=p.list();if(0<Object.keys(t).length){var n,r,o=u.get("favKey"),a=u.get("favVal"),i=t,s=o.length+2;for(n in i)n.length>s&&(s=n.length);for(r in c.print("\x1b[1m"+o+"\x1b[0m\x1b["+s+"G  \x1b[1m"+a+"\x1b[0m\r\n"),i)c.print("\x1b[(constant)m"+r+"\x1b[0m\x1b["+s+"G= "+i[r]+"\r\n");c.newLine()}c.print(u.get("favDesc")+"\r\n")}else{var l;"delete"===e[3].value?e[4]&&" "===e[4].value&&e[5]?(t=p.clear(e[5].value),c.print(u.get("favDel"+(t?"OK":"NotOK"),e[5].value)+"\r\n")):(p.clear(),c.print(u.get("favDel")+"\r\n")):(e.length<6&&((l=p.get(e[3].value))?setTimeout(function(){return f.setValue(l)},1):c.print(u.get("noFav",e[3].value)+"\r\n")),(o=e.slice(5).map(function(e){return e.value}).join(""))&&e[3].value&&(p.set(e[3].value,o),c.print(u.get("favSet",e[3].value)+"\r\n")))}},info:function(){c.print(u.get("info")+"\r\n")},logout:function(){var e=void 0;try{e=document.execCommand("ClearAuthenticationCache")}catch(e){}(e=e||function(e){if(e)return!!e&&(e.open("HEAD",location.href,!0,"logout",(new Date).getTime().toString()),e.send(""),!0)}(window.XMLHttpRequest?new window.XMLHttpRequest:window.ActiveXObject?new ActiveXObject("Microsoft.XMLHTTP"):null))?(c.printLine(u.get("logOut")),location.reload()):c.printLine(u.get("unLogOut"))},sql:function(){var e=o.MODE!==r.Terminal.prototype.MODE_SQL;return o.MODE=e?r.Terminal.prototype.MODE_SQL:r.Terminal.prototype.MODE_PROMPT,e?f.prompt(o.NAMESPACE+":SQL > "):(0,l.prompt)(o.NAMESPACE),!1},trace:function(e){var t,n;if(e.length<4)return c.print(u.get("tracingUsage")+"\r\n"),void((t=s.getList())&&c.print(u.get("traceSight",t)+"\r\n"));"stop"===e[3].value?i.send("StopTracing",{},function(){var e=0<arguments.length&&void 0!==arguments[0]?arguments[0]:{OK:!1};e.OK&&s.stop(),c.printAsync(u.get(e.OK?"traceStopOK":"traceStopNotOK")+"\r\n")}):(n=e.slice(3).map(function(e){return e.value}).join(""),i.send("Trace",n,function(){var e=0<arguments.length&&void 0!==arguments[0]?arguments[0]:{OK:0};if(e.OK)return e.started?(s.start(n),void c.printAsync(u.get("traceStart",n)+"\r\n")):void(e.stopped&&(s.stop(n),c.printAsync(u.get("traceStop",n)+"\r\n")));c.printAsync(u.get("traceBad",n)+"\r\n")}))},update:function(){(0,d.checkUpdate)(!0)}}},{"../config":337,"../favorite":339,"../index":340,"../input":345,"../localization":349,"../network":350,"../output":356,"../server":360,"../server/handlers":359,"../tracing":362}],347:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.onWindowLoad=function(e){window.addEventListener?window.addEventListener("load",e):window.attachEvent("onload",e)},n.get=function(e,t){var n=new XMLHttpRequest;n.onreadystatechange=function(){if(4===n.readyState)if(200===n.status){var e={error:"Parse error",data:n.responseText};try{e=JSON.parse(n.responseText)}catch(e){}t(e)}else t({error:"HTTP "+n.status+" error"})};try{n.open("GET",""+e+(-1===e.indexOf("?")?"?":"&")+"_="+(new Date).getTime(),!0),n.send()}catch(e){console.error(e)}},n.getURLParams=function(){for(var e={},t=window.location.search.substring(1).split("&"),n=0;n<t.length;n++){var r=t[n].split("=");void 0===e[r[0]]?e[r[0]]=decodeURIComponent(r[1]):"string"==typeof e[r[0]]?e[r[0]]=[e[r[0]],decodeURIComponent(r[1])]:e[r[0]].push(decodeURIComponent(r[1]))}return e},String.prototype.splice=function(e,t,n){return this.slice(0,e)+n+this.slice(e+Math.abs(t))};n.images={favicon:"data:image/x-icon;base64,AAABAAEAEBAAAAAAAABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAD///8BAAAABQAAABEAAAAJAAAAAwAAAAMAAAAD////Af///wH///8B////Af///wH///8B////Af///wH///8B////AQAAAAcAAAAVLyoiXzcxJa09NijfPjcp4YiHhcWbm5ypioqLhWtrbF8vLy85AAAAIQAAAAP///8B////AXt7fBGFhYZHiomLRXFua0FEPzNPOjMkY1dSSceqqqr/vLy9/7a2t/+vr7D/kZGS4wAAABkAAAAbAAAAFf///wGXlZKPq6qg57GtlK2vqIqjsaySt6+qlcOvr5/1t7es/76+t//GxsT/zMzM98fIyIW8vLxDwcHBKY6Njg////8BioZ8j5aTjpkUERGjHRIS4SIVFM8oGRa9Mh8ZrUc0KatfTT2tdWROsYZ1XauciHGVt6aQl7uwnp/GxLPRuLi2gYyIfo+XlJCZCQgIzQAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8IBgX/Eg8O5bOwpXuOi4CPmZaSmQgIB80AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wICAfGqqKB3kY2Cj5yZlJkIBwfNAAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8FBATtpaKcd5SQhY+em5eZCAcHzQAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AAAA/wUFBf8aGhr/Li0s65+dl3WXk4iPop+amQgHB80AAAD/AAAA/wAAAP8AAAD/AAAA/wAAAP8AAAD/AQEB/xISEv8mJib/MjIy/zk3NumamJJ1m5eMj6WinZkHBwfPXV1d/wcHB/9PT0//V1dX/0tLS/8AAAD/BQUF/xkZGf8nJyf/MjIy/zw8PP9CPz3nlJKNdZ+bj5GopZ+ZBwcHz25ubv+qqqr/ODg4/zg4OP8pKSn/CAgI/xwcHP8oKCj/MzMz/zw8PP9DQ0P/SENB55COiXOin5KRq6iimQcHBs9gYGD/m5ub/wAAAP8AAAD/DQ0N/x0dHf8oKCj/MzMz/z09Pf9DQ0P/R0dH/0pFQ+WMioVzpaGUkaunoZ8ICAjPc3Nz/wcHB/0GBgb1FBMT7x4eHecqKSfhNTMx3T89OttIRUHZT0xH2VVSTNtwbWTflZOQibKwrYe4tanplpGCs4uDcamblIOto52Ot6Gcj7+fmo69nZmNs5qWi6mVkombjoyFjYaFgH9/f3xxfXx9Y3t8fi+npqYbsbKyU7m4uE2/v787srKxKY+OjxdtbW0H////Af///wH///8B////Af///wH///8B////Af///wH///8B//8AAPA/AAD8DwAAAA8AAAAAAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAEAAAAAAAAADwAA//8AAA=="}},{}],348:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.default={storageErr:{en:"Storage error: local storage is not supported by your browser. Please, consider updating your browser.",ru:"\u041e\u0448\u0438\u0431\u043a\u0430 \u0445\u0440\u0430\u043d\u0438\u043b\u0438\u0449\u0430: \u043b\u043e\u043a\u0430\u043b\u044c\u043d\u043e\u0435 \u0445\u0440\u0430\u043d\u0438\u043b\u0438\u0449\u0435 \u043d\u0435 \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u0438\u0432\u0430\u0435\u0442\u0441\u044f \u0431\u0440\u0430\u0443\u0437\u0435\u0440\u043e\u043c. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u043e\u0431\u043d\u043e\u0432\u0438\u0442\u0435 \u0432\u0430\u0448 \u0431\u0440\u0430\u0443\u0437\u0435\u0440."},noLocale:{en:'No such locale "%s".',ru:'\u041d\u0435\u0442 \u043b\u043e\u043a\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438 \u0434\u043b\u044f "%s"'},wsErr:{en:"WebSocket error: %s",ru:"\u041e\u0448\u0438\u0431\u043a\u0430 WebSocket: %s"},serParseErr:{en:"Unable to parse server response: %s",ru:"\u041d\u0435\u0432\u043e\u0437\u043c\u043e\u0436\u043d\u043e \u043e\u0431\u0440\u0430\u0431\u043e\u0442\u0430\u0442\u044c \u043e\u0442\u0432\u0435\u0442 \u0441\u0435\u0440\u0432\u0435\u0440\u0430: %s"},reConn:{en:"Attempting to restore session in %n seconds...",ru:"\u041f\u043e\u043f\u044b\u0442\u043a\u0430 \u0432\u043e\u0441\u0441\u0442\u0430\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u044f \u0441\u0435\u0441\u0441\u0438\u0438 \u0447\u0435\u0440\u0435\u0437 %n \u0441\u0435\u043a\u0443\u043d\u0434..."},seeYou:{en:"See you!",ru:"\u0414\u043e \u043d\u043e\u0432\u044b\u0445 \u0432\u0441\u0442\u0440\u0435\u0447!"},eInt:{en:"WebTerminal internal error %s",ru:"\u0412\u043d\u0443\u0442\u0440\u0435\u043d\u043d\u044f\u044f \u043e\u0448\u0438\u0431\u043a\u0430 \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b\u0430 %s"},noJob:{en:"Unable to start new Job",ru:"\u041d\u0435\u0432\u043e\u0437\u043c\u043e\u0436\u043d\u043e \u0437\u0430\u043f\u0443\u0441\u0442\u0438\u0442\u044c \u043d\u043e\u0432\u044b\u0439 Job"},wsConnLost:{en:"WebTerminal lost connection with server (code %n%s).",ru:"\u0412\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b \u043f\u043e\u0442\u0435\u0440\u044f\u043b \u0441\u043e\u0435\u0434\u0438\u043d\u0435\u043d\u0438\u0435 \u0441 \u0441\u0435\u0440\u0432\u0435\u0440\u043e\u043c (\u043a\u043e\u0434 %n%s)"},plRefPageSes:{en:"Please, refresh the web page to start a new session.",ru:"\u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u043e\u0431\u043d\u043e\u0432\u0438\u0442\u0435 \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0443 \u0447\u0442\u043e\u0431\u044b \u043d\u0430\u0447\u0430\u0442\u044c \u043d\u043e\u0432\u0443\u044e \u0441\u0435\u0441\u0441\u0438\u044e."},noUpdUrl:{en:"Unable to get update URL. Please, update \x1b!URL=%s (manually).",ru:"\u041d\u0435 \u043f\u043e\u043b\u0443\u0447\u0430\u0435\u0442\u0441\u044f \u043f\u043e\u043b\u0443\u0447\u0438\u0442\u044c URL \u043e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u044f. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u044b\u043f\u043e\u043b\u043d\u0438\u0442\u0435 \u043e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0435 \x1b!URL=%s (\u0432\u0440\u0443\u0447\u043d\u0443\u044e)."},updReady:{en:"\x1b[36mNew update is available.\x1b[0m \x1b!URL=%s (Click here) to install it now. Changelist:",ru:"\x1b[36m\u0414\u043e\u0441\u0442\u0443\u043f\u043d\u043e \u043e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0435.\x1b[0m \x1b!URL=%s (\u041d\u0430\u0436\u043c\u0438\u0442\u0435 \u0442\u0443\u0442) \u0447\u0442\u043e\u0431\u044b \u0443\u0441\u0442\u0430\u043d\u043e\u0432\u0438\u0442\u044c \u0435\u0433\u043e \u0441\u0435\u0439\u0447\u0430\u0441. \u0421\u043f\u0438\u0441\u043e\u043a \u0438\u0437\u043c\u0435\u043d\u0435\u043d\u0438\u0439:"},updStart:{en:"Updating WebTerminal... %s -> %s",ru:"WebTerminal \u043e\u0431\u043d\u043e\u0432\u043b\u044f\u0435\u0442\u0441\u044f... %s -> %s"},rSerUpd:{en:"Requesting server to update...",ru:"\u041f\u0440\u043e\u0441\u0438\u043c \u0441\u0435\u0440\u0432\u0435\u0440 \u043e\u0431\u043d\u043e\u0432\u0438\u0442\u044c\u0441\u044f..."},sUpdSt:{en:"Update started, please, \x1b[4mdo not close this window\x1b[0m.",ru:"\u041e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0435 \u043d\u0430\u0447\u0430\u043b\u043e\u0441\u044c, \u043f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \x1b[4m\u043d\u0435 \u0437\u0430\u043a\u0440\u044b\u0432\u0430\u0439\u0442\u0435 \u044d\u0442\u043e \u043e\u043a\u043d\u043e.\x1b[0m"},sUpdRURL:{en:"Requesting %s",ru:"\u0417\u0430\u043f\u0440\u0430\u0448\u0438\u0432\u0430\u0435\u043c %s"},sUpdGetOK:{en:"Response downloaded.",ru:"\u041e\u0442\u0432\u0435\u0442 \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043d."},sUpdSCode:{en:"Unable to update WebTerminal: HTTPS request ended with the code %s.",ru:"\u041d\u0435\u0432\u043e\u0437\u043c\u043e\u0436\u043d\u043e \u043e\u0431\u043d\u043e\u0432\u0438\u0442\u044c \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b: HTTPS-\u0437\u0430\u043f\u0440\u043e\u0441 \u0437\u0430\u0432\u0435\u0440\u0448\u0438\u043b\u0441\u044f \u0441 \u043a\u043e\u0434\u043e\u043c %s."},sUpdWTF:{en:"Writing WebTerminal's new version a temporary file...",ru:"\u0417\u0430\u043f\u0438\u0441\u044b\u0432\u0430\u0435\u043c \u043d\u043e\u0432\u0443\u044e \u0432\u0435\u0440\u0441\u0438\u044e \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b\u0430 \u0432\u043e \u0432\u0440\u0435\u043c\u0435\u043d\u043d\u044b\u0439 \u0444\u0430\u0439\u043b..."},sUpdErr:{en:"Update \x1b[31mfailed\x1b[0m! Error: %s",ru:"\u041e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0435 \x1b[31m\u043d\u0435 \u043f\u043e\u043b\u0443\u0447\u0438\u043b\u043e\u0441\u044c\x1b[0m! \u041e\u0448\u0438\u0431\u043a\u0430: %s"},sUpdRes:{en:"Update failed. Possibly, the new WebTerminal version is not compatible with your system anymore, or the update was not tested for this system. Please report this issue \x1b!URL=https://github.com/intersystems-community/webterminal/issues (here) and attach the update log. You can try waiting some time (finite or infinite) until this problem is identified and fixed.",
+         ru:"\u041e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0435 \u043d\u0435 \u0443\u0434\u0430\u043b\u043e\u0441\u044c. \u0412\u043e\u0437\u043c\u043e\u0436\u043d\u043e, \u043d\u043e\u0432\u0430\u044f \u0432\u0435\u0440\u0441\u0438\u044f \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b\u0430 \u0431\u043e\u043b\u044c\u0448\u0435 \u043d\u0435 \u0441\u043e\u0432\u043c\u0435\u0441\u0442\u0438\u043c\u0430 \u0441 \u0432\u0430\u0448\u0435\u0439 \u0441\u0438\u0441\u0442\u0435\u043c\u043e\u0439, \u0438\u043b\u0438 \u043e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0435 \u043d\u0435 \u0431\u044b\u043b\u043e \u043f\u0440\u043e\u0442\u0435\u0441\u0442\u0438\u0440\u043e\u0432\u0430\u043d\u043e \u0434\u043b\u044f \u043d\u0435\u0451. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u043e\u0431\u0440\u0430\u0442\u0438\u0442\u0435\u0441\u044c \u0432 \x1b!URL=https://github.com/intersystems-community/webterminal/issues (\u043f\u043e\u0434\u0434\u0435\u0440\u0436\u043a\u0443) \u0441 \u0432\u043e\u043f\u0440\u043e\u0441\u043e\u043c, \u043f\u0440\u0438\u043a\u0440\u0435\u043f\u0438\u0432 \u043b\u043e\u0433 \u043e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u044f \u0438\u043b\u0438 \u043f\u043e\u0434\u043e\u0436\u0434\u0438\u0442\u0435 \u043d\u0435\u043a\u043e\u0442\u043e\u0440\u043e\u0435 \u043a\u043e\u043b\u0438\u0447\u0435\u0441\u0442\u0432\u043e \u0432\u0440\u0435\u043c\u0435\u043d\u0438 (\u043a\u043e\u043d\u0435\u0447\u043d\u043e\u0435 \u0438\u043b\u0438 \u0431\u0435\u0441\u043a\u043e\u043d\u0435\u0447\u043d\u043e\u0435), \u043f\u043e\u043a\u0430 \u043f\u0440\u043e\u0431\u043b\u0435\u043c\u0430 \u043d\u0435 \u0431\u0443\u0434\u0435\u0442 \u0432\u044b\u044f\u0432\u043b\u0435\u043d\u0430 \u0438 \u0438\u0441\u043f\u0440\u0430\u0432\u043b\u0435\u043d\u0430."},sUpdBack:{en:"Backing up current version to %s...",ru:"\u0421\u043e\u0445\u0440\u0430\u043d\u044f\u0435\u043c \u0440\u0435\u0437\u0435\u0440\u0432\u043d\u0443\u044e \u043a\u043e\u043f\u0438\u044e \u0442\u0435\u043a\u0443\u0449\u0435\u0439 \u0432\u0435\u0440\u0441\u0438\u0438 \u0432 %s..."},sUpdRemLoad:{en:"Deleting old version and importing a new one...",ru:"\u0423\u0434\u0430\u043b\u044f\u0435\u043c \u043f\u0440\u043e\u0448\u043b\u0443\u044e \u0432\u0435\u0440\u0441\u0438\u044e \u0438 \u0438\u043c\u043f\u043e\u0440\u0442\u0438\u0440\u0443\u0435\u043c \u043d\u043e\u0432\u0443\u044e..."},sUpdNoFile:{en:"No file %s",ru:"\u041d\u0435\u0442 \u0444\u0430\u0439\u043b\u0430 %s"},sUpdCleanLog:{en:"Deleting log file %s...",ru:"\u0423\u0434\u0430\u043b\u044f\u0435\u043c \u0444\u0430\u0439\u043b \u0441 \u043b\u043e\u0433\u0430\u043c\u0438 %s..."},sUpdClean:{en:"Deleting temporary file %s...",ru:"\u0423\u0434\u0430\u043b\u044f\u0435\u043c \u0432\u0440\u0435\u043c\u0435\u043d\u043d\u044b\u0439 \u0444\u0430\u0439\u043b %s..."},sUpdDone:{en:"Update completed! Please, \x1b!URL=javascript:location.reload() (reload) the page.",ru:"\u041e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0435 \u0437\u0430\u0432\u0435\u0440\u0448\u0435\u043d\u043e! \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \x1b!URL=javascript:location.reload() (\u043e\u0431\u043d\u043e\u0432\u0438\u0442\u0435) \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0443."},askEnSpec:{en:"Please, enter the special command. Try entering \x1b[(special)m/help\x1b[0m first.",ru:"\u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \u0441\u043f\u0435\u0446\u0438\u0430\u043b\u044c\u043d\u0443\u044e \u043a\u043e\u043c\u0430\u043d\u0434\u0443. \u041d\u0430\u0447\u043d\u0438\u0442\u0435 \u0441 \u0432\u0432\u043e\u0434\u0430 \x1b[(special)m/help\x1b[0m, \u043d\u0430\u043f\u0440\u0438\u043c\u0435\u0440."},noSpecComm:{en:"There is no special command \x1b[(special)m/%s\x1b[0m. Please, enter \x1b[(special)m/help\x1b[0m to get a list of available commands.",ru:"\u0421\u043f\u0435\u0446\u0438\u0430\u043b\u044c\u043d\u0430\u044f \u043a\u043e\u043c\u0430\u043d\u0434\u0430 \x1b[(special)m/%s\x1b[0m \u043d\u0435 \u0441\u0443\u0449\u0435\u0441\u0442\u0432\u0443\u0435\u0442. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \x1b[(special)m/help\x1b[0m \u0447\u0442\u043e\u0431\u044b \u0443\u0437\u043d\u0430\u0442\u044c \u0441\u043f\u0438\u0441\u043e\u043a \u0434\u043e\u0441\u0442\u0443\u043f\u043d\u044b\u0445 \u043a\u043e\u043c\u0430\u043d\u0434."},help:{en:"\x1b[1mCach\xe9 WEB Terminal \x1b[(keyword)mv4.9.4\x1b[0m\n\r\n\r\x1b[4mAvailable commands:\x1b[0m\n\r\x1b[(special)m/help\x1b[0m\x1b[20GDisplay the short documentation (like you just did).\n\r\x1b[(special)m/clear\x1b[0m\x1b[20GClears the screen and all the history.\n\r\x1b[(special)m/config\x1b[0m ...\x1b[20GAllows you to configure WebTerminal's behavior. Enter this command to get more information.\n\r\x1b[(special)m/favorite\x1b[0m ...\x1b[20GAllows you to save or restore any frequently used commands. Enter this command to get more information.\n\r\x1b[(special)m/info\x1b[0m\x1b[20GShow the information about the WebTerminal project.\n\r\x1b[(special)m/logout\x1b[0m\x1b[20GLog out the current WebTerminal user and prompt for the authentication again.\n\r\x1b[(special)m/sql\x1b[0m\x1b[20GSwitches terminal to SQL mode. Type SQL commands instead of ObjectScript. To exit SQL mode, enter this command again.\n\r\x1b[(special)m/trace\x1b[0m ...\x1b[20GEnables global/file tracing. Type this command to get more information.\n\r\x1b[(special)m/update\x1b[0m\x1b[20GChecks for available updates.\n\r\n\r\x1b[4mKeys:\x1b[0m\n\r\x1b[(special)mCtrl + C\x1b[0m\x1b[20GInterrupt the command execution.\n\r\x1b[(special)mTAB\x1b[0m\x1b[20GComplete the input with proposed autocomplete variant.\n\r\x1b[(special)mRight/left CTRL\x1b[0m\x1b[20GSwitch autocomplete variant when multiple are available.\n\r\n\rPress \x1b!URL=http://intersystems-community.github.io/webterminal/#docs (here) to see the full documentation.",ru:"\x1b[1mCach\xe9 WEB Terminal \x1b[(keyword)mv4.9.4\x1b[0m\n\r\n\r\x1b[4m\u0414\u043e\u0441\u0442\u0443\u043f\u043d\u044b\u0435 \u043a\u043e\u043c\u0430\u043d\u0434\u044b:\x1b[0m\n\r\x1b[(special)m/help\x1b[0m\x1b[20G\u041e\u0442\u043e\u0431\u0440\u0430\u0437\u0438\u0442\u044c \u043a\u043e\u0440\u043e\u0442\u043a\u0443\u044e \u0434\u043e\u043a\u0443\u043c\u0435\u043d\u0442\u0430\u0446\u0438\u044e (\u043a\u0430\u043a \u0432\u044b \u0442\u043e\u043b\u044c\u043a\u043e \u0447\u0442\u043e \u0441\u0434\u0435\u043b\u0430\u043b\u0438).\n\r\x1b[(special)m/clear\x1b[0m\x1b[20G\u041f\u043e\u043b\u043d\u043e\u0441\u0442\u044c\u044e \u043e\u0447\u0438\u0449\u0430\u0435\u0442 \u044d\u043a\u0440\u0430\u043d \u0438 \u0435\u0433\u043e \u0438\u0441\u0442\u043e\u0440\u0438\u044e.\n\r\x1b[(special)m/config\x1b[0m ...\x1b[20G\u041f\u043e\u0437\u0432\u043e\u043b\u044f\u0435\u0442 \u043d\u0430\u0441\u0442\u0440\u0430\u0438\u0432\u0430\u0442\u044c \u043f\u043e\u0432\u0435\u0434\u0435\u043d\u0438\u0435 \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b\u0430. \u0412\u0432\u0435\u0434\u0438\u0442\u0435 \u044d\u0442\u0443 \u043a\u043e\u043c\u0430\u043d\u0434\u0443, \u0447\u0442\u043e\u0431\u044b \u043f\u043e\u043b\u0443\u0447\u0438\u0442\u044c \u0431\u043e\u043b\u044c\u0448\u0435 \u0438\u043d\u0444\u043e\u0440\u043c\u0430\u0446\u0438\u0438.\n\r\x1b[(special)m/favorite\x1b[0m ...\x1b[20G\u041f\u043e\u0437\u0432\u043e\u043b\u044f\u0435\u0442 \u0441\u043e\u0445\u0440\u0430\u043d\u044f\u0442\u044c \u0438 \u0437\u0430\u0433\u0440\u0443\u0436\u0430\u0442\u044c \u043b\u044e\u0431\u044b\u0435 \u0447\u0430\u0441\u0442\u043e \u0438\u0441\u043f\u043e\u043b\u044c\u0437\u0443\u0435\u043c\u044b\u0435 \u043a\u043e\u043c\u0430\u043d\u0434\u044b. \u0412\u0432\u0435\u0434\u0438\u0442\u0435 \u044d\u0442\u0443 \u043a\u043e\u043c\u0430\u043d\u0434\u0443, \u0447\u0442\u043e\u0431\u044b \u043f\u043e\u043b\u0443\u0447\u0438\u0442\u044c \u0431\u043e\u043b\u044c\u0448\u0435 \u0438\u043d\u0444\u043e\u0440\u043c\u0430\u0446\u0438\u0438.\n\r\x1b[(special)m/info\x1b[0m\x1b[20G\u041f\u043e\u043a\u0430\u0437\u0430\u0442\u044c \u0438\u043d\u0444\u043e\u0440\u043c\u0430\u0446\u0438\u044e \u043f\u0440\u043e \u043f\u0440\u043e\u0435\u043a\u0442 \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b\u0430.\n\r\x1b[(special)m/logout\x1b[0m\x1b[20G\u0412\u044b\u0439\u0442\u0438 \u0438\u0437 \u0442\u0435\u043a\u0443\u0449\u0435\u0433\u043e \u0441\u0435\u0430\u043d\u0441\u0430 \u0438 \u0441\u043d\u043e\u0432\u0430 \u043f\u0440\u043e\u0439\u0442\u0438 \u0430\u0443\u0442\u0435\u043d\u0442\u0438\u0444\u0438\u043a\u0430\u0446\u0438\u044e.\n\r\x1b[(special)m/sql\x1b[0m\x1b[20G\u041f\u0435\u0440\u0435\u043a\u043b\u044e\u0447\u0438\u0442\u044c \u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b \u0432 \u0440\u0435\u0436\u0438\u043c SQL. \u0414\u0430\u043b\u0435\u0435 \u0432\u0432\u043e\u0434\u0438\u0442\u0435 SQL \u043a\u043e\u043c\u0430\u043d\u0434\u044b \u0432\u043c\u0435\u0441\u0442\u043e ObjectScript. \u0427\u0442\u043e\u0431\u044b \u0432\u044b\u0439\u0442\u0438 \u0438\u0437 \u0440\u0435\u0436\u0438\u043c\u0430 SQL, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \u044d\u0442\u0443 \u043a\u043e\u043c\u0430\u043d\u0434\u0443 \u0435\u0449\u0451 \u0440\u0430\u0437.\n\r\x1b[(special)m/trace\x1b[0m ...\x1b[20G\u0412\u043a\u043b\u044e\u0447\u0430\u0435\u0442 \u0442\u0440\u0430\u0441\u0441\u0438\u0440\u043e\u0432\u043a\u0443 \u0433\u043b\u043e\u0431\u0430\u043b\u0430/\u0444\u0430\u0439\u043b\u0430. \u0412\u0432\u0435\u0434\u0438\u0442\u0435 \u044d\u0442\u0443 \u043a\u043e\u043c\u0430\u043d\u0434\u0443, \u0447\u0442\u043e\u0431\u044b \u043f\u043e\u043b\u0443\u0447\u0438\u0442\u044c \u0431\u043e\u043b\u044c\u0448\u0435 \u0438\u043d\u0444\u043e\u0440\u043c\u0430\u0446\u0438\u0438.\n\r\x1b[(special)m/update\x1b[0m\x1b[20G\u041f\u0440\u043e\u0432\u0435\u0440\u044f\u0435\u0442 \u043d\u0430\u043b\u0438\u0447\u0438\u0435 \u043e\u0431\u043d\u043e\u0432\u043b\u0435\u043d\u0438\u0439.\n\r\n\r\x1b[4m\u041a\u043b\u0430\u0432\u0438\u0448\u0438:\x1b[0m\n\r\x1b[(special)mCtrl + C\x1b[0m\x1b[20G\u041f\u0440\u0435\u0440\u0432\u0430\u0442\u044c \u0432\u044b\u043f\u043e\u043b\u043d\u0435\u043d\u0438\u0435 \u043a\u043e\u043c\u0430\u043d\u0434\u044b.\n\r\x1b[(special)mTAB\x1b[0m\x1b[20G\u0417\u0430\u0432\u0435\u0440\u0448\u0438\u0442\u044c \u0432\u0432\u043e\u0434 \u043f\u0440\u0435\u0434\u043b\u043e\u0436\u0435\u043d\u043d\u044b\u043c \u0432\u0430\u0440\u0438\u0430\u043d\u0442\u043e\u043c.\n\r\x1b[(special)m\u041f\u0440\u0430\u0432\u044b\u0439/\u043b\u0435\u0432\u044b\u0439 CTRL\x1b[0m\x1b[20G\u041f\u0435\u0440\u0435\u043a\u043b\u044e\u0447\u0438\u0442\u044c \u0432\u0430\u0440\u0438\u0430\u043d\u0442 \u0430\u0432\u0442\u043e\u0434\u043e\u043f\u043e\u043b\u043d\u0435\u043d\u0438\u044f, \u043a\u043e\u0433\u0434\u0430 \u0438\u0445 \u0434\u043e\u0441\u0442\u0443\u043f\u043d\u043e \u043d\u0435\u0441\u043a\u043e\u043b\u044c\u043a\u043e.\n\r\n\r\u041d\u0430\u0436\u043c\u0438\u0442\u0435 \x1b!URL=http://intersystems-community.github.io/webterminal/#docs (\u0437\u0434\u0435\u0441\u044c) \u0447\u0442\u043e\u0431\u044b \u043e\u0437\u043d\u0430\u043a\u043e\u043c\u0438\u0442\u044c\u0441\u044f \u0441 \u043f\u043e\u043b\u043d\u043e\u0439 \u0434\u043e\u043a\u0443\u043c\u0435\u043d\u0442\u0430\u0446\u0438\u0435\u0439."},info:{en:"Cach\xe9 WEB Terminal v4.9.4\n\rAuthor:\x1b[32G\x1b!URL=https://nikita.tk (Nikita Savchenko) (ZitRo)\n\rWebsite:\x1b[32G\x1b!URL=https://intersystems-community.github.io/webterminal (GitHub Pages)\n\rDocumentation:\x1b[32G\x1b!URL=http://intersystems-community.github.io/webterminal/#docs (GitHub Pages)\n\rRepository:\x1b[32G\x1b!URL=https://github.com/intersystems-community/webterminal (GitHub)\n\rBug/Feature Tracker:\x1b[32G\x1b!URL=https://github.com/intersystems-community/webterminal/issues (GitHub)\n\r2013-"+(new Date).getFullYear()+" \xa9 Nikita Savchenko",ru:"Cach\xe9 WEB Terminal v4.9.4\n\r\u0410\u0432\u0442\u043e\u0440:\x1b[32G\x1b!URL=https://nikita.tk (\u041d\u0438\u043a\u0438\u0442\u0430 \u0421\u0430\u0432\u0447\u0435\u043d\u043a\u043e) (ZitRo)\n\r\u0412\u0435\u0431\u0441\u0430\u0439\u0442:\x1b[32G\x1b!URL=https://intersystems-community.github.io/webterminal (\u0421\u0442\u0440\u0430\u043d\u0438\u0446\u0430 \u043f\u0440\u043e\u0435\u043a\u0442\u0430)\n\r\u0414\u043e\u043a\u0443\u043c\u0435\u043d\u0442\u0430\u0446\u0438\u044f:\x1b[32G\x1b!URL=http://intersystems-community.github.io/webterminal/#docs (\u041d\u0430 \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0435 \u043f\u0440\u043e\u0435\u043a\u0442\u0430)\n\r\u0420\u0435\u043f\u043e\u0437\u0438\u0442\u043e\u0440\u0438\u0439:\x1b[32G\x1b!URL=https://github.com/intersystems-community/webterminal (GitHub)\n\r\u0411\u0430\u0433/\u0424\u0438\u0447 \u0442\u0440\u0435\u043a\u0435\u0440:\x1b[32G\x1b!URL=https://github.com/intersystems-community/webterminal/issues (GitHub)\n\r2013-"+(new Date).getFullYear()+" \xa9 \u041d\u0438\u043a\u0438\u0442\u0430 \u0421\u0430\u0432\u0447\u0435\u043d\u043a\u043e"},beforeInit:{en:"Terminal load complete. Getting auth key...",ru:"\u0422\u0435\u0440\u043c\u0438\u043d\u0430\u043b \u0437\u0430\u0433\u0440\u0443\u0436\u0435\u043d. \u041f\u043e\u043b\u0443\u0447\u0435\u043d\u0438\u0435 \u043a\u043b\u044e\u0447\u0430 \u0434\u043b\u044f \u0430\u0432\u0442\u043e\u0440\u0438\u0437\u0430\u0446\u0438\u0438..."},unSerRes:{en:"Unknown server response: %s",ru:"\u041d\u0435\u043e\u043f\u043e\u0437\u043d\u0430\u043d\u043d\u044b\u0439 \u043e\u0442\u0432\u0435\u0442 \u0441\u0435\u0440\u0432\u0435\u0440\u0430: %s"},wsRefuse:{en:"Server refused WebSocket connection with the next message: %s",ru:"\u0421\u0435\u0440\u0432\u0435\u0440 \u043e\u0442\u043a\u043b\u043e\u043d\u0438\u043b \u0441\u043e\u0435\u0434\u0438\u043d\u0435\u043d\u0438\u0435 \u0447\u0435\u0440\u0435\u0437 WebSocket \u0441\u043e \u0441\u043b\u0435\u0434\u0443\u044e\u0449\u0438\u043c \u0441\u043e\u043e\u0431\u0449\u0435\u043d\u0438\u0435\u043c: %s"},wsReadErr:{en:"WebSocket read error",ru:"\u041e\u0448\u0438\u0431\u043a\u0430 WebSocket \u043f\u0440\u0438 \u0447\u0442\u0435\u043d\u0438\u0438"},wsParseErr:{en:"WebSocket message parse error",ru:"\u041e\u0448\u0431\u0438\u043a\u0430 \u0434\u0435\u0441\u0435\u0440\u0435\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438 WebSocket-\u0444\u0440\u0435\u0439\u043c\u0430"},wsAbnormal:{en:"WebSocket abnormal exit occurred",ru:"\u041f\u0440\u043e\u0438\u0437\u043e\u0448\u043b\u043e \u043d\u0435\u0442\u0440\u0430\u0434\u0438\u0446\u0438\u043e\u043d\u043d\u043e\u0435 \u0437\u0430\u043a\u0440\u044b\u0442\u0438\u0435 WebSocket-\u0441\u043e\u0435\u0434\u0438\u043d\u0435\u043d\u0438\u044f"},availConfLoc:{en:"WebTerminal's local configuration (persists in the browser):",
+         ru:"\u041b\u043e\u043a\u0430\u043b\u044c\u043d\u0430\u044f \u043a\u043e\u043d\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044f \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b\u0430 (\u0445\u0440\u0430\u043d\u0438\u0442\u0441\u044f \u0432 \u0431\u0440\u0430\u0443\u0437\u0435\u0440\u0435):"},availConfGlob:{en:"WebTerminal's global configuration (persists on the server):",ru:"\u0413\u043b\u043e\u0431\u0430\u043b\u044c\u043d\u0430\u044f \u043a\u043e\u043d\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044f \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b\u0430 (\u0445\u0440\u0430\u043d\u0438\u0442\u0441\u044f \u043d\u0430 \u0441\u0435\u0440\u0432\u0435\u0440\u0435):"},confHintSet:{en:"To change any option, enter \x1b[(special)m/config\x1b[0m \x1b[(variable)mkey\x1b[0m = \x1b[(constant)mvalue\x1b[0m. Enter \x1b[(special)m/config\x1b[0m \x1b[(global)mdefault\x1b[0m to reset \x1b[4mlocal\x1b[0m configuration.",ru:"\u0427\u0442\u043e\u0431\u044b \u0438\u0437\u043c\u0435\u043d\u0438\u0442\u044c \u043e\u043f\u0446\u0438\u044e, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \x1b[(special)m/config\x1b[0m \x1b[(variable)m\u043a\u043b\u044e\u0447\x1b[0m = \x1b[(constant)m\u0437\u043d\u0430\u0447\u0435\u043d\u0438\u0435\x1b[0m. \u0412\u0432\u0435\u0434\u0438\u0442\u0435 \x1b[(special)m/config\x1b[0m \x1b[(global)mdefault\x1b[0m \u0447\u0442\u043e\u0431\u044b \u0441\u0431\u0440\u043e\u0441\u0438\u0442\u044c \x1b[4m\u043b\u043e\u043a\u0430\u043b\u044c\u043d\u0443\u044e\x1b[0m \u043a\u043e\u043d\u0444\u0438\u0433\u0443\u0440\u0430\u0446\u0438\u044e."},confNoKey:{en:"No option \x1b[(variable)m%s\x1b[0m.",ru:"\u041d\u0435\u0442 \u043e\u043f\u0446\u0438\u0438 \x1b[(variable)m%s\x1b[0m."},confInvVal:{en:"Invalid value for \x1b[(variable)m%s\x1b[0m. Only the next values available: %s",ru:"\u041d\u0435\u0434\u043e\u043f\u0443\u0441\u0442\u0438\u043c\u043e\u0435 \u0437\u043d\u0430\u0447\u0435\u043d\u0438\u0435 \u0434\u043b\u044f \x1b[(variable)m%s\x1b[0m. \u0414\u043e\u043f\u0443\u0441\u0442\u0438\u043c\u044b \u0442\u043e\u043b\u044c\u043a\u043e \u0441\u043b\u0435\u0434\u0443\u044e\u0449\u0438\u0435 \u0437\u043d\u0430\u0447\u0435\u043d\u0438\u044f: %s"},firstLaunchMessage:{en:"Welcome to WebTerminal! Type \x1b[(special)m/help\x1b[0m special command to see how to use all the features.",ru:"\u0414\u043e\u0431\u0440\u043e \u043f\u043e\u0436\u0430\u043b\u043e\u0432\u0430\u0442\u044c \u0432 \u0432\u0435\u0431-\u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b! \u0412\u0432\u0435\u0434\u0438\u0442\u0435 \u0441\u043f\u0435\u0446\u0438\u0430\u043b\u044c\u043d\u0443\u044e \u043a\u043e\u043c\u0430\u043d\u0434\u0443 \x1b[(special)m/help\x1b[0m \u0447\u0442\u043e\u0431\u044b \u0443\u0437\u043d\u0430\u0442\u044c \u043e\u0431\u043e \u0432\u0441\u0435\u0445 \u0435\u0433\u043e \u043e\u0441\u043e\u0431\u0435\u043d\u043d\u043e\u0441\u0442\u044f\u0445."},badSQL:{en:"Mistake in SQL statement, %s",ru:"\u041e\u0448\u0438\u0431\u043a\u0430 \u0432 SQL-\u0437\u0430\u043f\u0440\u043e\u0441\u0435, %s"},sqlErr:{en:"SQL Error, %s",ru:"SQL \u043e\u0448\u0438\u0431\u043a\u0430, %s"},sqlMaxRows:{en:"The maximum number of rows displayed is %s. Adjust the limit by typing <span class='m special'>/config</span> <span class='m variable'>sqlMaxResults</span> = <span class='m constant'>100500</span> if you need more.",ru:"\u0412\u044b\u0432\u0435\u0434\u0435\u043d\u043e \u043c\u0430\u043a\u0441\u0438\u043c\u0443\u043c %s \u0440\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442\u043e\u0432. \u0415\u0441\u043b\u0438 \u043d\u0435\u043e\u0431\u0445\u043e\u0434\u0438\u043c\u043e \u043e\u0442\u043e\u0431\u0440\u0430\u0436\u0430\u0442\u044c \u0431\u043e\u043b\u044c\u0448\u0435 \u0440\u0435\u0437\u0443\u043b\u044c\u0442\u0430\u0442\u043e\u0432, \u0432\u044b \u043c\u043e\u0436\u0435\u0442\u0435 \u0438\u0437\u043c\u0435\u043d\u0438\u0442\u044c \u044d\u0442\u043e\u0442 \u043b\u0438\u043c\u0438\u0442, \u043d\u0430\u0431\u0440\u0430\u0432 <span class='m special'>/config</span> <span class='m variable'>sqlMaxResults</span> = <span class='m constant'>100500</span>."},sqlNoData:{en:"Nothing to display",ru:"\u0422\u0443\u0442 \u043d\u0438\u0447\u0435\u0433\u043e \u043d\u0435\u0442"},tracingUsage:{en:"To watch for changes in file, enter \x1b[(special)m/trace\x1b[0m \x1b[(string)m/path/to/file\x1b[0m.\r\nFor changes in global dimentions use \x1b[(special)m/trace\x1b[0m \x1b[(global)m^globalName\x1b[0m.\r\nTo stop watching for changes, enter \x1b[(special)m/trace\x1b[0m \x1b[(global)mstop\x1b[0m.",ru:"\u0427\u0442\u043e\u0431\u044b \u0441\u043b\u0435\u0434\u0438\u0442\u044c \u0437\u0430 \u0438\u0437\u043c\u0435\u043d\u0435\u043d\u0438\u044f\u043c\u0438 \u0432 \u0444\u0430\u0439\u043b\u0435, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \x1b[(special)m/trace\x1b[0m \x1b[(string)m/path/to/file\x1b[0m.\r\n\u0414\u043b\u044f \u043d\u0430\u0431\u043b\u044e\u0434\u0435\u043d\u0438\u044f \u0437\u0430 \u0438\u0437\u043c\u0435\u0440\u0435\u043d\u0438\u044f\u043c\u0438 \u0433\u043b\u043e\u0431\u0430\u043b\u043e\u0432 \u0438\u0441\u043f\u043e\u043b\u044c\u0437\u0443\u0439\u0442\u0435 \x1b[(special)m/trace\x1b[0m \x1b[(global)m^globalName\x1b[0m.\r\n\u0427\u0442\u043e\u0431\u044b \u043e\u0441\u0442\u0430\u043d\u043e\u0432\u0438\u0442\u044c \u043d\u0430\u0431\u043b\u044e\u0434\u0435\u043d\u0438\u0435, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \x1b[(special)m/trace\x1b[0m \x1b[(global)mstop\x1b[0m."},traceStopOK:{en:"Tracing stopped.",ru:"\u0412\u0441\u0435 \u043d\u0430\u0431\u043b\u044e\u0434\u0435\u043d\u0438\u044f \u043e\u0441\u0442\u0430\u043d\u043e\u0432\u043b\u0435\u043d\u044b."},traceStopNotOK:{en:"Nothing is being traced.",ru:"\u041d\u0435\u0442 \u0430\u043a\u0442\u0438\u0432\u043d\u044b\u0445 \u043d\u0430\u0431\u043b\u044e\u0434\u0435\u043d\u0438\u0439."},traceBad:{en:"Unable to trace %s.",ru:"\u041d\u0435\u0432\u043e\u0437\u043c\u043e\u0436\u043d\u043e \u0442\u0440\u0430\u0441\u0441\u0438\u0440\u043e\u0432\u0430\u0442\u044c %s."},traceStart:{en:"Starting tracing %s.",ru:"\u041d\u0430\u0447\u0438\u043d\u0430\u0435\u043c \u043d\u0430\u0431\u043b\u044e\u0434\u0430\u0442\u044c \u0437\u0430 %s."},traceStop:{en:"Stopping tracing %s.",ru:"\u0417\u0430\u0432\u0435\u0440\u0448\u0430\u0435\u043c \u043d\u0430\u0431\u043b\u044e\u0434\u0430\u0442\u044c \u0437\u0430 %s."},traceSight:{en:"Currently tracing %s.",ru:"\u041d\u0430 \u0434\u0430\u043d\u043d\u044b\u0439 \u043c\u043e\u043c\u0435\u043d\u0442 \u043d\u0430\u0431\u043b\u044e\u0434\u0430\u0435\u043c \u0437\u0430 %s."},favDesc:{en:"To save the command, enter \x1b[(special)m/favorite\x1b[0m \x1b[(constant)mname\x1b[0m \x1b[(keyword)mdo\x1b[0m \x1b[(string)many ObjectScript code\x1b[0m.\r\nTo load the command, enter \x1b[(special)m/favorite\x1b[0m \x1b[(constant)mname\x1b[0m.\r\nTo delete saved commands, use \x1b[(special)m/favorite\x1b[0m \x1b[(wrong)mdelete\x1b[0m \x1b[(constant)mname\x1b[0m.\r\nTo delete all saved commands, use just \x1b[(special)m/favorite\x1b[0m \x1b[(wrong)mdelete\x1b[0m.",ru:"\u0414\u043b\u044f \u0442\u043e\u0433\u043e \u0447\u0442\u043e\u0431\u044b \u0437\u0430\u043f\u043e\u043c\u043d\u0438\u0442\u044c \u043a\u043e\u043c\u0430\u043d\u0434\u0443, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \x1b[(special)m/favorite\x1b[0m \x1b[(constant)m\u0438\u043c\u044f\x1b[0m \x1b[(keyword)mdo\x1b[0m \x1b[(string)m\u043b\u044e\u0431\u043e\u0439 ObjectScript \u043a\u043e\u0434\x1b[0m.\r\n\u0414\u043b\u044f \u0442\u043e\u0433\u043e \u0447\u0442\u043e\u0431\u044b \u0437\u0430\u0433\u0440\u0443\u0437\u0438\u0442\u044c \u043a\u043e\u043c\u0430\u043d\u0434\u0443, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \x1b[(special)m/favorite\x1b[0m \x1b[(constant)m\u0438\u043c\u044f\x1b[0m.\r\n\u0427\u0442\u043e\u0431\u044b \u0443\u0434\u0430\u043b\u044f\u0442\u044c \u0441\u043e\u0445\u0440\u0430\u043d\u0451\u043d\u043d\u044b\u0435 \u043a\u043e\u043c\u0430\u043d\u0434\u044b, \u0438\u0441\u043f\u043e\u043b\u044c\u0437\u0443\u0439\u0442\u0435 \x1b[(special)m/favorite\x1b[0m \x1b[(wrong)mdelete\x1b[0m \x1b[(constant)m\u0438\u043c\u044f\x1b[0m.\r\n\u0427\u0442\u043e\u0431\u044b \u0443\u0434\u0430\u043b\u0438\u0442\u044c \u0432\u0441\u0435 \u043a\u043e\u043c\u0430\u043d\u0434\u044b, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \x1b[(special)m/favorite\x1b[0m \x1b[(wrong)mdelete\x1b[0m."},favs:{en:"Saved commands:",ru:"\u0421\u043e\u0445\u0440\u0430\u043d\u0451\u043d\u043d\u044b\u0435 \u043a\u043e\u043c\u0430\u043d\u0434\u044b:"},favSet:{en:"Command \x1b[(constant)m%s\x1b[0m saved.",ru:"\u041a\u043e\u043c\u0430\u043d\u0434\u0430 \x1b[(constant)m%s\x1b[0m \u0441\u043e\u0445\u0440\u0430\u043d\u0435\u043d\u0430."},favDelOK:{en:"Command \x1b[(constant)m%s\x1b[0m deleted.",ru:"\u041a\u043e\u043c\u043c\u0430\u043d\u0434\u0430 \x1b[(constant)m%s\x1b[0m \u0443\u0434\u0430\u043b\u0435\u043d\u0430."},favDelNotOK:{en:"No \x1b[(constant)m%s\x1b[0m command.",ru:"\u041a\u043e\u043c\u043c\u0430\u043d\u0434\u0430 \x1b[(constant)m%s\x1b[0m \u043d\u0435 \u0431\u044b\u043b\u0430 \u0437\u0430\u0434\u0430\u043d\u0430."},favDel:{en:"All commands are deleted.",ru:"\u0412\u0441\u0435 \u043a\u043e\u043c\u0430\u043d\u0434\u044b \u0443\u0434\u0430\u043b\u0435\u043d\u044b."},favKey:{en:"Name",ru:"\u0418\u043c\u044f"},favVal:{en:"Value",ru:"\u0417\u043d\u0430\u0447\u0435\u043d\u0438\u0435"},noFav:{en:"Command \x1b[(constant)m%s\x1b[0m has never been saved.",ru:"\u041a\u043e\u043c\u0430\u043d\u0434\u0430 \x1b[(constant)m%s\x1b[0m \u043d\u0435 \u0431\u044b\u043b\u0430 \u0441\u043e\u0445\u0440\u0430\u043d\u0435\u043d\u0430 \u0440\u0430\u043d\u0435\u0435."},jsErr:{en:"JavaScript error occurred: %s",ru:"\u041f\u0440\u043e\u0438\u0437\u043e\u0448\u043b\u0430 \u043e\u0448\u0438\u0431\u043a\u0430 JavaScript: %s"},wsNormalClose:{en:"Session ended.",ru:"\u0421\u0435\u0441\u0441\u0438\u044f \u0437\u0430\u043a\u043e\u043d\u0447\u0435\u043d\u0430."},logOut:{en:"Logging out...",ru:"\u0412\u044b\u0445\u043e\u0434\u0438\u043c..."},unLogOut:{en:"Your browser is too old or too weird to support log out functionality. Please, restart the browser manually.",ru:"\u0412\u0430\u0448 \u0431\u0440\u0430\u0443\u0437\u0435\u0440 \u0441\u043b\u0438\u0448\u043a\u043e\u043c \u0441\u0442\u0440\u0430\u043d\u043d\u044b\u0439 \u0438\u043b\u0438 \u0441\u0442\u0430\u0440\u044b\u0439, \u0438 \u043e\u043d \u043d\u0435 \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u0438\u0432\u0430\u0435\u0442 \u0444\u0443\u043d\u043a\u0446\u0438\u043e\u043d\u0430\u043b\u044c\u043d\u043e\u0441\u0442\u044c \u0432\u044b\u0445\u043e\u0434\u0430. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u043f\u0435\u0440\u0435\u0437\u0430\u043f\u0443\u0441\u0442\u0438\u0442\u0435 \u0431\u0440\u0430\u0443\u0437\u0435\u0440 \u0432\u0440\u0443\u0447\u043d\u0443\u044e."},unNS:{en:"Unable to change namespace to %s.",ru:"\u041d\u0435 \u043f\u043e\u043b\u0443\u0447\u0430\u0435\u0442\u0441\u044f \u043f\u043e\u043c\u0435\u043d\u044f\u0442\u044c \u043e\u0431\u043b\u0430\u0441\u0442\u044c \u043d\u0430 %s."},cpTerm:{en:"Terminal process was terminated.",ru:"\u041f\u0440\u043e\u0446\u0435\u0441\u0441 \u0442\u0435\u0440\u043c\u0438\u043d\u0430\u043b\u0430 \u0431\u044b\u043b \u0437\u0430\u0432\u0435\u0440\u0448\u0451\u043d."}}},{}],349:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.LOCALES=void 0,n.getLocales=f,n.suggestLocale=d,n.getLocale=function(){var e=r.get(s);i.length||(n.LOCALES=i=f());e&&-1!==i.indexOf(e)||(e=navigator.language,-1===i.indexOf(e)&&(e=l));return e},n.setLocale=function(e){return-1!==i.indexOf(e)?(c=e,r.set(s,e),!0):((0,o.printLine)(v("noLocale",e)),!1)},n.get=v,n.parse=function r(e){for(var t=arguments.length,o=Array(1<t?t-1:0),n=1;n<t;n++)o[n-1]=arguments[n];var a=0;return(e+"").replace(u,function(e,t,n){return p(t)?v.apply(window,[t].concat(n?n.split(",").map(function(e){return r(e)}):void 0)):void 0!==o[a]?o[a++]:e})};var r=function(e){{if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}}(e("../storage")),o=e("../output"),e=e("./dictionary"),a=(e=e)&&e.__esModule?e:{default:e};var i=n.LOCALES=[],s="terminal-localization",l="en",u=/%([a-zA-Z0-9]+)(?:\(([^)]*)\))?/g,c=d();function f(){var e,t=[];for(e in a.default){for(var n in a.default[e])t.push(n);return t}}function p(e){return"s"!==e&&"d"!==e&&a.default.hasOwnProperty(e)}function d(){var e=navigator.language;return i.length||(n.LOCALES=i=f()),e=-1===i.indexOf(e)?l:e}function v(e){for(var t=arguments.length,n=Array(1<t?t-1:0),r=1;r<t;r++)n[r-1]=arguments[r];var o=-1;return(a.default[e]?a.default[e][c]||"["+e+"."+c+"?]":"["+e+"?]").replace(/%[sn]/g,function(e){return void 0!==n[++o]?"s"===e.charAt(1)?n[o].toString():parseFloat(n[o]):e})}},{"../output":356,"../storage":361,"./dictionary":348}],350:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.checkUpdate=c;var r=e("../lib"),a=o(e("../input")),i=o(e("../index")),s=o(e("../output")),l=o(e("../localization"));e("./update");var u=o(e("../config"));function o(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}function c(){var t=0<arguments.length&&void 0!==arguments[0]&&arguments[0];(0,r.get)("https://intersystems-community.github.io/webterminal/terminal.json",function(){var e=0<arguments.length&&void 0!==arguments[0]?arguments[0]:{};e.error||void 0===e.motd||i.onAuth(function(){return function(e){var r,t,o,n=1<arguments.length&&void 0!==arguments[1]&&arguments[1];(u.get("updateCheck")||n)&&(a.clearPrompt(),e.motd&&u.get("initMessage")&&s.printLine(e.motd),e.versions instanceof Array&&(n=e.versions,r=[],o=t="",n.forEach(function(n){f(n.v,i.VERSION)&&((n.changes||[]).forEach(function(e,t){return r.push("\x1b[2m"+((0===t?n.v:"")+(0===t?":":"")+"                        ").substring(0,16)+"\x1b[0m"+("string"==typeof e?e:e.text||""))}),f(n.v,t)&&(t=n.v,o=n.url))}),r.length&&(s.printLine(l.get("updReady",'javascript:window.updateTerminal("'+t+'","'+o+'")')),o?s.printLine(r.join("\r\n")):s.printLine(l.get("noUpdUrl","https://intersystems-community.github.io/webterminal/#downloads")))),a.reprompt())}(e,t)})})}function f(e,t){for(var n=e.split(/[\-\.]/g),r=t.split(/[\-\.]/g),o=0;o<n.length;o++)if(isNaN(+n[o])||isNaN(+r[o])){if(n[o]>r[o])return 1;if(n[o]<r[o])return}else{if(+n[o]>+r[o])return 1;if(+n[o]<+r[o])return}return r.length>n.length}u.get("updateCheck")&&c()},{"../config":337,"../index":340,"../input":345,"../lib":347,"../localization":349,"../output":356,"./update":351}],351:[function(e,t,n){"use strict";var r=l(e("../index")),o=l(e("../output")),a=l(e("../input")),i=l(e("../localization")),s=l(e("../server"));function l(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}var u=!1;window.updateTerminal=function(e,t){u||(t=t.replace(/^http:/,"https:"),u=!0,a.hideInput(),o.printLine(i.get(
+         "updStart",r.VERSION,e)),o.printLine("URL: "+t),o.printLine(i.get("rSerUpd")),s.send("Update",t))}},{"../index":340,"../input":345,"../localization":349,"../output":356,"../server":360}],352:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.LINE_CLASS_NAME=void 0,n.Line=o;var i=e("./index"),r=function(e){{if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}}(e("../elements"));n.LINE_CLASS_NAME="line";function o(e){this._lineElement=document.createElement("div"),this._lineElement.className="line",this.text="",this.INDEX=e,this.HTML_LINE=!1,this.HTMLRendered=!1,this.graphicProperties=[],this.setIndex(e),this._lineElement.style.height=i.SYMBOL_HEIGHT+"px",r.output.appendChild(this._lineElement)}function a(e,t){for(var n=["g"],r=[],o="span",a=[],i=0;i<e.length;i+=2){if(e[i+1].class&&n.push(e[i+1].class),e[i+1].style&&r.push(e[i+1].style),e[i+1].attrs)for(var s in e[i+1].attrs)a.push([s,e[i+1].attrs[s]]);e[i+1].tag&&(o=e[i+1].tag)}var l=document.createElement(o),u=(l.className=n.join(" "),r.length&&l.setAttribute("style",r.join(";")),!0),c=!1,f=void 0;try{for(var p,d=a[Symbol.iterator]();!(u=(p=d.next()).done);u=!0){var v=p.value;l.setAttribute(v[0],v[1])}}catch(e){c=!0,f=e}finally{try{!u&&d.return&&d.return()}finally{if(c)throw f}}return l.textContent=t,l}function s(e,t,n,r,o){for(var t=1<arguments.length&&void 0!==t?t:0,a=n,n=3<arguments.length&&void 0!==r?r:[],i=4<arguments.length&&void 0!==o&&o,s=n,l=t;l<a;l++)void 0!==e[l]&&(s=e[l],i&&(e[l]=void 0));return s}function l(e,t){if(e.length===t.length){for(var n=0;n<e.length;n++)if(e[n]!==t[n])return;return 1}}o.prototype.setIndex=function(e){this.INDEX=e,this._lineElement.setAttribute("index",e),this._lineElement.style.top=e*i.SYMBOL_HEIGHT+"px"},o.prototype.setHTML=function(e){this.HTML_LINE=!0,this.text=e,this._lineElement.className="html line",this.HTMLRendered=!1,this.render(),this._lineElement.style.maxHeight=Math.max(i.SYMBOL_HEIGHT,this._lineElement.offsetHeight)+"px"},o.prototype.getHeight=function(){return this._lineElement.offsetHeight},o.prototype.render=function(){if(this.HTML_LINE)return this.HTMLRendered?void 0:(this._lineElement.innerHTML=this.text,void(this.HTMLRendered=!0));for(var e=this._lineElement.style.display,t=(this._lineElement.style.display="none",this._lineElement.innerHTML="",0),n=0;n<this.text.length;n++)void 0!==this.graphicProperties[n]&&(t!==n&&this._lineElement.appendChild(a(this.graphicProperties[t]||[],this.text.substring(t,n))),t=n);0<this.text.length&&this._lineElement.appendChild(a(this.graphicProperties[t]||[],this.text.substr(t))),this._lineElement.style.display=e},o.prototype.print=function(e){var t=1<arguments.length&&void 0!==arguments[1]?arguments[1]:this.text.length,n=(this.HTML_LINE&&(this.HTML_LINE=!1,this._lineElement.className="line",this._lineElement.style.maxHeight="",this.text=""),e.substr(0,i.WIDTH-t)),r=t+n.length,o=s(this.graphicProperties,0,t,[]),a=s(this.graphicProperties,t,r,o,!0);return l(o,i.GRAPHIC_PROPERTIES)||(this.graphicProperties[t]=i.GRAPHIC_PROPERTIES.slice()),(a.length||i.GRAPHIC_PROPERTIES.length)&&!l(a,i.GRAPHIC_PROPERTIES)&&r<this.text.length&&(this.graphicProperties[r]=s(this.graphicProperties,r,r+1,a),0===i.GRAPHIC_PROPERTIES.length&&0===this.graphicProperties[r].length&&(this.graphicProperties[r]=void 0)),this.text=t<this.text.length?this.text.substring(0,t)+n+this.text.substr(r):this.text+new Array(t-this.text.length+1).join(" ")+n,n.length===e.length?"":e.substr(n.length)},o.prototype.clear=function(){this.text="",this.graphicProperties={},this.render()},o.prototype.remove=function(){this._lineElement.parentNode&&this._lineElement.parentNode.removeChild(this._lineElement)}},{"../elements":338,"./index":356}],353:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0});n.COLOR_8BIT={0:"#000000",1:"#800000",2:"#008000",3:"#808000",4:"#000080",5:"#800080",6:"#008080",7:"#c0c0c0",8:"#808080",9:"#ff0000",10:"#00ff00",11:"#ffff00",12:"#0000ff",13:"#ff00ff",14:"#00ffff",15:"#ffffff",16:"#000000",17:"#00005f",18:"#000087",19:"#0000af",20:"#0000df",21:"#0000ff",22:"#005f00",23:"#005f5f",24:"#005f87",25:"#005faf",26:"#005fdf",27:"#005fff",28:"#008700",29:"#00875f",30:"#008787",31:"#0087af",32:"#0087df",33:"#0087ff",34:"#00af00",35:"#00af5f",36:"#00af87",37:"#00afaf",38:"#00afdf",39:"#00afff",40:"#00df00",41:"#00df5f",42:"#00df87",43:"#00dfaf",44:"#00dfdf",45:"#00dfff",46:"#00ff00",47:"#00ff5f",48:"#00ff87",49:"#00ffaf",50:"#00ffdf",51:"#00ffff",52:"#5f0000",53:"#5f005f",54:"#5f0087",55:"#5f00af",56:"#5f00df",57:"#5f00ff",58:"#5f5f00",59:"#5f5f5f",60:"#5f5f87",61:"#5f5faf",62:"#5f5fdf",63:"#5f5fff",64:"#5f8700",65:"#5f875f",66:"#5f8787",67:"#5f87af",68:"#5f87df",69:"#5f87ff",70:"#5faf00",71:"#5faf5f",72:"#5faf87",73:"#5fafaf",74:"#5fafdf",75:"#5fafff",76:"#5fdf00",77:"#5fdf5f",78:"#5fdf87",79:"#5fdfaf",80:"#5fdfdf",81:"#5fdfff",82:"#5fff00",83:"#5fff5f",84:"#5fff87",85:"#5fffaf",86:"#5fffdf",87:"#5fffff",88:"#870000",89:"#87005f",90:"#870087",91:"#8700af",92:"#8700df",93:"#8700ff",94:"#875f00",95:"#875f5f",96:"#875f87",97:"#875faf",98:"#875fdf",99:"#875fff",100:"#878700",101:"#87875f",102:"#878787",103:"#8787af",104:"#8787df",105:"#8787ff",106:"#87af00",107:"#87af5f",108:"#87af87",109:"#87afaf",110:"#87afdf",111:"#87afff",112:"#87df00",113:"#87df5f",114:"#87df87",115:"#87dfaf",116:"#87dfdf",117:"#87dfff",118:"#87ff00",119:"#87ff5f",120:"#87ff87",121:"#87ffaf",122:"#87ffdf",123:"#87ffff",124:"#af0000",125:"#af005f",126:"#af0087",127:"#af00af",128:"#af00df",129:"#af00ff",130:"#af5f00",131:"#af5f5f",132:"#af5f87",133:"#af5faf",134:"#af5fdf",135:"#af5fff",136:"#af8700",137:"#af875f",138:"#af8787",139:"#af87af",140:"#af87df",141:"#af87ff",142:"#afaf00",143:"#afaf5f",144:"#afaf87",145:"#afafaf",146:"#afafdf",147:"#afafff",148:"#afdf00",149:"#afdf5f",150:"#afdf87",151:"#afdfaf",152:"#afdfdf",153:"#afdfff",154:"#afff00",155:"#afff5f",156:"#afff87",157:"#afffaf",158:"#afffdf",159:"#afffff",160:"#df0000",161:"#df005f",162:"#df0087",163:"#df00af",164:"#df00df",165:"#df00ff",166:"#df5f00",167:"#df5f5f",168:"#df5f87",169:"#df5faf",170:"#df5fdf",171:"#df5fff",172:"#df8700",173:"#df875f",174:"#df8787",175:"#df87af",176:"#df87df",177:"#df87ff",178:"#dfaf00",179:"#dfaf5f",180:"#dfaf87",181:"#dfafaf",182:"#dfafdf",183:"#dfafff",184:"#dfdf00",185:"#dfdf5f",186:"#dfdf87",187:"#dfdfaf",188:"#dfdfdf",189:"#dfdfff",190:"#dfff00",191:"#dfff5f",192:"#dfff87",193:"#dfffaf",194:"#dfffdf",195:"#dfffff",196:"#ff0000",197:"#ff005f",198:"#ff0087",199:"#ff00af",200:"#ff00df",201:"#ff00ff",202:"#ff5f00",203:"#ff5f5f",204:"#ff5f87",205:"#ff5faf",206:"#ff5fdf",207:"#ff5fff",208:"#ff8700",209:"#ff875f",210:"#ff8787",211:"#ff87af",212:"#ff87df",213:"#ff87ff",214:"#ffaf00",215:"#ffaf5f",216:"#ffaf87",217:"#ffafaf",218:"#ffafdf",219:"#ffafff",220:"#ffdf00",221:"#ffdf5f",222:"#ffdf87",223:"#ffdfaf",224:"#ffdfdf",225:"#ffdfff",226:"#ffff00",227:"#ffff5f",228:"#ffff87",229:"#ffffaf",230:"#ffffdf",231:"#ffffff",232:"#080808",233:"#121212",234:"#1c1c1c",235:"#262626",236:"#303030",237:"#3a3a3a",238:"#444444",239:"#4e4e4e",240:"#585858",241:"#606060",242:"#666666",243:"#767676",244:"#808080",245:"#8a8a8a",246:"#949494",247:"#9e9e9e",248:"#a8a8a8",249:"#b2b2b2",250:"#bcbcbc",251:"#c6c6c6",252:"#d0d0d0",253:"#dadada",254:"#e4e4e4",255:"#eeeeee"}},{}],354:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0});var r=function(e,t){if(Array.isArray(e))return e;if(Symbol.iterator in Object(e)){var n=t,r=[],o=!0,t=!1,a=void 0;try{for(var i,s=e[Symbol.iterator]();!(o=(i=s.next()).done)&&(r.push(i.value),!n||r.length!==n);o=!0);}catch(e){t=!0,a=e}finally{try{!o&&s.return&&s.return()}finally{if(t)throw a}}return r}throw new TypeError("Invalid attempt to destructure non-iterable instance")},o=l(e("./index")),a=e("./const"),i=l(e("../server")),s=l(e("../input/caret"));function l(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}var u=[],c={},f={"\f":function(){o.clear()},"\n":function(){o.scrollDisplay(1)},"\r":function(){o.setCursorX(1)},"\t":function(){for(var e=o.getCursorX(),t=o.getTabs(),n=0;n<t.length;n++)if(e<t[n])return void o.setCursorX(t[n])},"\x1bH":function(){o.setTabAt(o.getCursorX())},"\x1b[g":function(){o.clearTab(o.getCursorX())},"\x1b[3g":function(){o.clearTab()},"\x1b[r":function(){o.disableScrolling()},"\x1b[{\\d*}{;?}{\\d*}r":function(e){var t=e[0]||1,n=e[2]||o.HEIGHT;(t=e[1]?t:e[0]||e[2])?o.enableScrolling(t,n):o.disableScrolling()},"\x1bD":function(){o.scrollDisplay(1)},"\x1bM":function(){o.scrollDisplay(-1)},"\x1b[c":function(){i.send("i","\x1b10c")},"\x1b[5n":function(){i.send("i","\x1b0n")},"\x1b[6n":function(){i.send("i","\x1b["+o.getCursorY()+";"+o.getCursorY()+"n")},"\x1bc":function(){o.LINE_WRAP_ENABLED=!0},"\x1b[7h":function(){o.LINE_WRAP_ENABLED=!0},"\x1b[7l":function(){o.LINE_WRAP_ENABLED=!1},"\x1b[?25h":function(){s.hide()},"\x1b[?25l":function(){s.update()},"\x1b(":function(){},"\x1b)":function(){},"\x1b[{\\d*}i":function(){window.print()},"\x1b[{\\d*}{;?}{\\d*}H":e=function(e){e[0]||e[2]?(e[0]&&o.setCursorY(+e[0]),e[2]&&o.setCursorX(+e[2])):(o.setCursorX(1),o.setCursorY(1))},"\x1b[{\\d*}{;?}{\\d*}f":e,"\x1b[{\\d*}A":function(e){o.setCursorY(Math.max(1,o.getCursorY()-(+e[0]||1)))},"\x1b[{\\d*}B":function(e){o.setCursorY(Math.min(o.HEIGHT,o.getCursorY()+(+e[0]||1)))},"\x1b[{\\d*}C":function(e){o.setCursorX(Math.min(o.WIDTH,o.getCursorX()+(+e[0]||1)))},"\x1b[{\\d*}D":function(e){o.setCursorX(Math.max(1,o.getCursorX()-(+e[0]||1)))},"\x1b[{\\d*}G":function(e){o.setCursorX(+e[0])},"\x1b[s":function(){u=[o.getCursorX(),o.getCursorY()]},"\x1b[u":function(){u.length&&(o.setCursorX(u[0]),o.setCursorY(u[1]))},"\x1b7":function(){u=[o.getCursorX(),o.getCursorY()],c=JSON.parse(JSON.stringify(o.GRAPHIC_PROPERTIES))},"\x1b8":function(){u.length&&(o.setCursorX(u[0]),o.setCursorY(u[1]),o.GRAPHIC_PROPERTIES=JSON.parse(JSON.stringify(c)))},"\x1b[K":e=function(){var e=o.getCursorX(),t=o.GRAPHIC_PROPERTIES;o.resetGraphicProperties(),o.getCurrentLine().print(new Array(o.WIDTH-e+2).join(" "),e-1),o.GRAPHIC_PROPERTIES=t},"\x1b[0K":e,"\x1b[1K":function(){var e=o.getCursorX(),t=o.GRAPHIC_PROPERTIES;o.resetGraphicProperties(),o.getCurrentLine().print(new Array(e+1).join(" "),0),o.GRAPHIC_PROPERTIES=t},"\x1b[2K":function(){o.getCurrentLine().clear()},"\x1b[J":e=function(){var e=o.getCursorY()+1;for(f["\x1b[K"]();e<o.HEIGHT+1;e++)o.getLineByCursorY(e).clear()},"\x1b[0J":e,"\x1b[1J":function(){var e=o.getCursorY()-1;for(f["\x1b[1K"]();0<e;e--)o.getLineByCursorY(e).clear()},"\x1b[2J":function(){for(var e=1;e<o.HEIGHT+1;e++)o.getLineByCursorY(e).clear();o.setCursorX(1),o.setCursorY(1)},'\x1b[{\\d*};"{[^"]}"p':function(e){console.log("todo: implement key assignment",e)},"\x1b[{\\d*(?:;\\d*)*}m":function(e){for(var t=e[0].split(";"),n=0;n<t.length;n++)"0"===t[n]||""===t[n]?o.resetGraphicProperties():"22"===t[n]?(o.clearGraphicProperty(1),o.clearGraphicProperty(2)):"38"!==t[n]&&"48"!==t[n]||"5"!==t[n+1]?o.setGraphicProperty(t[n],{class:"m"+t[n]}):(o.setGraphicProperty(+t[n],{class:"m"+t[n],style:("48"===t[n]?"background-":"")+"color:"+a.COLOR_8BIT[t[n+2]]}),n+=2)},"\x1b[({[\\w\\-]+})m":function(e){e=e[0];e&&o.setGraphicProperty(9,{class:e})},"\x1b!URL={[^\\x20]*} ({[^\\)]+})":function(e){var e=r(e,2),t=e[0],t=void 0===t?"":t,e=e[1],e=void 0===e?"":e;o.setGraphicProperty(9,{tag:"a",attrs:{href:t,target:0===t.indexOf("javascript:")?"":"_blank"}}),o.immediatePlainPrint(e),o.clearGraphicProperty(9)},"\x1b!<HTML>{![^]*(?=<\\/HTML>)}</HTML>":function(e){var e=r(e,1)[0],t=o.getCurrentLine(),e=(t.setHTML(e),t.INDEX+Math.ceil(t.getHeight()/o.SYMBOL_HEIGHT));o.getLineByIndex(e),o.setCursorYToLineIndex(e),o.setCursorX(1)}};n.default=f},{"../input/caret":342,"../server":360,"./const":353,"./index":356}],355:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.ESC_CHARS_MASK=void 0,n.applyEscapeSequence=a;var e=e("./esc"),r=(e=e)&&e.__esModule?e:{default:e};var o,l={};for(o in r.default)!function(e,t){for(var n=0<arguments.length&&void 0!==e?e:"",r=t,o=0,a=void 0,i=void 0,s=l;o<n.length;)if("{"===n[o]&&-1!==(a=n.indexOf("}",o))){try{i=new RegExp(n.substring(o+1,a))}catch(e){console.error('Malformed RegExp in "'+n+'" pattern.',e);continue}o=a+1,s=(s[""]=s[""]||{})[i.source]=o<n.length?s[""][i.source]||{}:r}else s=s[n[o]]=o+1<n.length?s[n[o]]||{}:r,o++}(o,r.default[o]);n.ESC_CHARS_MASK=/[\x00-\x1F]/;function a(){var e=0<arguments.length&&void 0!==arguments[0]?arguments[0]:"",t=function e(t,n,r){var o=2<arguments.length&&void 0!==r?r:[];if(!n)return 0;var a,i,s=void 0,l=-1;if(t[n[0]]){if("function"==typeof t[n[0]])return t[n[0]](o),1;if(0<(l=e(t[n[0]],n.substr(1),o)))return 1+l}for(i in t[""]){var u="!"===i[0]?i.slice(1):i;if(s=n.match("^"+u)){if(0<(a=e(t[""][i],n.substr(u=s.join().length),o.concat(s))))return a+u;l=l<a?a:l}else"!"===i[0]&&(l=0)}return l}(l,e);return-1===t?e.substr(1):0===t?e:e.substr(t)}window.applyEscapeSequence=a},{"./esc":354}],356:[function(e,N,a){"use strict";Object.defineProperty(a,"__esModule",{value:!0}),a.GRAPHIC_PROPERTIES=a.LINE_WRAP_ENABLED=a.HEIGHT=a.WIDTH=a.SYMBOL_WIDTH=a.SYMBOL_HEIGHT=void 0,a.getCursorX=function(){return m.x},a.getCursorY=G,a.getLinesNumber=function(){return h.length},a.getCurrentLineIndex=g,a.getTopLineIndex=b,a.setCursorYToLineIndex=x,a.printAsync=function(e){r.clearPrompt(),j(e),r.reprompt()},a.print=j,a.printLine=function(e){j(e+"\r\n")},a.setTabAt=function(e){for(var t=0;t<w.length;t++){if(e<w[t])return void w.splice(t,0,e);if(e===w[t])return}w.push(e)},a.clearTab=function(e){var t=void 0;e?-1!==(t=w.indexOf(e))&&w.splice(t,1):w=[]},a.getTabs=function(){return w},a.setCursorX=A,a.setCursorY=S,a.enableScrolling=function(e,t){d.enabled=!0,d.lineStart=Math.max(e,1),d.lineEnd=Math.min(t,p),A(1),S(1)},a.disableScrolling=function(){d.enabled=!1,A(1),S(1)},a.scrollDisplay=k,a.setGraphicProperty=function(e){var t=1<arguments.length&&void 0!==arguments[1]?arguments[1]:{};-1!==_.indexOf(+e)&&E(+e);_.push(+e,{class:t.class,style:t.style,tag:t.tag,attrs:t.attrs})},a.clearGraphicProperty=E,a.resetGraphicProperties=function(){a.GRAPHIC_PROPERTIES=_=[]},a.getCurrentLine=U,a.pushLines=I,a.immediatePlainPrint=function(e){return P(e)},a.newLine=function(){o.default["\r"](),o.default["\n"]()},a.getLineByIndex=L,a.getLineByCursorY=M,a.clear=function(){k(1);var e=b()+m.y-1,e=h.length-e-1,t=h.length-b();I(Math.max(p-e,t)),A(1),S(1),T()},a.reset=function(){var e=!0,t=!1,n=void 0;try{for(var r,o=h[Symbol.iterator]();!(e=(r=o.next()).done);e=!0)r.value.remove()}catch(e){t=!0,n=e}finally{try{!e&&o.return&&o.return()}finally{if(t)throw n}}h=[],d.enabled=!1,A(1),S(1)},a.scrollDown=T;var u=e("./Line"),i=s(e("../elements")),D=e("../lib"),n=e("./escStateMachine"),t=e("./esc"),o=(t=t)&&t.__esModule?t:{default:t},r=s(e("../input")),t=e("../init"),F=e("../index");
+         function s(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}var H=10,l=a.SYMBOL_HEIGHT=12,c=a.SYMBOL_WIDTH=8,f=a.WIDTH=0,p=a.HEIGHT=0,d=(a.LINE_WRAP_ENABLED=!0,{enabled:!1,lineStart:1,lineEnd:1}),v=!1,y=((0,t.onInit)(function(){v=!0,W()}),""),_=a.GRAPHIC_PROPERTIES=[],h=[],m={x:1,y:1};function G(){return m.y}function g(){return M(m.y).INDEX}function b(){return Math.max(h.length-p,0)}function x(e){return S(e-b()+1,!1)}var w=[];function j(e){(0,F.onOutput)(e),y+=e,v&&W()}function A(e){return m.x=Math.max(1,Math.min(f,e)),e===m.x}function S(e){return m.y=!(1<arguments.length&&void 0!==arguments[1])||arguments[1]?Math.max(1,Math.min(p,e)):e,M(m.y),e===m.y}function k(e){var t=m.y;if(!d.enabled||!(d.lineStart===t&&e<0||d.lineEnd===t&&0<e))return p<t+e&&I(1),void S(t+e);var e=b(),n=d.lineStart===t,t=(L(e+d.lineEnd),h.slice(e+d.lineStart-1,e+d.lineEnd)),r=(t[n?"pop":"shift"]().remove(),!0),o=!1,a=void 0;try{for(var i,s=t[Symbol.iterator]();!(r=(i=s.next()).done);r=!0){var l=i.value;l.setIndex(l.INDEX+(n?1:-1))}}catch(e){o=!0,a=e}finally{try{!r&&s.return&&s.return()}finally{if(o)throw a}}t[n?"unshift":"push"](new u.Line(e+(n?d.lineStart:d.lineEnd)-1)),h.splice.apply(h,[e+d.lineStart-1,t.length].concat(t))}function E(e){e=_.indexOf(+e);-1!==e&&_.splice(e,2)}function U(){return L(b()+m.y-1)}function I(e){for(;0<e;e--)h.push(new u.Line(h.length))}function W(){if(y){for(var e,t=void 0;-1!==(e=y.search(n.ESC_CHARS_MASK));)if(P(y.substring(0,e)),(y=(0,n.applyEscapeSequence)((t=y).substr(e))).length===t.length)return;P(y),y="",T()}}(0,D.onWindowLoad)(function(){window.addEventListener("resize",R),R();for(var e=9;e<f;e+=8)w.push(e)});var C={},O=0;function P(e){var t=0<arguments.length&&void 0!==e?e:"";if(t.length){for(var n,r=void 0;r=U(),n=t.length,t=r.print(t,m.x-1),C[r.INDEX]=!0,n-=t.length,!t&&A(m.x+n)||(o.default["\r"](),o.default["\n"]()),t;);0===O&&(O=setTimeout(function(){for(var e in C)h[e]&&h[e].render(),delete C[e];O=0,T()},H))}}function L(e){var t=Math.max(e-h.length+1,0);return 0<t&&I(t),h[e]}function M(e){return L(b()+(e-1))}function T(){i.output.scrollTop=b()*l}function R(){var e,t=g(),n=document.createElement("span"),r=document.createElement("div"),o=i.output.style.overflowY;if(i.output.style.overflowY="scroll",r.className=u.LINE_CLASS_NAME,i.output.appendChild(r),e=i.output.offsetWidth-r.offsetWidth,i.output.style.overflowY=o,n.innerHTML="XXXXXXXXXX",r.appendChild(n),a.SYMBOL_WIDTH=c=n.offsetWidth/10||8.8,a.SYMBOL_HEIGHT=l=n.offsetHeight||19,a.WIDTH=f=(o=Math.floor((i.terminal.offsetWidth-e)/c))||32*l,a.HEIGHT=p=(n=Math.floor(i.terminal.offsetHeight/l))||80*c,i.input.style.width=f*c+"px",i.output.removeChild(r),x(t),!o||!n){setTimeout(R,25);try{console.warn("[WebTerminal] Size calculations delayed for 25s due to WebTerminal is not attached to the page. If this message doesn't stop appearing, check if WebTerminal's iFrame is visible and is attached to the DOM.")}catch(e){}}}},{"../elements":338,"../index":340,"../init":341,"../input":345,"../lib":347,"./Line":352,"./esc":354,"./escStateMachine":355}],357:[function(t,e,n){!function(e){!function(){"use strict";Object.defineProperty(n,"__esModule",{value:!0});function e(e){return e}var I="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e},C=(n.getAutomaton=function(){return M},n.process=function(e){var t=1<arguments.length&&void 0!==arguments[1]?arguments[1]:e.length,n=!(2<arguments.length&&void 0!==arguments[2])||arguments[2],r=3<arguments.length&&void 0!==arguments[3]?arguments[3]:"CWTInput",o=function(e){var t=void 0,n=[];for(;null!==(t=P.exec(e));)for(var r=1;r<t.length;r++)if(t[r]){n.push({type:r,value:t[r],class:L[r-1]||""});break}return P.lastIndex=0,n}(e),a=[],i=[],s=T[r]||1,l=0,u=s,c=0,f=0,p=0,d=!1,v=u,y=0,_=[],h=-1,m=-1,g=0,b=-1,x="";for(;c<o.length&&g++<100;){void 0===M[u]&&(console.warn("No state",M[u]),u=s),f<c&&(f=c,g=0);for(var w,j=!1,A=u,S=void 0;p<(M[u]||[]).length;p++){var k=M[u][p],E=o[c];if(null===k[0])c--;else{if(!1===k[0])break;if(!0===k[0])E.type===O.TYPE_WHITESPACE&&(d=!0),"string"==typeof E.value&&(l+=E.value.length);else if(0===k[0])i.push([u,p,a.length,l,c,_.length]),c--;else if(k[0].type===O.TYPE_WHITESPACE){if(d)c--;else{if(k[0].type!==E.type)continue;"string"==typeof E.value&&(l+=E.value.length)}d=!0}else if(k[0].type===O.TYPE_ID){if(k[0].type!==E.type)continue;if(l<t&&t<=l+E.value.length&&(x=E.value.substr(0,t-l)[k[0].value.CI?"toLowerCase":"toString"]()),"string"==typeof k[0].value){if(E.value!==k[0].value)continue}else if("object"===I(k[0].value)&&void 0!==k[0].value.value&&E.value[k[0].value.CI?"toLowerCase":"toString"]()!==k[0].value.value)continue;"string"==typeof E.value&&(l+=E.value.length),S=E.value[k[0].value.CI?"toLowerCase":"toString"](),d=!1}else if(k[0].type===O.TYPE_STRING){if(k[0].type!==E.type)continue;"string"==typeof E.value&&(l+=E.value.length),d=!1}else if(k[0].type===O.TYPE_CONSTANT){if(k[0].type!==E.type)continue;"string"==typeof E.value&&(l+=E.value.length),d=!1}else if(k[0].type===O.TYPE_CHAR){if(k[0].type!==E.type)continue;if("string"==typeof k[0].value){if(E.value!==k[0].value)continue}else if("object"===I(k[0].value)&&void 0!==k[0].value.value&&E.value!==k[0].value.value)continue;"string"==typeof E.value&&(l+=E.value.length),d=!1}}if(k[0]&&"object"===I(k[0].value)&&(k[0].value.class&&(E.class=k[0].value.class),y&&b!==c||(k[0].value.type&&"*"!==k[0].value.type?_.push({type:k[0].value.type,value:-1===b?E.value:E.value.substring(0,t-(l-E.value.length))}):"*"===k[0].value.type||_[_.length-1]&&","===_[_.length-1].type||_.push({type:",",value:""}))),void 0!==k[2]&&a.push(k[2]),0===k[1]){for(;;)if(u=a.pop(),i.length&&i[i.length-1][2]===a.length&&i.pop(),0!==u)break;void 0===u&&(u=0)}else u=k[1];c++,j=!0;break}j?(w=o[c]?o[c].value.length:1,h<c&&(v=u),p=0,h<c&&l<=t&&t<l+w&&(y=o[(b=c)-1]&&o[c-1].type===O.TYPE_ID?A:v,S&&(x=S))):function(){if(h<c&&(h=c),!i.length)return-1===m&&(m=Math.max(c,h)),1;var e=i.pop();u=e[0],p=e[1]+1,a.length>e[2]&&(a=a.slice(0,e[2])),l=e[3],c=e[4],!y&&_.length>e[5]&&(_=_.slice(0,e[5]))}()&&(u=p=0,d=!1,o[c]&&("string"==typeof o[c].value&&(l+=o[c].value.length),h<=c&&(o[c].class="error"),c++),a=[],i=[],w=o[c]?o[c].value.length:1,!y&&l<=t&&t<l+w&&o[c-1]&&o[c-1].type===O.TYPE_ID&&m===c-1&&(y=v,x=o[c-1].value.toLowerCase()))}100<=g&&console.error("Statement",o,"looped more than 100 times without a progress, exiting.");l!==e.length&&console.error("Oops, you've caught a rare exception! parsedStringLength != string.length ("+l+" != "+e.length+") for '"+e+"'. Please, report this issue.");return{lexemes:o,suggestions:0!==y&&n?(0,C.suggest)(y,x):[],collector:_}},t("../autocomplete")),O=t("./pushdownAutomaton"),P=/([\s\t]+)|([a-z]+[a-z0-9]*)|("(?:"(?=")"|[^"])*(?:"|$))|([0-9]*\.[0-9]+|[0-9]+)|([^])/gi,L=["","","string","constant",""],M=e([[[!1,0]],[[{type:5,value:{value:"/",class:"special"}},2,0],[null,3]],[[{type:2,value:{value:"help",class:"special"}},0],[{type:2,value:{value:"clear",class:"special"}},0],[{type:2,value:{value:"config",class:"special"}},6],[{type:2,value:{value:"favorite",class:"special"}},12],[{type:2,value:{value:"info",class:"special"}},0],[{type:2,value:{value:"logout",class:"special"}},0],[{type:2,value:{value:"sql",class:"special"}},0],[{type:2,value:{value:"trace",class:"special"}},18],[{type:2,value:{value:"update",class:"special"}},0]],[[null,4,5]],[[{type:2,value:{CI:!0,value:"break",class:"keyword"}},22,23],[{type:2,value:{CI:!0,value:"b",class:"keyword"}},22,23],[{type:2,value:{CI:!0,value:"close",class:"keyword"}},22,25],[{type:2,value:{CI:!0,value:"c",class:"keyword"}},22,25],[{type:2,value:{CI:!0,value:"continue",class:"keyword"}},22,0],[{type:2,value:{CI:!0,value:"do",class:"keyword"}},22,29],[{type:2,value:{CI:!0,value:"d",class:"keyword"}},22,29],[{type:2,value:{CI:!0,value:"write",class:"keyword"}},22,35],[{type:2,value:{CI:!0,value:"w",class:"keyword"}},22,35],[{type:2,value:{CI:!0,value:"hang",class:"keyword"}},22,42],[{type:2,value:{CI:!0,value:"h",class:"keyword"}},22,42],[{type:2,value:{CI:!0,value:"halt",class:"keyword"}},22,0],[{type:2,value:{CI:!0,value:"job",class:"keyword"}},22,43],[{type:2,value:{CI:!0,value:"j",class:"keyword"}},22,43],[{type:2,value:{CI:!0,value:"merge",class:"keyword"}},22,48],[{type:2,value:{CI:!0,value:"m",class:"keyword"}},22,48],[{type:2,value:{CI:!0,value:"open",class:"keyword"}},22,54],[{type:2,value:{CI:!0,value:"o",class:"keyword"}},22,54],[{type:2,value:{CI:!0,value:"zwrite",class:"keyword"}},22,68],[{type:2,value:{CI:!0,value:"zw",class:"keyword"}},22,68],[{type:2,value:{CI:!0,value:"set",class:"keyword"}},22,73],[{type:2,value:{CI:!0,value:"s",class:"keyword"}},22,73],[{type:2,value:{CI:!0,value:"try",class:"keyword"}},79],[{type:2,value:{CI:!0,value:"kill",class:"keyword"}},22,97],[{type:2,value:{CI:!0,value:"k",class:"keyword"}},22,97],[{type:2,value:{CI:!0,value:"quit",class:"keyword"}},22,106],[{type:2,value:{CI:!0,value:"q",class:"keyword"}},22,106],[{type:2,value:{CI:!0,value:"return",class:"keyword"}},22,106],[{type:2,value:{CI:!0,value:"read",class:"keyword"}},22,108],[{type:2,value:{CI:!0,value:"r",class:"keyword"}},22,108],[{type:2,value:{CI:!0,value:"tstart",class:"keyword"}},22,0],[{type:2,value:{CI:!0,value:"ts",class:"keyword"}},22,0],[{type:2,value:{CI:!0,value:"tcommit",class:"keyword"}},22,0],[{type:2,value:{CI:!0,value:"tc",class:"keyword"}},22,0],[{type:2,value:{CI:!0,value:"trollback",class:"keyword"}},22,0],[{type:2,value:{CI:!0,value:"tro",class:"keyword"}},22,0],[{type:2,value:{CI:!0,value:"use",class:"keyword"}},22,116],[{type:2,value:{CI:!0,value:"u",class:"keyword"}},22,116],[{type:2,value:{CI:!0,value:"xecute",class:"keyword"}},22,126],[{type:2,value:{CI:!0,value:"x",class:"keyword"}},22,126],[{type:2,value:{CI:!0,value:"zload",class:"keyword"}},22,131],[{type:2,value:{CI:!0,value:"zl",class:"keyword"}},22,131],[{type:2,value:{CI:!0,value:"znspace",class:"keyword"}},22,133],[{type:2,value:{CI:!0,value:"zn",class:"keyword"}},22,133],[{type:2,value:{CI:!0,value:"if",class:"keyword"}},135],[{type:2,value:{CI:!0,value:"i",class:"keyword"}},135],[{type:2,value:{CI:!0,value:"for",class:"keyword"}},154],[{type:2,value:{CI:!0,value:"f",class:"keyword"}},154],[{type:2,value:{CI:!0,value:"while",class:"keyword"}},171]],[[{type:1},3]],[[{type:1},7]],[[{type:2,value:{value:"default",class:"global"}},0],[{type:2,value:{value:"defaultNamespace",class:"variable"}},8],[{type:2,value:{value:"initMessage",class:"variable"}},8],[{type:2,value:{value:"language",class:"variable"}},8],[{type:2,value:{value:"maxHistorySize",class:"variable"}},8],[{type:2,value:{value:"sqlMaxResults",class:"variable"}},8],[{type:2,value:{value:"suggestions",class:"variable"}},8],[{type:2,value:{value:"syntaxHighlight",class:"variable"}},8],[{type:2,value:{value:"serverName",class:"variable"}},8],[{type:2,value:{value:"updateCheck",class:"variable"}},8],[{type:2,value:{class:"variable"}},8]],[[{type:1},9],[null,9]],[[{type:5,value:{value:"="}},10]],[[{type:1},11],[null,11]],[[{type:2,value:{class:"constant"}},0],[{type:3,value:{class:"string"}},0],[{type:4,value:{class:"constant"}},0]],[[{type:1},13]],[[{type:2,value:{value:"delete",class:"wrong"}},14],[{type:2,value:{class:"constant",type:"favorites"}},16],[{type:4,value:{type:"favorites"}},16]],[[{type:1},15]],[[{type:2,value:{class:"constant",type:"favorites"}},0],[{type:4,value:{type:"favorites"}},0]],[[{type:1},17]],[[null,4,0]],[[{type:1},19]],[[{type:2,value:{value:"stop",class:"global"}},0],[{type:5,value:{value:"^",class:"global",type:"global"}},20,0],[{type:5,value:{type:"filename",class:"string"}},21],[{type:2,value:{type:"filename",class:"string"}},21]],[[{type:5,value:{value:"%",class:"global",type:"global"}},257],[null,257]],[[{type:5,value:{type:"filename",class:"string"}},21],[{type:2,value:{type:"filename",class:"string"}},21],[{type:1},21]],[[{type:5,value:{value:":"}},37,0],[null,0]],[[{type:1},24],[null,24]],[[{type:3},0],[{type:4},0],[null,0]],[[{type:1},26]],[[{type:3},27],[{type:4},27]],[[{type:5,value:{value:","}},28],[null,0]],[[{type:1},26],[null,26]],[[{type:1},30]],[[null,31,32]],[[{type:5,value:{value:"^",class:"global"}},194],[{type:2,value:{class:"variable",type:"variable"}},197],[null,206,0]],[[{type:1},33],[null,33]],[[{type:5,value:{value:","}},34],[null,0]],[[{type:1},30],[null,30]],[[{type:1},36]],[[{type:5,value:{value:"!",class:"special"}},39],[0,37,39],[0,38,39],[null,39]],[[{type:4},241],[{type:5,value:{value:"("}},229],[{type:5,value:{value:"[",class:"argument"}},232],[{type:5,value:{value:"{",class:"argument"}},236],[{type:5,value:{value:"-"}},37,241],[{type:5,value:{value:"'"}},37,241],[{type:3},241],[0,50,241],[0,206,241],[0,240,241]],[[{type:5,value:{value:"!",class:"special"}},193],[{type:5,value:{value:"#",class:"special"}},193],[{type:5,value:{value:"?",class:"special"}},37,0]],[[{type:1},40],[null,40]],[[{type:5,value:{value:","}},41],[null,0]],[[{type:1},36],[null,36]],[[{type:1},37,0]],[[{type:1},44]],[[null,31,45]],[[{type:1},46],[null,46]],[[{type:5,value:{value:","}},47],[null,0]],[[{type:1},44],[null,44]],[[{type:1},49]],[[{type:5,value:{value:"^",class:"global",type:"global"}},20,49],[null,50,49],[{type:1},51],[null,51]],[[{type:5,value:{value:"^",class:"global",type:"global"}},20,0],[{type:5,value:{value:"@"}},248],[null,248]],[[{type:5,value:{value:"="}},52]],[[{type:1},53],[null,53]],[[{type:5,value:{value:"^",class:"global",type:"global"}},20,0],[null,50,0]],[[{type:1},55]],[[{type:3},56],[{type:4},56]],[[{type:5,value:{value:":"}},57],[null,66]],[[{type:5,value:{value:"("}},58,59],[{type:4},64],[{type:3},66]],[[{type:5,value:{value:"/",class:"special"}},189],[{type:3},192],[null,0]],[[{type:5,value:{value:")"}},60]],[[{type:5,value:{value:":"}},61],[null,66]],[[{type:4},62],[{type:3},66]],[[{type:5,value:{value:":"}},63],[null,66]],[[{type:3},66]],[[{type:5,value:{value:":"}},65],[null,66]],[[{type:3},66]],[[{type:5,value:{value:","}},67],[null,0]],[[{type:1},55],[null,55]],[[{type:1},69]],[[0,37,70],[null,70]],[[{type:1},71],[null,71]],[[{type:5,value:{value:","}},72],[null,0]],[[{type:1},69],[null,69]],[[{type:1},74]],[[null,75,76]],[[{type:5,value:{value:"("}},180],[null,50,183]],[[{type:1},77],[null,77]],[[{type:5,value:{value:","}},78],[null,0]],[[{type:1},74],[null,74]],[[{type:1},80],[null,80]],[[{type:5,value:{value:"{"}},81]],[[{type:1},82],[null,82]],[[{type:5,value:{value:"}"}},83],[null,4,96]],[[{type:1},84],[null,84]],[[{type:2,value:{CI:!0,value:"catch",class:"keyword"}},85]],[[{type:1},86],[null,86]],[[{type:5,value:{value:"("}},87],[{type:2,value:{class:"variable"}},91]],[[{type:1},88],[null,88]],[[{type:2,value:{class:"variable"}},89]],[[{type:1},90],[null,90]],[[{type:5,value:{value:")"}},91]],[[{type:1},92],[null,92]],[[{type:5,value:{value:"{"}},93]],[[{type:1},94],[null,94]
+         ],[[{type:5,value:{value:"}"}},0],[null,4,95]],[[{type:1},93]],[[{type:1},81]],[[{type:1},98]],[[{type:5,value:{value:"("}},99],[null,50,103]],[[{type:1},100,101],[null,100,101]],[[null,50,186]],[[{type:1},102],[null,102]],[[{type:5,value:{value:")"}},103]],[[{type:1},104],[null,104]],[[{type:5,value:{value:","}},105],[null,0]],[[{type:1},98],[null,98]],[[{type:1},107],[null,107]],[[0,37,0],[null,0]],[[{type:1},109]],[[{type:3},113],[{type:2,value:{class:"variable",type:"variable"}},110],[{type:5,value:{value:"*",class:"special"}},111],[null,38,113]],[[{type:5,value:{value:"#",class:"special"}},37,112],[null,112]],[[{type:2,value:{class:"variable",type:"variable"}},112]],[[{type:5,value:{value:":",class:"special"}},37,113],[null,113]],[[{type:1},114],[null,114]],[[{type:5,value:{value:","}},115],[null,0]],[[{type:1},109],[null,109]],[[{type:1},117]],[[{type:3},119],[{type:4},119],[{type:5,value:{value:"$",class:"keyword"}},118]],[[{type:2,value:{CI:!0,value:"io",class:"keyword"}},119],[{type:2,value:{CI:!0,value:"principal",class:"keyword"}},119]],[[{type:5,value:{value:":"}},120],[null,124]],[[{type:5,value:{value:"("}},58,121],[{type:3},124]],[[{type:5,value:{value:")"}},122]],[[{type:5,value:{value:":"}},123],[null,124]],[[{type:3},124]],[[{type:5,value:{value:","}},125],[null,0]],[[{type:1},117],[null,117]],[[{type:1},127]],[[{type:3},22,128]],[[{type:1},129],[null,129]],[[{type:5,value:{value:","}},130],[null,0]],[[{type:1},127],[null,127]],[[{type:1},132]],[[{type:2,value:{type:"routine",class:"global"}},0]],[[{type:1},134]],[[{type:3},0]],[[{type:1},37,136]],[[{type:1},137],[null,137]],[[{type:5,value:{value:"{"}},138],[null,4,0]],[[{type:1},139],[null,139]],[[null,4,140]],[[{type:1},141],[null,141]],[[{type:5,value:{value:"}"}},142],[null,139]],[[{type:1},143],[null,143]],[[{type:2,value:{CI:!0,value:"else",class:"keyword"}},144],[{type:2,value:{CI:!0,value:"elseif",class:"keyword"}},150]],[[{type:1},145],[null,145]],[[{type:5,value:{value:"{"}},146]],[[{type:1},147],[null,147]],[[null,4,148]],[[{type:1},149],[null,149]],[[{type:5,value:{value:"}"}},0],[null,147]],[[{type:1},37,151]],[[{type:1},152],[null,152]],[[{type:5,value:{value:"{"}},153]],[[{type:1},139],[null,139]],[[{type:1},155]],[[{type:2,value:{type:"variable",class:"variable"}},156]],[[{type:5,value:{value:"="}},37,157]],[[{type:1},158],[null,158]],[[{type:5,value:{value:":"}},159],[null,163]],[[{type:1},37,160],[null,37,160]],[[{type:1},161],[null,161]],[[{type:5,value:{value:":"}},162],[null,163]],[[{type:1},37,163],[null,37,163]],[[{type:1},164],[null,164]],[[{type:5,value:{value:","}},165],[null,166]],[[{type:1},155],[null,155]],[[{type:5,value:{value:"{"}},167]],[[{type:1},168],[null,168]],[[null,4,169]],[[{type:1},170],[null,170]],[[{type:5,value:{value:"}"}},0],[null,168]],[[{type:1},172]],[[null,37,173]],[[{type:1},174],[null,174]],[[{type:5,value:{value:","}},175],[{type:5,value:{value:"{"}},176]],[[{type:1},172],[null,172]],[[{type:1},177],[null,177]],[[null,4,178]],[[{type:1},179],[null,179]],[[{type:5,value:{value:"}"}},0],[null,177]],[[{type:1},100,181],[null,100,181]],[[{type:1},182],[null,182]],[[{type:5,value:{value:")"}},183]],[[{type:1},184],[null,184]],[[{type:5,value:{value:"="}},185]],[[{type:1},37,0],[null,37,0]],[[{type:1},187],[null,187]],[[{type:5,value:{value:","}},188],[null,0]],[[{type:1},100],[null,100]],[[{type:2,value:{class:"special"}},190]],[[{type:5,value:{value:"="}},37,191],[null,191]],[[{type:5,value:{value:":"}},58],[null,0]],[[{type:5,value:{value:":"}},58],[null,0]],[[{type:5,value:{value:"!",class:"special"}},193],[{type:5,value:{value:"#",class:"special"}},193],[{type:5,value:{value:"?",class:"special"}},37,0],[null,0]],[[{type:5,value:{value:"%",type:"routine",class:"global"}},195],[null,195]],[[{type:2,value:{type:"routine",class:"global"}},196]],[[{type:5,value:{value:".",type:"routine",class:"global"}},194],[null,22,0]],[[{type:5,value:{value:".",type:"*"}},198]],[[{type:5,value:{value:"%",type:"memberMethod"}},199],[null,199]],[[{type:2,value:{type:"memberMethod"}},200]],[[{type:5,value:{value:"("}},201],[{type:5,value:{value:".",type:"*"}},198]],[[{type:1},202,203],[null,202,203]],[[0,252,0],[null,0]],[[{type:1},204],[null,204]],[[{type:5,value:{value:")"}},205]],[[{type:5,value:{value:".",type:"*"}},198],[null,22,0]],[[{type:5,value:{value:"#",class:"special"}},268],[{type:5,value:{value:"$",class:"special"}},278]],[[{type:5,value:{value:"("}},208],[{type:5,value:{value:"{",class:"argument"}},211],[{type:5,value:{value:"[",class:"argument"}},216],[{type:3},0],[{type:4},0]],[[{type:1},37,209],[null,37,209]],[[{type:1},210],[null,210]],[[{type:5,value:{value:")"}},0]],[[{type:1},212],[null,212]],[[{type:5,value:{value:"}",class:"argument"}},0],[null,213,214]],[[{type:3},221]],[[{type:1},215],[null,215]],[[{type:5,value:{value:"}",class:"argument"}},0]],[[{type:1},217],[null,217]],[[{type:5,value:{value:"]",class:"argument"}},0],[null,218,219]],[[{type:1},207,227],[null,207,227]],[[{type:1},220],[null,220]],[[{type:5,value:{value:"]",class:"argument"}},0]],[[{type:1},222],[null,222]],[[{type:5,value:{value:":"}},223]],[[{type:1},207,224],[null,207,224]],[[{type:1},225],[null,225]],[[{type:5,value:{value:","}},226],[null,0]],[[{type:1},213],[null,213]],[[{type:1},228],[null,228]],[[{type:5,value:{value:","}},218],[null,0]],[[{type:1},37,230],[null,37,230]],[[{type:1},231],[null,231]],[[{type:5,value:{value:")"}},241]],[[{type:1},233],[null,233]],[[{type:5,value:{value:"]",class:"argument"}},241],[null,218,234]],[[{type:1},235],[null,235]],[[{type:5,value:{value:"]",class:"argument"}},241]],[[{type:1},237],[null,237]],[[{type:5,value:{value:"}",class:"argument"}},241],[null,213,238]],[[{type:1},239],[null,239]],[[{type:5,value:{value:"}",class:"argument"}},241]],[[{type:5,value:{value:"$",class:"keyword"}},288]],[[{type:1},242],[null,242]],[[{type:5,value:{value:"+",class:"special"}},247],[{type:5,value:{value:"-",class:"special"}},247],[{type:5,value:{value:"*",class:"special"}},247],[{type:5,value:{value:"/",class:"special"}},247],[{type:5,value:{value:"_",class:"special"}},247],[{type:5,value:{value:"=",class:"special"}},247],[{type:5,value:{value:"'",class:"special"}},243],[{type:5,value:{value:"<",class:"special"}},244],[{type:5,value:{value:">",class:"special"}},244],[{type:5,value:{value:"&",class:"special"}},245],[{type:5,value:{value:"|",class:"special"}},246],[{type:5,value:{value:"[",class:"special"}},247],[{type:5,value:{value:"]",class:"special"}},247],[{type:5,value:{value:"#",class:"special"}},247],[null,0]],[[{type:5,value:{value:"=",class:"special"}},247],[{type:5,value:{value:">",class:"special"}},247],[{type:5,value:{value:"<",class:"special"}},247]],[[{type:5,value:{value:"=",class:"special"}},247],[null,247]],[[{type:5,value:{value:"&",class:"special"}},247],[null,247]],[[{type:5,value:{value:"|",class:"special"}},247]],[[{type:1},37,0],[null,37,0]],[[{type:2,value:{class:"variable",type:"variable"}},250],[{type:5,value:{value:"%",class:"variable",type:"variable"}},249]],[[{type:2,value:{class:"variable",type:"variable"}},250]],[[{type:5,value:{value:"("}},251],[null,255]],[[{type:1},252,253],[null,252,253]],[[{type:5,value:{value:".",class:"argument"}},294],[{type:5,value:{value:","}},295],[null,37,296]],[[{type:1},254],[null,254]],[[{type:5,value:{value:")"}},255]],[[{type:5,value:{value:".",type:"*"}},256,255],[null,0]],[[{type:5,value:{value:"%",type:"member"}},263],[{type:5,value:{value:"#",type:"member"}},263],[null,263]],[[{type:2,value:{class:"global",type:"global"}},258]],[[{type:5,value:{value:".",class:"global",type:"global"}},257],[null,259]],[[{type:5,value:{value:"("}},260],[null,0]],[[{type:1},202,261],[null,202,261]],[[{type:1},262],[null,262]],[[{type:5,value:{value:")"}},0]],[[{type:2,value:{type:"member"}},264]],[[{type:5,value:{value:"("}},265],[null,0]],[[{type:1},202,266],[null,202,266]],[[{type:1},267],[null,267]],[[{type:5,value:{value:")"}},0]],[[{type:5,value:{value:"#",class:"special"}},269]],[[{type:2,value:{CI:!0,value:"class",class:"special"}},270],[{type:2,value:{CI:!0,value:"super",class:"special"}},276]],[[{type:5,value:{value:"(",class:"special"}},271]],[[{type:5,value:{value:"%",type:"classname",class:"classname"}},272],[null,272]],[[{type:2,value:{type:"classname",class:"classname"}},273]],[[{type:5,value:{value:".",type:"classname",class:"classname"}},272],[{type:5,value:{value:")",class:"special",type:"*"}},274]],[[{type:5,value:{value:".",type:"*"}},275,0]],[[{type:5,value:{value:"#",type:"parameter",class:"keyword"}},282],[{type:5,value:{value:"%",type:"publicClassMember",class:"keyword"}},283],[null,283]],[[{type:5,value:{value:"(",class:"special"}},202,277]],[[{type:5,value:{value:")",class:"special"}},0]],[[{type:2,value:{CI:!0,value:"system",class:"special"}},279]],[[{type:5,value:{value:".",type:"classname",class:"classname"}},280]],[[{type:2,value:{type:"classname",class:"classname"}},281]],[[{type:5,value:{value:".",type:"*"}},275,0]],[[{type:2,value:{type:"parameter",class:"keyword"}},0]],[[{type:2,value:{type:"publicClassMember",class:"keyword"}},284]],[[{type:5,value:{value:"("}},285]],[[{type:1},202,286],[null,202,286]],[[{type:1},287],[null,287]],[[{type:5,value:{value:")"}},0]],[[{type:2,value:{CI:!0,class:"keyword",value:"ascii"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"bit"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"bitcount"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"bitfind"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"bitlogic"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"char"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"classmethod"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"classname"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"compile"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"data"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"decimal"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"double"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"extract"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"factor"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"find"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"fnumber"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"get"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"increment"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"inumber"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"isobject"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"isvaliddouble"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"isvalidnum"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"justify"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"length"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"lb"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listbuild"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listdata"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listfind"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listfromstring"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listget"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listlength"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listnext"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listsame"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listtostring"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listupdate"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"listvalid"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"list"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"locate"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"match"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"method"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"name"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"nconvert"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"next"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"normalize"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"now"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"number"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"order"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"parameter"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"piece"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"prefetchoff"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"prefetchon"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"property"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"qlength"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"qsubscript"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"query"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"random"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"replace"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"reverse"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"sconvert"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"sequence"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"sortbegin"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"sortend"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"stack"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"text"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"translate"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"view"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"wascii"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"wchar"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"wextract"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"wfind"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"wiswide"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"wlength"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"wreverse"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"xecute"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"xecute"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zabs"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zarccos"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zarcsin"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zarctan"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zcos"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zcot"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zcsc"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zdate"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zdateh"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zdatetime"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zdatetimeh"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zexp"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zhex"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zln"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zlog"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zpower"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zsec"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zsin"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"zsqr"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"ztan"}},
+         290],[{type:2,value:{CI:!0,class:"keyword",value:"ztime"}},290],[{type:2,value:{CI:!0,class:"keyword",value:"ztimeh"}},290],[{type:2,value:{CI:!0,class:"keyword"}},290],[{type:5,value:{value:"$",class:"keyword"}},289],[null,290]],[[{type:2,value:{class:"keyword"}},290]],[[{type:5,value:{value:"("}},291],[null,0]],[[{type:1},202,292],[null,202,292]],[[{type:1},293],[null,293]],[[{type:5,value:{value:")"}},0]],[[{type:2,value:{class:"argument"}},296]],[[{type:1},252],[null,252]],[[{type:5,value:{value:","}},297],[null,0]],[[{type:1},252],[null,252]],[[{type:5,value:{value:"/",class:"special"}},2,0],[{type:2,value:{CI:!0,value:"delete",class:"keyword"}},299],[{type:2,value:{CI:!0,value:"update",class:"keyword"}},301],[{type:2,value:{CI:!0,value:"select",class:"keyword"}},303],[{type:2,value:{CI:!0,value:"call",class:"keyword"}},305]],[[{type:1},300,0]],[[null,338,374]],[[{type:1},302,0]],[[null,316,360]],[[{type:1},304,0]],[[{type:2,value:{CI:!0,value:"top",class:"keyword"}},323],[null,326]],[[{type:1},306,0]],[[null,316,317]],[[{type:2,value:{class:"variable",type:"sqlFieldName"}},308]],[[{type:5,value:{value:"."}},309],[null,310]],[[{type:2,value:{class:"variable",type:"sqlFieldName"}},310]],[[{type:1},311],[null,311]],[[{type:5,value:{value:"-"}},312],[null,0]],[[{type:5,value:{value:">"}},313]],[[{type:1},314],[null,314]],[[{type:2,value:{class:"variable",type:"sqlFieldName"}},315]],[[{type:1},311],[null,311]],[[{type:5,value:{value:"%",type:"sqlClassname",class:"classname"}},378],[null,378]],[[{type:5,value:{value:"_",type:"sqlClassname",class:"classname"}},317],[{type:2,value:{CI:!0,type:"sqlClassname",class:"classname"}},317],[null,318]],[[{type:5,value:{value:"("}},319]],[[{type:1},320,321],[null,320,321]],[[{type:5,value:{value:"("}},383],[{type:4},387],[{type:5,value:{value:"'",class:"string"}},386],[null,387]],[[{type:1},322],[null,322]],[[{type:5,value:{value:")"}},0]],[[{type:1},324]],[[{type:4},325]],[[{type:1},326]],[[{type:5,value:{value:"*",class:"special"}},337],[{type:2,value:{CI:!0,value:"avg",class:"keyword"}},327],[{type:2,value:{CI:!0,value:"count",class:"keyword"}},327],[{type:2,value:{CI:!0,value:"max",class:"keyword"}},327],[{type:2,value:{CI:!0,value:"min",class:"keyword"}},327],[null,307,331]],[[{type:5,value:{value:"("}},328]],[[{type:1},307,329],[null,307,329]],[[{type:1},330],[null,330]],[[{type:5,value:{value:")"}},337]],[[{type:2,value:{CI:!0,value:"as",class:"keyword"}},332],[null,335]],[[{type:1},333]],[[{type:2,value:{class:"variable"}},334]],[[{type:1},335],[null,335]],[[{type:5,value:{value:","}},336],[null,337]],[[{type:1},326],[null,326]],[[{type:1},338,339]],[[{type:2,value:{CI:!0,value:"from",class:"keyword"}},377]],[[{type:1},340],[null,340]],[[{type:2,value:{CI:!0,value:"order",class:"keyword"}},341,0],[{type:2,value:{CI:!0,value:"where",class:"keyword"}},342],[{type:2,value:{class:"variable"}},346],[null,0]],[[{type:1},351]],[[{type:1},343,344]],[[{type:4},409],[{type:2,value:{CI:!0,value:"null",class:"constant"}},409],[{type:5,value:{value:"("}},390],[{type:2,value:{CI:!0,value:"not",class:"keyword"}},400],[{type:5,value:{value:"'",class:"string"}},401],[{type:2,value:{CI:!0,value:"char",class:"keyword",type:"sqlFunc"}},402],[{type:2,value:{CI:!0,value:"ascii",class:"keyword",type:"sqlFunc"}},402],[{type:2,value:{class:"variable",type:"sqlFieldName"}},406]],[[{type:1},345],[null,345]],[[{type:2,value:{CI:!0,value:"order",class:"keyword"}},341,0],[null,0]],[[{type:1},347]],[[{type:2,value:{CI:!0,value:"order",class:"keyword"}},341,0],[{type:2,value:{CI:!0,value:"where",class:"keyword"}},348],[null,0]],[[{type:1},343,349]],[[{type:1},350],[null,350]],[[{type:2,value:{CI:!0,value:"order",class:"keyword"}},341,0],[null,0]],[[{type:2,value:{CI:!0,value:"by",class:"keyword"}},352]],[[{type:1},353]],[[{type:2,value:{class:"variable",type:"sqlFieldName"}},354]],[[{type:1},355],[null,355]],[[{type:2,value:{CI:!0,value:"desc",class:"keyword"}},356],[{type:2,value:{CI:!0,value:"asc",class:"keyword"}},357],[null,358]],[[{type:1},358],[null,358]],[[{type:1},358],[null,358]],[[{type:5,value:{value:","}},359],[null,0]],[[{type:1},353],[null,353]],[[{type:1},361]],[[{type:2,value:{CI:!0,value:"set",class:"keyword"}},364],[{type:2,value:{class:"variable"}},362]],[[{type:1},363]],[[{type:2,value:{CI:!0,value:"set",class:"keyword"}},364]],[[{type:1},365]],[[{type:2,value:{type:"sqlFieldName",class:"variable"}},366]],[[{type:1},367],[null,367]],[[{type:5,value:{value:"="}},368]],[[{type:1},343,369],[null,343,369]],[[{type:1},370],[null,370]],[[{type:5,value:{value:","}},371],[null,372]],[[{type:1},365],[null,365]],[[{type:2,value:{CI:!0,value:"where",class:"keyword"}},373]],[[{type:1},343,0]],[[{type:1},375]],[[{type:2,value:{CI:!0,value:"where",class:"keyword"}},376]],[[{type:1},343,0]],[[{type:1},316,0]],[[{type:2,value:{type:"sqlClassname",class:"classname"}},379]],[[{type:5,value:{value:"_",type:"sqlClassname",class:"classname"}},378],[{type:5,value:{value:".",type:"sqlClassname",class:"classname"}},380]],[[{type:2,value:{CI:!0,type:"sqlClassname",class:"classname"}},381]],[[{type:5,value:{value:"_",type:"sqlClassname",class:"classname"}},382],[null,0]],[[{type:2,value:{CI:!0,type:"sqlClassname",class:"classname"}},0]],[[{type:1},320,384],[null,320,384]],[[{type:1},385],[null,385]],[[{type:5,value:{value:")"}},387]],[[{type:5,value:{value:"'",class:"string"}},387],[{type:4,value:{class:"string"}},386],[{type:2,value:{class:"string"}},386],[{type:3,value:{class:"string"}},386],[{type:5,value:{class:"string"}},386],[{type:1},386]],[[{type:1},388],[null,388]],[[{type:5,value:{value:","}},389],[null,0]],[[{type:1},320],[null,320]],[[{type:1},391],[null,391]],[[{type:2,value:{CI:!0,value:"delete",class:"keyword"}},392],[{type:2,value:{CI:!0,value:"update",class:"keyword"}},394],[{type:2,value:{CI:!0,value:"select",class:"keyword"}},396],[null,343,398]],[[{type:1},300,393]],[[{type:1},399],[null,399]],[[{type:1},302,395]],[[{type:1},399],[null,399]],[[{type:1},304,397]],[[{type:1},399],[null,399]],[[{type:1},399],[null,399]],[[{type:5,value:{value:")"}},409]],[[{type:1},343,409],[null,343,409]],[[{type:5,value:{value:"'",class:"string"}},409],[{type:4,value:{class:"string"}},401],[{type:2,value:{class:"string"}},401],[{type:3,value:{class:"string"}},401],[{type:5,value:{class:"string"}},401],[{type:1},401]],[[{type:5,value:{value:"("}},403]],[[{type:1},343,404],[null,343,404]],[[{type:1},405],[null,405]],[[{type:5,value:{value:")"}},409]],[[{type:5,value:{value:"_",class:"variable",type:"sqlFieldName"}},407],[{type:5,value:{value:".",class:"variable",type:"sqlFieldName"}},408],[null,409]],[[{type:2,value:{class:"variable",type:"sqlFieldName"}},409]],[[{type:2,value:{class:"variable",type:"sqlFieldName"}},406]],[[{type:1},410],[null,410]],[[{type:5,value:{value:"+"}},412],[{type:5,value:{value:"-"}},412],[{type:5,value:{value:"*"}},412],[{type:5,value:{value:"/"}},412],[{type:5,value:{value:"="}},412],[{type:5,value:"<"},411],[{type:5,value:">"},411],[{type:2,value:{CI:!0,value:"and",class:"keyword"}},412],[{type:2,value:{CI:!0,value:"like",class:"keyword"}},412],[{type:2,value:{CI:!0,value:"or",class:"keyword"}},412],[{type:2,value:{CI:!0,value:"is",class:"keyword"}},412],[null,0]],[[{type:5,value:{value:"="}},412],[null,412]],[[{type:1},343,0],[null,343,0]]]),T=e({CWTInput:1,CWTSpecial:2,OSCommand:4,globalBody:20,postCondition:22,doArgument:31,expression:37,termSpecial:38,variable:50,deviceParameters:58,setExpression:75,variableListExpression:100,argumentList:202,class:206,jsonValue:207,jsonObjectBody:213,jsonArrayBody:218,function:240,nonEmptyArgumentList:252,member:256,classStatic:275,SQLMode:298,SQLDelete:300,SQLUpdate:302,SQLSelect:304,SQLCall:306,SQLVar:307,SQLClassName:316,SQLCallArgList:320,SQLFrom:338,SQLOrder:341,SQLExpression:343})}.call(this)}.call(this,t("_process"))},{"../autocomplete":335,"./pushdownAutomaton":358,_process:331}],358:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0});var r="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e},I=(n.getAutomaton=function(){return{automaton:function(e){var t,n=e.slice();for(t in n)if(n[t])for(var r in n[t]=n[t].slice(),n[t])n[t][r]=n[t][r].slice();n[0]=[[!1,0]];for(var o=1;o<n.length;o++)if(!n[o]){for(var a in n)if(n[a])for(var i in n[a])parseInt(n[a][i][1])>o&&--n[a][i][1],parseInt(n[a][i][2])>o&&--n[a][i][2];if(!l)for(var s in u)u[s]>o&&--u[s];n.splice(o,1),o--}return l=!0,n}(o),ruleMappings:u}},n.rule=function(e){var t=new i;return t.ruleName=e,t},n.TYPE_WHITESPACE=1),C=n.TYPE_ID=2,O=n.TYPE_STRING=3,P=n.TYPE_CONSTANT=4,L=n.TYPE_CHAR=5,M=n.TYPE_EXIT=6,T=n.TYPE_MERGE=7,R=n.TYPE_ANY=8,N=n.TYPE_CALL=9,D=n.TYPE_BRANCH=10,F=n.TYPE_OPT_WHITESPACE=11,H=n.TYPE_TRY_CALL=12,G=n.TYPE_ALL=13,U=n.TYPE_NONE=14,W=n.TYPE_SPLIT=15,o=[],l=!1,u={};function a(e){return e instanceof i?e:new i(!0)}function i(e){this.built=e||!1,this.ruleName="",this.chain=[]}function s(n){return function(e){var t=a(this);return t.chain.push({type:n,value:n!==L&&n!==C||"object"===(void 0===e?"undefined":r(e))?e:void 0===e?{}:{value:e}}),t}}n.branch=i.prototype.branch=s(D),n.call=i.prototype.call=s(N),n.char=i.prototype.char=s(L),n.string=i.prototype.string=s(O),n.id=i.prototype.id=s(C),n.any=i.prototype.any=s(R),n.all=i.prototype.all=s(G),n.none=i.prototype.none=s(U),n.whitespace=i.prototype.whitespace=s(I),n.optWhitespace=i.prototype.optWhitespace=s(F),n.constant=i.prototype.constant=s(P),n.tryCall=s(H),i.prototype.end=function(){this.built||this.buildTable()},n.merge=i.prototype.merge=function(){var e=a(this);return e.chain.push({type:T}),e.built||e.buildTable(),e},n.exit=i.prototype.exit=function(){var e=a(this);return e.chain.push({type:M}),e.built||e.buildTable(),e},n.split=i.prototype.split=function(){for(var e=a(this),t=[],n=0;n<arguments.length;n++)t.push(arguments[n].chain);return e.chain.push({type:W,value:t}),e};i.prototype.buildTable=function(){this.built=!0;var e=this.ruleName,t=this.chain;if((t=function e(t,n,r){var o=void 0===r?++B:r,a=[],i=[];function s(t){a.length&&(o=++B,a.forEach(function(e){return e[1]=void 0===t?o:t}),a=[])}function l(t){i.length&&(i.forEach(function(e){return e[2]=void 0===t?o:t}),i=[])}for(var u in t){var c=t[u];switch(c.type){case L:case C:case P:case I:case O:s(),l();var f=z(o);if(c.value instanceof Array){var p=!0,d=!1,v=void 0;try{for(var y,_=c.value[Symbol.iterator]();!(p=(y=_.next()).done);p=!0){var h=y.value,m=[{type:c.type,value:h}];f.push(m),a.push(m)}}catch(e){d=!0,v=e}finally{try{!p&&_.return&&_.return()}finally{if(d)throw v}}}else{d=[c];f.push(d),a.push(d)}break;case F:s(),l();var v=[{type:I,value:void 0}],g=[null];z(o).push(v,g),a.push(v,g);break;case R:s(),l();g=[null];z(o).push(g),a.push(g);break;case G:case U:s(),l();var b=[c.type===G];z(o).push(b),a.push(b);break;case D:s(),l(),n=n.concat(o);break;case T:b=n.pop();if(void 0===o)throw new Error("Unmatched 'merge()': no matching 'branch()' in the chain.");s(b),l(b);break;case W:s(),l();var x=!0,w=!1,j=void 0;try{for(var A,S=c.value[Symbol.iterator]();!(x=(A=S.next()).done);x=!0){var k=A.value,E=e(k,n.slice(),o);a=a.concat(E[0]),i=i.concat(E[1])}}catch(e){w=!0,j=e}finally{try{!x&&S.return&&S.return()}finally{if(w)throw j}}break;case N:a.length?(i=i.concat(a),s(Y(c.value))):(w=[null,Y(c.value)],z(o).push(w),i.push(w),o=++B);break;case H:a.length&&(s(),l());j=[0,Y(c.value)];z(o).push(j),i.push(j),o=++B;break;case M:s(0),l(0)}}return[a,i]}(t,[],Y(e)))[0].length||t[1].length)throw console.error("Not completed state. Stack",t[0],", BackStack:",t[1]),new Error("There is a mistake in grammar definition. Please, make sure all chains are exited or looped.")};var B=0;function Y(e){return u.hasOwnProperty(e)||(u[e]=++B),u[e]}function z(e){return void 0===o[e]&&(o[e]=[]),o[e]}},{}],359:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0});var i="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e};n.init=function(){var e=0<arguments.length&&void 0!==arguments[0]?arguments[0]:{};u.get("initMessage")&&!e.cleanStart&&(s.printLine("CWTv"+a.VERSION+" "+e.system+":\x1b[(keyword)m"+e.username+"\x1b[0m"+(e.name?" ("+e.name+")":"")),e.firstLaunch&&s.printLine(l.get("firstLaunchMessage")));e.cleanStart&&u.setTemp("updateCheck","false");c.collect(e),u.set("serverName",e.name,!0),document.title=(e.name||e.system)+" - WebTerminal",a.authDone()},n.prompt=function(e){a.NAMESPACE=e,r.prompt(e+" > ",{},function(e){o.send("Execute",e)})},n.promptCallback=function(e){a.promptCallback(e)},n.execError=function(){var e=0<arguments.length&&void 0!==arguments[0]?arguments[0]:"",t=[""];if("object"===(void 0===e?"undefined":i(e))){var n=p(e.zerror||"?");if(t.push(n.string),!n.internal)for(var r=e.source.split(/\n/g),o=0;o<r.length;o++){var a=o===e.line;t.push("\x1b["+(a?"(wrong)":"(special)")+"m"+(a?"\u2560":"\u2551")+"\x1b[0m"+(a?"\x1b[(wrong)m":"")+r[o]+(a?"\x1b[0m":""))}}else t.push(p(e).string);s.printAsync(t.join("\r\n")+"\r\n")},n.error=function(){var e=0<arguments.length&&void 0!==arguments[0]?arguments[0]:"";s.print("\x1b[31m"+l.parse(e)+"\x1b[0m")},n.readString=function(){var e=0<arguments.length&&void 0!==arguments[0]?arguments[0]:{};r.prompt("",e,function(e){o.send("i",e)},!1)},n.readChar=function(){var e=0<arguments.length&&void 0!==arguments[0]?arguments[0]:{};r.getKey(e,function(e){o.send("i",e)})},n.o=function(){var e=0<arguments.length&&void 0!==arguments[0]?arguments[0]:"";s.print(e)},n.oLocalized=function(){var e=0<arguments.length&&void 0!==arguments[0]?arguments[0]:"";s.print(l.parse(e))};var s=f(e("../output")),r=f(e("../input")),o=f(e("./index")),a=f(e("../index")),l=f(e("../localization")),u=f(e("../config")),c=f(e("../analytics"));function f(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}function p(e){var e=e.replace(/(\w+(?:\+[0-9]+)?\^(?:\w\.?)+)/,"\x1b[(special)m$1\x1b[0m").replace(/^(<.*>)/,"\x1b[31m$1\x1b[0m"),t=e.replace(/z\w+\+[0-9]+\^WebTerminal\.\w+\.[0-9]+/,"");return{string:t,internal:t.length!==e.length}}},{"../analytics":333,"../config":337,"../index":340,"../input":345,"../localization":349,"../output":356,"./index":360}],360:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.connect=_,n.send=j;var r=e("../output"),o=e("../localization"),a=function(e){{if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}}(e("./handlers"));var i="WebTerminal.Engine.cls",s=1e4,l=!1,u=void 0,c=[],f=0,p=void 0,d=1,v={},y={};function _(e){clearTimeout(f),f=0,u=new WebSocket(("https:"===location.protocol?"wss:":"ws:"
+         )+"//"+location.hostname+":"+(location.port||("https:"===location.protocol?"443":"80"))+(location.pathname.includes("/terminal")?location.pathname.replace(/\/terminal.*/,"/terminalsocket"):"/terminalsocket")+"/"+encodeURIComponent(i)),e&&(y=e),u.addEventListener("open",h),u.addEventListener("close",b),u.addEventListener("error",m),u.addEventListener("message",function(t){if("o"===t.data[0])x({h:"o",d:t.data.slice(1)});else{var e=void 0;try{e=JSON.parse(t.data)}catch(e){return void(0,r.printLine)((0,o.get)("serParseErr",t.data))}x(e)}})}function h(){l=!0,j("Auth",y),w()}function m(e){(0,r.printLine)((0,o.get)("wsErr",e.data||e))}function g(){(0,r.printLine)((0,o.get)("plRefPageSes")),c.unshift(p),_()}function b(e){l=!1,1e3!==e.code&&1005!==e.code?((0,r.printLine)("\r\n"+(0,o.get)("wsConnLost",e.code,e.reason?" "+e.reason:"")),(0,r.printLine)((0,o.get)("reConn",s/1e3)),f=setTimeout(g,s)):(0,r.printLine)((0,o.get)("seeYou"))}function x(e){e=0<arguments.length&&void 0!==e?e:{};e._cb?v[e._cb]?(v[e._cb](e.d),delete v[e._cb]):(0,r.printLine)("\r\n"+(0,o.get)("eInt","E.server.index.3 ("+e._cb+")")):e.h?"function"==typeof a[e.h]?a[e.h](e.d):(0,r.printLine)("\r\n"+(0,o.get)("eInt","E.server.index.1 ("+e.h+")")):(0,r.printLine)("\r\n"+(0,o.get)("eInt","E.server.index.2 ("+JSON.stringify(e)+")"))}function w(){l&&(c=c.filter(function(e){try{u.send(JSON.stringify(e))}catch(e){return f=f||setTimeout(g,s),!0}return!1}))}function j(e,t,n){t={d:t||null,h:e};"function"==typeof n&&(t._cb=d,v[d++]=n),p=p||t,c.push(t),w()}},{"../localization":349,"../output":356,"./handlers":359}],361:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.clear=function(){localStorage.clear()},n.set=function(e,t){localStorage.setItem(e,t)},n.remove=function(e){localStorage.removeItem(e)},n.get=function(e){return localStorage.getItem(e)};n=e("./output"),e=function(e){{if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}}(e("./localization"));"undefined"!=typeof JSON&&"undefined"!=typeof localStorage||(0,n.printLine)(e.get("storageErr"))},{"./localization":349,"./output":356}],362:[function(e,t,n){"use strict";Object.defineProperty(n,"__esModule",{value:!0}),n.getList=function(){return s.map(function(e){return"\x1b[("+("^"===e[0]?"global":"string")+")m"+e+"\x1b[0m"}).join(", ")},n.start=function(e){-1===s.indexOf(e)&&(s.push(e),0===l&&(l=setTimeout(c,i)))},n.stop=u;var r=a(e("../server")),o=a(e("../output"));function a(e){if(e&&e.__esModule)return e;var t={};if(null!=e)for(var n in e)Object.prototype.hasOwnProperty.call(e,n)&&(t[n]=e[n]);return t.default=e,t}var i=1e3,s=[],l=0;function u(t){if(!t)return s=[],void(l&&clearTimeout(l));0<(s=s.filter(function(e){return e!==t})).length||l&&(clearTimeout(l),l=0)}function c(){0===s.length?l=0:r.send("TracingStatus",{},function(e){for(var t in e.changes&&o.printAsync(e.changes),e.stop)u(t);l=setTimeout(c,i)})}},{"../output":356,"../server":360}]},{},[340]);]]]]><![CDATA[>
+</data>
+]]></Data>
+</XData>
+</Class>
+
+
+<Class name="WebTerminal.Trace">
+<Super>Common</Super>
+<TimeChanged>66289,77576.378675</TimeChanged>
+<TimeCreated>66289,77576.378675</TimeCreated>
+
+<Property name="Watches">
+<Description>
+Property is used to store watching files/globals. </Description>
+<Type>%List</Type>
+</Property>
+
+<Property name="WatchesCaret">
+<Description>
+Watch position in file or global</Description>
+<Type>%Numeric</Type>
+<MultiDimensional>1</MultiDimensional>
+</Property>
+
+<Method name="Trace">
+<Description>
+Checks for correct watch source and sets watch target to ..Watches
+Returns status of this operation</Description>
+<FormalSpec>name</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set s = $CHAR(0)
+    set watches = s _ $LISTTOSTRING(..Watches, s) _ s
+    if ($FIND(watches, s_name_s) '= 0) return 0 // if watch already defined
+
+    if ($EXTRACT(name,1,1) = "^") { // watching global
+        set g = 0
+        try {
+            if (($data(@name)) '= 0) set g = 1
+        } catch {  }
+        set $ZERROR = ""
+        if (g = 1) {
+            set ..Watches = ..Watches _ $LISTBUILD(name)
+            set ..WatchesCaret(name, 0) = $QUERY(@name@(""), -1) // last
+            set ..WatchesCaret(name, 1) = "?"
+            return 1
+        }
+    } else { // watch file
+        if (##class(%File).Exists(name)) {
+            set ..Watches = ..Watches _ $LISTBUILD(name)
+            set file = ##class(%File).%New(name)
+            set ..WatchesCaret(name,0) = file.Size // current watch cursor position
+            set ..WatchesCaret(name,1) = file.DateModified
+            return 1
+        }
+    }
+
+    return 0
+]]></Implementation>
+</Method>
+
+<Method name="StopTracing">
+<Description>
+Removes watch from watches list
+Returns success status</Description>
+<FormalSpec>name</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    set s = $CHAR(0)
+    set watches = s _ $LISTTOSTRING(..Watches,s) _ s
+    set newWatches = $REPLACE(watches, s_name_s, s)
+    set ..Watches = $LISTFROMSTRING($EXTRACT(newWatches, 2, *-1), s)
+    if (watches '= newWatches) {
+        kill ..WatchesCaret(name)
+    }
+    return watches '= newWatches
+]]></Implementation>
+</Method>
+
+<Method name="ListWatches">
+<Description>
+Returns a list current watches</Description>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    set no = 0
+    set s = "Watching: " _ $CHAR(10)
+    while $LISTNEXT(..Watches, no, value) {
+        set s = s_"(pos: "_..WatchesCaret(value,0)_
+            "; mod: "_..WatchesCaret(value,1)_") "_value_$CHAR(10)
+    }
+    return s
+]]></Implementation>
+</Method>
+
+<Method name="GetTraceGlobalModified">
+<Description>
+Return null string if global hadn't been updated
+This method watches only for tail of global and detects if global still alive</Description>
+<FormalSpec>watch</FormalSpec>
+<ReturnType>%List</ReturnType>
+<Implementation><![CDATA[
+    set data = ""
+    if ($data(@watch)=0) {
+        do ..StopTracing(watch)
+        return $lb($C(27)_"[(wrong)m[D]"_$C(27)_"[0m", $C(13, 10))
+    }
+    for {
+        set query = $QUERY(@..WatchesCaret(watch,0))
+        quit:query=""
+        set ..WatchesCaret(watch,0) = query
+        set data = data _ $case(data = "", 1: "", :$CHAR(13, 10)) _ @query
+    }
+    return $lb($C(27)_"[(special)m[M]"_$C(27)_"[0m", data)
+]]></Implementation>
+</Method>
+
+<Method name="GetTraceFileModified">
+<FormalSpec>watch</FormalSpec>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    set file=##class(%File).%New(watch)
+    set size = file.Size
+    set modDate = file.DateModified
+    set output = ""
+    if (size < 0) { // file had been deleted
+        do ..StopTracing(watch)
+        return $lb($C(27)_"[(wrong)m[D]"_$C(27)_"[0m", $C(13, 10))
+    }
+
+    if (size > ..WatchesCaret(watch, 0)) {
+
+        set stream = ##class(%Stream.FileCharacter).%New()
+        set sc = stream.LinkToFile(watch)
+        do stream.MoveTo(..WatchesCaret(watch, 0) + 1)
+        set read = stream.Read(size - ..WatchesCaret(watch, 0))
+        set output = output _ read
+        set ..WatchesCaret(watch, 0) = size
+        set ..WatchesCaret(watch, 1) = file.DateModified
+        return $lb($C(27)_"[(constant)m[A]"_$C(27)_"[0m", output)
+
+    } elseif ((size < ..WatchesCaret(watch, 0)) || (file.DateModified '= ..WatchesCaret(watch, 1))) {
+
+        set output = output _ "Size change: " _ (size - ..WatchesCaret(watch, 0))
+        set ..WatchesCaret(watch, 0) = size
+        set ..WatchesCaret(watch, 1) = file.DateModified
+        return $lb($C(27)_"[(special)m[M]"_$C(27)_"[0m", output)
+
+    } // else file not changed
+
+    return $lb("", "")
+]]></Implementation>
+</Method>
+
+<Method name="CheckTracing">
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    set no = 0
+    set data = ""
+    set overall = ""
+    set watchList = ..Watches // do not remove or simplify: ..Watches can be modified
+    while $LISTNEXT(watchList, no, value) {
+        set global = $EXTRACT(value, 1, 1) = "^"
+        if global {
+            set data = ..GetTraceGlobalModified(value)
+        } else {
+            set data = ..GetTraceFileModified(value)
+        }
+        if ($LISTGET(data, 2) '= "") {
+            set overall = $LISTGET(data, 1) _ " " _ $C(27) _ "[2m" _ $ZDATETIME($NOW(),1,1)
+            _ $C(27) _ "[0m " _ $C(27) _ "[(" _ $case(global, 1: "global", :"string") _ ")m"
+            _ value _ $C(27) _ "[0m" _ $CHAR(13, 10) _ $LISTGET(data, 2) _ $CHAR(13, 10)
+        }
+        set data = ""
+    }
+    return overall
+]]></Implementation>
+</Method>
+</Class>
+
+
+<Class name="WebTerminal.Updater">
+<Description>
+Web Terminal version 4.9.4 update module class.
+This class represents update mechanism for WebTerminal. Internet connection is required to
+update WebTerminal.</Description>
+<TimeChanged>66289,77576.387864</TimeChanged>
+<TimeCreated>66289,77576.387864</TimeCreated>
+
+<Parameter name="SSLConfigName">
+<Description>
+SSL configuration name used for HTTPS requests.</Description>
+<Default>WebTerminalSSL</Default>
+</Parameter>
+
+<Method name="GetSSLConfigurationName">
+<ClassMethod>1</ClassMethod>
+<ReturnType>%String</ReturnType>
+<Implementation><![CDATA[
+    new $namespace
+    zn "%SYS"
+    if ('##class(Security.SSLConfigs).Exists(..#SSLConfigName)) {
+        set st = ##class(Security.SSLConfigs).Create(..#SSLConfigName)
+        return:(st '= 1) "UnableToCreateSSLConfig:"_$System.Status.GetErrorText(st)
+    }
+    return ..#SSLConfigName
+]]></Implementation>
+</Method>
+
+<Method name="WriteAndDelete">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,file:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    if ##class(%File).Exists(file) {
+        set stream = ##class(%Stream.FileCharacter).%New()
+        set sc = stream.LinkToFile(file)
+        while 'stream.AtEnd {
+            do client.Send("o", stream.Read()_$CHAR(13, 10))
+        }
+        do client.Send("oLocalized", "%sUpdCleanLog("_file_")"_$CHAR(13, 10))
+        do ##class(%File).Delete(file)
+    } else {
+        do client.Send("oLocalized", "%sUpdNoFile")
+    }
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="Stop">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,status:%Status</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    if ($$$ISERR(status)) {
+        do client.Send("oLocalized", "%sUpdErr("_$System.Status.GetErrorText(status)_")"_$C(13, 10))
+    }
+    return status
+]]></Implementation>
+</Method>
+
+<Method name="Update">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>client:WebTerminal.Engine,URL:%String</FormalSpec>
+<ReturnType>%Status</ReturnType>
+<Implementation><![CDATA[
+    do client.Send("oLocalized", "%sUpdSt"_$CHAR(13, 10))
+    set request = ##class(%Net.HttpRequest).%New()
+    set request.Server = $PIECE(URL, "/", 3)
+    set request.Location = $PIECE(URL, "/", 4, *)
+    set request.Https = 1
+    set request.SSLConfiguration = ..GetSSLConfigurationName()
+    do client.Send("oLocalized", "%sUpdRURL(https://"_request.Server_"/"_request.Location_")"_$CHAR(13, 10))
+    set status = request.Get()
+    do client.Send("oLocalized", "%sUpdGetOK"_$CHAR(13, 10))
+    return:(status '= $$$OK) status
+
+    if (request.HttpResponse.StatusCode '= 200) {
+        do client.Send("oLocalized", "%sUpdSCode("_request.HttpResponse.StatusCode_")"_$CHAR(13, 10))
+        return $$$ERROR($$$GeneralError, "HTTP "_request.HttpResponse.StatusCode)
+    }
+
+    do client.Send("oLocalized", "%sUpdWTF"_$CHAR(13, 10))
+    set tempFile = ##class(%File).TempFilename("xml")
+    set file = ##class(%File).%New(tempFile)
+    do file.Open("NW")
+    set data = request.HttpResponse.Data
+    if (($IsObject(data)) && (data.%IsA("%Stream.Object"))) {
+        while 'data.AtEnd {
+            set chunk = data.Read(data.Size)
+            do file.Write(chunk)
+        }
+    } else {
+        do file.Write(data)
+    }
+    do file.Close()
+
+    set backupFile = ##class(%File).TempFilename("xml")
+    do client.Send("oLocalized", "%sUpdBack("_backupFile_")"_$CHAR(13, 10))
+
+    set logFile = ##class(%File).TempFilename("txt")
+    set io = $IO
+
+    open logFile:("NW")
+    use logFile
+    set exportStatus = $System.OBJ.Export("WebTerminal.*.CLS", backupFile)
+    close logFile
+    use io
+
+    do ..WriteAndDelete(client, logFile)
+    if ($$$ISERR(exportStatus)) {
+        do ##class(WebTerminal.Analytics).ReportInstallStatus(exportStatus, "Update")
+        return ..Stop(client, exportStatus)
+    }
+    do client.Send("oLocalized", "%sUpdRemLoad"_$CHAR(13, 10))
+
+    open logFile:("NW")
+    use logFile
+    write $C(27)_"[2m"
+    do $System.OBJ.DeletePackage("WebTerminal")
+    write $C(27)_"[0m", !
+    set loadStatus = $SYSTEM.OBJ.Load(tempFile, "c")
+
+    // At this moment WebTerminal's code can be broken, totally changed or deleted. Do not call
+    // WebTerminal's methods until terminal is restored / fully updated
+
+    if '$$$ISOK(loadStatus) { // roll back
+        write !, $C(27)_"[(wrong)m==FAILED=="_$C(27)_"[0m", !,
+            $System.Status.GetErrorText(loadStatus), !, !,
+            $C(27)_"[(special)m==RESTORING=="_$C(27)_"[0m", !
+        do $SYSTEM.OBJ.Load(backupFile, "c")
+    }
+
+    // end
+
+    close logFile
+    use io
+    do ..WriteAndDelete(client, logFile)
+
+    do client.Send("oLocalized", "%sUpdClean("_tempFile_")"_$CHAR(13, 10))
+    do ##class(%File).Delete(tempFile)
+    do client.Send("oLocalized", "%sUpdClean("_backupFile_")"_$CHAR(13, 10, 13, 10))
+    do ##class(%File).Delete(backupFile)
+    if '$$$ISOK(loadStatus) {
+        do ..Stop(client, loadStatus)
+        do client.Send("oLocalized", $CHAR(13, 10)_"%sUpdRes"_$CHAR(13, 10))
+    }
+    do client.Send("oLocalized", "%sUpdDone"_$CHAR(13, 10))
+
+    do ##class(WebTerminal.Analytics).ReportInstallStatus(loadStatus, "Update")
+
+    return $$$OK
+]]></Implementation>
+</Method>
+</Class>
+</Export>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1530,6 +1530,10 @@ localization/dictionary.js</a></code></td>
                 <h2>The Latest Versions:</h2>
                 <ul class="downloadLinks">
                     <li>
+                        <a href="files/WebTerminal-v4.9.4.xml">WebTerminal-v4.9.4</a>
+                        - No longer require /terminal to be at the root of the URL
+                    </li>
+                    <li>
                         <a href="files/WebTerminal-v4.9.3.xml">WebTerminal-v4.9.3</a>
                         - URIS compatibility
                     </li>

--- a/docs/terminal.json
+++ b/docs/terminal.json
@@ -487,6 +487,13 @@
       "changes": [
         "IRIS 2020 compatibility add"
       ]
+    },
+    {
+      "v": "4.9.4",
+      "url": "https://intersystems-community.github.io/webterminal/files/WebTerminal-v4.9.4.xml",
+      "changes": [
+        "No longer require /terminal to be at the root of the URL"
+      ]
     }
   ]
 }

--- a/import.bat
+++ b/import.bat
@@ -18,5 +18,5 @@ set PACKAGE_NAME=WebTerminal
 :: Build and import application to Caché
 echo Building the project...
 npm run build && ^
-echo s st = $system.Status.GetErrorText($system.OBJ.ImportDir("%~dp0%BUILD_DIR%",,"ck")) w "IMPORT STATUS: "_$case(st="",1:"OK",:st) halt | "%CACHE_DIR%\bin\cache.exe" -s "%CACHE_DIR%\mgr" -U %NAMESPACE% && ^
+echo s st = $system.Status.GetErrorText($system.OBJ.ImportDir("%~dp0%BUILD_DIR%",,"ck",,1)) w "IMPORT STATUS: "_$case(st="",1:"OK",:st) halt | "%CACHE_DIR%\bin\cache.exe" -s "%CACHE_DIR%\mgr" -U %NAMESPACE% && ^
 echo s st = $system.Status.GetErrorText($system.OBJ.ExportPackage("%PACKAGE_NAME%", "%~dp0%XML_EXPORT_DIR%\%PACKAGE_NAME%-v"_##class(%PACKAGE_NAME%.Installer).#VERSION_".xml")) w $c(13,10)_"EXPORT STATUS: "_$case(st="",1:"OK",:st) halt | "%CACHE_DIR%\bin\cache.exe" -s "%CACHE_DIR%\mgr" -U %NAMESPACE%

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "name": "Nikita Savchenko",
     "url": "https://nikita.tk"
   },
-  "version": "4.9.3",
+  "version": "4.9.4",
   "gaID": "UA-83005064-2",
   "releaseNumber": 26,
   "scripts": {
@@ -24,17 +24,18 @@
     "babel-preset-es2015": "^6.22.0",
     "babelify": "^7.3.0",
     "browserify": "^14.1.0",
-    "gulp": "^3.9.1",
-    "gulp-cssnano": "^2.1.2",
+    "gulp": "^4.0.2",
+    "gulp-cssnano": "^2.1.3",
     "gulp-minify-css": "^1.2.4",
-    "gulp-preprocess": "^2.0.0",
-    "gulp-rename": "^1.2.2",
+    "gulp-preprocess": "^4.0.2",
+    "gulp-rename": "^2.0.0",
     "gulp-replace": "^0.5.4",
-    "gulp-rimraf": "^0.2.1",
-    "gulp-sass": "^3.1.0",
-    "gulp-uglify": "^2.1.0",
+    "gulp-rimraf": "^1.0.0",
+    "gulp-sass": "^5.1.0",
+    "gulp-uglify": "^3.0.2",
     "preprocessify": "^1.0.1",
-    "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0"
+    "sass": "^1.53.0",
+    "vinyl-buffer": "^1.0.1",
+    "vinyl-source-stream": "^2.0.0"
   }
 }

--- a/src/client/js/server/index.js
+++ b/src/client/js/server/index.js
@@ -57,7 +57,7 @@ function getNewWs () {
     return new WebSocket(`${ (location.protocol === "https:" ? "wss:" : "ws:")
         }//${ location.hostname }:${ location.port ||
         (location.protocol === "https:" ? "443" : "80")
-        }/terminalsocket/${ encodeURIComponent(CACHE_CLASS_NAME) }`);
+        }${ location.pathname.includes('/terminal') ? location.pathname.replace(/\/terminal.*/, "/terminalsocket") : "/terminalsocket" }/${ encodeURIComponent(CACHE_CLASS_NAME) }`);
 }
 
 function onOpen () {


### PR DESCRIPTION
This PR fixes #142, allowing WebTerminal to work on sites that configure a single web server to host apps for multiple InterSystems servers.

It also updates gulp to version 4 so it works with modern Node versions.